### PR TITLE
Avoid retrying with the webproxy when we know it won't help

### DIFF
--- a/wwtlib/Graphics/Texture.cs
+++ b/wwtlib/Graphics/Texture.cs
@@ -79,7 +79,9 @@ namespace wwtlib
                 {
                     if (!ImageElement.HasAttribute("proxyattempt"))
                     {
-                        ImageElement.Src = URLHelpers.singleton.activateProxy(URL);
+                        string new_url = URLHelpers.singleton.activateProxy(URL);
+                        if (new_url != null)  // null => don't bother: we know that the proxy won't help
+                            ImageElement.Src = new_url;
                         ImageElement.SetAttribute("proxyattempt", true);
                     }
                     else

--- a/wwtlib/Planets.cs
+++ b/wwtlib/Planets.cs
@@ -2042,7 +2042,7 @@ namespace wwtlib
             {
                 return;
             }
-            ringsTexture = Planets.LoadPlanetTexture(URLHelpers.singleton.engineAssetUrl("SaturnRingsStrip.png"));
+            ringsTexture = Planets.LoadPlanetTexture(URLHelpers.singleton.engineAssetUrl("saturnringsstrip.png"));
             double inner = 1.113;
             double outer = 2.25;
 

--- a/wwtlib/Tile.cs
+++ b/wwtlib/Tile.cs
@@ -207,7 +207,9 @@ namespace wwtlib
                 {
                     if (!texture.HasAttribute("proxyattempt"))
                     {
-                        texture.Src = URLHelpers.singleton.activateProxy(this.URL);
+                        string new_url = URLHelpers.singleton.activateProxy(this.URL);
+                        if (new_url != null)  // null => don't bother: we know that the proxy won't help
+                            texture.Src = new_url;
                         texture.SetAttribute("proxyattempt", true);
                     }
                     else

--- a/wwtlib/URLHelpers.cs
+++ b/wwtlib/URLHelpers.cs
@@ -205,7 +205,17 @@ namespace wwtlib
                         // upgrade, so be it.
                         url = "http://" + url;
                     }
-                    return this.core_dynamic_baseurl + "/webserviceproxy.aspx?targeturl=" + url.EncodeUriComponent();
+
+                    // We need to encode the URL as a query-string parameter
+                    // to pass to the proxy. However, the encoding will turn
+                    // "{}" into "%7B%7D", so that *if* this URL is then going
+                    // to be fed into the templating system,
+                    // search-and-replace for e.g. "{0}" will break. So we
+                    // un-encode those particular characters, since it ought
+                    // to be safe to do so anyway.
+                    url = url.EncodeUriComponent().Replace("%7B", "{").Replace("%7D", "}");
+
+                    return this.core_dynamic_baseurl + "/webserviceproxy.aspx?targeturl=" + url;
 
                 case DomainHandling.WWTFlagship:
                     // Rewrite "flagship"/core URLs to go through whatever our

--- a/wwtlib/URLHelpers.cs
+++ b/wwtlib/URLHelpers.cs
@@ -232,6 +232,8 @@ namespace wwtlib
         // Call this when you have tried to load a url via XMLHttpRequest or
         // something along those lines, and the attempt has failed. We will mark the
         // domain as needing proxying, and will return a new proxy-enabled URL to try.
+        // The exception is for flagship website URLs, which we know that the proxy
+        // won't help with. For those, null is returned.
         public string activateProxy(string url) {
             // Get the domain. XXX copy/pastey from the above.
 
@@ -257,7 +259,18 @@ namespace wwtlib
                 lcdomain = url_no_protocol.Substring(0, slash_index).ToLowerCase();
             }
 
-            // OK, the rest of this is simple:
+            // Is this a flagship URL? If so, don't bother proxying.
+
+            if (!this.domain_handling.ContainsKey(lcdomain))
+                this.domain_handling[lcdomain] = DomainHandling.TryNoProxy;
+
+            DomainHandling mode = this.domain_handling[lcdomain];
+
+            if (mode == DomainHandling.WWTFlagship) {
+                return null;
+            }
+
+            // OK, we should try proxying. So:
 
             this.domain_handling[lcdomain] = DomainHandling.Proxy;
             return this.rewrite(url);

--- a/wwtlib/WebFile.cs
+++ b/wwtlib/WebFile.cs
@@ -121,8 +121,13 @@ namespace wwtlib
                             {
                                 triedOnce = true;
                                 xhr.OnReadyStateChange = null;
-                                _url = URLHelpers.singleton.activateProxy(_url);
-                                CORS();
+
+                                string new_url = URLHelpers.singleton.activateProxy(_url);
+
+                                if (new_url != null) { // null => don't bother: we know that the proxy won't help
+                                    _url = new_url;
+                                    CORS();
+                                }
                             }
                         }
                         else


### PR DESCRIPTION
If a tile or file get fails on a URL that comes from the flagship domain, we know that the proxy won't help. So in those cases, don't bother with retries.