### PR TITLE
Need to properly mark tiles as failed if we don't retry them.

### DIFF
--- a/wwtlib/Graphics/Texture.cs
+++ b/wwtlib/Graphics/Texture.cs
@@ -79,17 +79,18 @@ namespace wwtlib
                 {
                     if (!ImageElement.HasAttribute("proxyattempt"))
                     {
-                        string new_url = URLHelpers.singleton.activateProxy(URL);
-                        if (new_url != null)  // null => don't bother: we know that the proxy won't help
-                            ImageElement.Src = new_url;
                         ImageElement.SetAttribute("proxyattempt", true);
+                        string new_url = URLHelpers.singleton.activateProxy(URL);
+
+                        if (new_url != null) {  // null => don't bother: we know that the proxy won't help
+                            ImageElement.Src = new_url;
+                            return;
+                        }
                     }
-                    else
-                    {
-                        Downloading = false;
-                        Ready = false;
-                        Errored = true;
-                    }
+
+                    Downloading = false;
+                    Ready = false;
+                    Errored = true;
                 }, false);
 
                 xdomimg.crossOrigin = "anonymous";

--- a/wwtlib/Tile.cs
+++ b/wwtlib/Tile.cs
@@ -207,20 +207,20 @@ namespace wwtlib
                 {
                     if (!texture.HasAttribute("proxyattempt"))
                     {
-                        string new_url = URLHelpers.singleton.activateProxy(this.URL);
-                        if (new_url != null)  // null => don't bother: we know that the proxy won't help
-                            texture.Src = new_url;
                         texture.SetAttribute("proxyattempt", true);
+                        string new_url = URLHelpers.singleton.activateProxy(this.URL);
+
+                        if (new_url != null) {  // null => don't bother: we know that the proxy won't help
+                            texture.Src = new_url;
+                            return;
+                        }
                     }
-                    else
-                    {
-                        Downloading = false;
-                        ReadyToRender = false;
-                        errored = true;
-                        RequestPending = false;
-                        TileCache.RemoveFromQueue(this.Key, true);
-                    }
-                    
+
+                    Downloading = false;
+                    ReadyToRender = false;
+                    errored = true;
+                    RequestPending = false;
+                    TileCache.RemoveFromQueue(this.Key, true);
                 }, false);
 
                 xdomimg.crossOrigin = "anonymous";


### PR DESCRIPTION
Otherwise the tile cache thinks that it has no capacity left in its download queue and stops trying to fetch anything. That's bad.