### PR TITLE
wwtlib/URLHelpers.cs: add a mode parameter to URLHelpers.rewrite()

### DIFF
--- a/wwtlib/Folder.cs
+++ b/wwtlib/Folder.cs
@@ -58,7 +58,7 @@ namespace wwtlib
         {
             onComplete = complete;
 
-            webFile = new WebFile(URLHelpers.singleton.rewrite(url));
+            webFile = new WebFile(URLHelpers.singleton.rewrite(url, URLRewriteMode.OriginRelative));
             webFile.OnStateChange = LoadData;
             webFile.Send();
 

--- a/wwtlib/Layers/VOTable.cs
+++ b/wwtlib/Layers/VOTable.cs
@@ -60,7 +60,7 @@ namespace wwtlib
 
             temp.onComplete = complete;
 
-            temp.webFile = new WebFile(URLHelpers.singleton.rewrite(url));
+            temp.webFile = new WebFile(URLHelpers.singleton.rewrite(url, URLRewriteMode.OriginRelative));
             temp.webFile.OnStateChange = temp.LoadData;
             temp.webFile.Send();
 

--- a/wwtlib/PlotTile.cs
+++ b/wwtlib/PlotTile.cs
@@ -53,7 +53,7 @@ namespace wwtlib
             {
                 Downloading = true;
 
-                webFile = new WebFile(URLHelpers.singleton.rewrite(this.URL));
+                webFile = new WebFile(URLHelpers.singleton.rewrite(this.URL, URLRewriteMode.AsIfAbsolute));
                 webFile.OnStateChange = FileStateChange;
                 webFile.Send();
             }

--- a/wwtlib/Tile.cs
+++ b/wwtlib/Tile.cs
@@ -961,7 +961,7 @@ namespace wwtlib
         {
             get
             {
-                string rewritten_url = URLHelpers.singleton.rewrite(dataset.Url);
+                string rewritten_url = URLHelpers.singleton.rewrite(dataset.Url, URLRewriteMode.AsIfAbsolute);
                 string returnUrl = rewritten_url;
                 
                 if (rewritten_url.IndexOf("{1}") > -1)
@@ -1057,7 +1057,7 @@ namespace wwtlib
         {
             get
             {
-                string rewritten_url = URLHelpers.singleton.rewrite(dataset.DemUrl);
+                string rewritten_url = URLHelpers.singleton.rewrite(dataset.DemUrl, URLRewriteMode.AsIfAbsolute);
 
                 if (dataset.Projection == ProjectionType.Mercator)
                 {


### PR DESCRIPTION
I've had a feeling for a while that I'd need to add this, and this was spurred by issues with the production beta webclient having problems loading a folder with URL `../Resource/...`.

I want a mode parameter here because if we load up a WTML file that contains a relative URL, that URL should be absolute-ified relative to the source of the WTML file, not the window origin. Right now, relative URLs in WTML files are not allowed, but I'd like that to change one day. (If/when we implement this, this function will probably need to acquire a third parameter to give the base URL to use in the relative-to-something-else case.)