### PR TITLE
wwtlib/URLHelpers.cs: add a web_static_baseurl parameter

### DIFF
--- a/wwtlib/URLHelpers.cs
+++ b/wwtlib/URLHelpers.cs
@@ -27,6 +27,7 @@ namespace wwtlib
         String origin_protocol;  // this will be "http:" or "https:"
         String origin_domain;  // host name, no port number
         bool force_https;
+        String engine_asset_baseurl;  // baseurl for webgl engine static assets
         String core_static_baseurl;  // baseurl for core static assets: NB, includes things like wwt.o/wwtweb/dss.aspx
         String core_dynamic_baseurl;  // baseurl for core dynamic services
         Dictionary<String, DomainHandling> domain_handling;
@@ -71,6 +72,8 @@ namespace wwtlib
                     this.core_dynamic_baseurl = this.origin_protocol + "//beta.worldwidetelescope.org";
                     break;
             }
+
+            this.engine_asset_baseurl = this.origin_protocol + "//web.wwtassets.org/engine/assets";
 
             this.flagship_static_lcpaths = new Dictionary<String, bool>();
             this.flagship_static_lcpaths["/wwtweb/2massoct.aspx"] = true;
@@ -311,7 +314,7 @@ namespace wwtlib
 
         public string engineAssetUrl(string subpath)
         {
-            return String.Format("{0}/engine/assets/{1}", this.core_static_baseurl, subpath);
+            return String.Format("{0}/{1}", this.engine_asset_baseurl, subpath);
         }
 
         public string coreDynamicUrl(string subpath)


### PR DESCRIPTION
At the moment this is always set to web.wwtassets.org, which is a CDN-ified version of the `wwtwebstatic` static website served off of our storage account.

The motivation here is that cdn.worldwidetelescope.org is always going to have to route its requests through worldwidetelescope.org, which means they will have to go through the App Gateway reverse proxy before, in the case of web static assets, eventually being routed to `wwtwebstatic`. By using a different CDN endpoint, we can cut out the App Gateway middleman, which should reduce load on that service, hopefully be faster, and hopefully save us some money.

Like many other big websites, we use a separate second-level domain, namely the new wwtassets.org. The apparent motivation is that that way you don't have the cookies from your main website making their way into every single one of your asset requests. I'd also like to think that it helps maintain clarity between the traffic that gets routed through the App Gateway and everything else. The domain was $13/yr right now so it feels easily worthwhile.