### PR TITLE
Release 6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wwt_webgl_engine",
   "description": "AAS WorldWide Telescope WebGL Engine",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "keywords": [
     "AAS WorldWide Telescope"
   ],

--- a/wwtlib/Properties/AssemblyInfo.cs
+++ b/wwtlib/Properties/AssemblyInfo.cs
@@ -16,7 +16,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright("Copyright © 2012 - 2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("6.0.0.0")]
-[assembly: AssemblyFileVersion("6.0.0.0")]
+[assembly: AssemblyVersion("6.0.1.0")]
+[assembly: AssemblyFileVersion("6.0.1.0")]
 
 [assembly: ScriptAssembly("wwtlib")]

--- a/wwtlib/URLHelpers.cs
+++ b/wwtlib/URLHelpers.cs
@@ -68,8 +68,8 @@ namespace wwtlib
                     break;
 
                 default:
-                    this.core_static_baseurl = this.origin_protocol + "//beta-cdn.worldwidetelescope.org"; // TEMPORARY
-                    this.core_dynamic_baseurl = this.origin_protocol + "//beta.worldwidetelescope.org";
+                    this.core_static_baseurl = this.origin_protocol + "//cdn.worldwidetelescope.org";
+                    this.core_dynamic_baseurl = this.origin_protocol + "//worldwidetelescope.org";
                     break;
             }
 


### PR DESCRIPTION
We're ready to go live with the new infrastructure. In 6.0.1 we default the engine to point at the main worldwidetelescope.org domain for unknown origins, rather than the beta-test domains.