### PR TITLE
Release 7.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wwtelescope/engine",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "The AAS WorldWide Telescope WebGL engine",
   "keywords": [
     "AAS WorldWide Telescope"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wwtelescope/engine",
-  "version": "7.0.1",
+  "version": "7.0.2-dev.0",
   "description": "The AAS WorldWide Telescope WebGL engine",
   "keywords": [
     "AAS WorldWide Telescope"

--- a/wwtlib/Properties/AssemblyInfo.cs
+++ b/wwtlib/Properties/AssemblyInfo.cs
@@ -16,7 +16,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright("Copyright © 2012 - 2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("7.0.0.0")]
-[assembly: AssemblyFileVersion("7.0.0.0")]
+[assembly: AssemblyVersion("7.0.1.0")]
+[assembly: AssemblyFileVersion("7.0.1.0")]
 
 [assembly: ScriptAssembly("wwtlib")]

--- a/wwtlib/Properties/AssemblyInfo.cs
+++ b/wwtlib/Properties/AssemblyInfo.cs
@@ -16,7 +16,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright("Copyright © 2012 - 2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("7.0.1.0")]
-[assembly: AssemblyFileVersion("7.0.1.0")]
+[assembly: AssemblyVersion("7.0.1.99")]
+[assembly: AssemblyFileVersion("7.0.1.99")]
 
 [assembly: ScriptAssembly("wwtlib")]


### PR DESCRIPTION
This PR includes the commit that will become the 7.0.1 release tag. That release fixes the critical `Enum.parse` bug in 7.0.0.