### PR TITLE
CI/CD iteration: try to fix `embed` release process

### DIFF
--- a/embed/package.json
+++ b/embed/package.json
@@ -21,6 +21,7 @@
     "postpublish": "node -e \"console.log('##vso[task.setvariable variable=publishedEmbedVersion];'+process.env.npm_package_version)\""
   },
   "dependencies": {
+    "@wwtelescope/embed-common": "0.0.0-dev",
     "@wwtelescope/engine": "0.0.0-dev",
     "@wwtelescope/engine-vuex": "0.0.0-dev",
     "vue": "^2.6.11",

--- a/embed/tsconfig.json
+++ b/embed/tsconfig.json
@@ -1,13 +1,30 @@
 {
-  "extends": "../tsconfig.json",
   "compilerOptions": {
+    "rootDir": "..",
+    "target": "es5",
+    "module": "esnext",
+    "composite": true,
+    "strict": true,
+    "jsx": "preserve",
+    "importHelpers": true,
+    "downlevelIteration": true,
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "sourceMap": true,
+    "baseUrl": ".",
+    "outDir": "dist",
+    "paths": {
+      "@/*": [
+        "src/*"
+      ]
+    },
     "lib": [
       "dom",
       "dom.iterable",
       "es6"
-    ],
-    "rootDir": "..",
-    "outDir": "dist"
+    ]
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
I had to manually push an update to `release` before this PR to allow for a successful merge of the change that adds the `embed-common` dep to `embed`. We then needed to add additional, non-conflicting commits to this branch so that the PR and `master` CI processes have something new to merge into `release`.

We also add a change to `graduate.js` that will, I hope, fix the versioning problem of `embed` that will allow us to have a package definition that simultaneously builds locally *and* can be published as a freestanding package.