### PR TITLE
Add a few "tools" in the embed

### DIFF
--- a/embed-creator/src/Creator.vue
+++ b/embed-creator/src/Creator.vue
@@ -529,6 +529,11 @@ export default class Creator extends Vue {
     }
 
     this.showImageUrlValidity = urlIsOk;
+
+    if (urlIsOk) {
+      // Clear out state for other modes with which we're mutually exclusive.
+      this.qsb.planetaryBody = null;
+    }
   }
 
   onClipboardSuccess() {

--- a/embed/package.json
+++ b/embed/package.json
@@ -21,6 +21,9 @@
     "postpublish": "node -e \"console.log('##vso[task.setvariable variable=publishedEmbedVersion;]'+process.env.npm_package_version)\""
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.28",
+    "@fortawesome/free-solid-svg-icons": "^5.13.0",
+    "@fortawesome/vue-fontawesome": "^0.1.9",
     "@wwtelescope/embed-common": "0.0.0-dev",
     "@wwtelescope/engine": "0.0.0-dev",
     "@wwtelescope/engine-vuex": "0.0.0-dev",

--- a/embed/package.json
+++ b/embed/package.json
@@ -27,6 +27,7 @@
     "@wwtelescope/embed-common": "0.0.0-dev",
     "@wwtelescope/engine": "0.0.0-dev",
     "@wwtelescope/engine-vuex": "0.0.0-dev",
+    "v-tooltip": "=2.0.2",
     "vue": "^2.6.11",
     "vuex": "^3.1.3"
   },

--- a/embed/public/index.html
+++ b/embed/public/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+    <link rel="icon" href="https://worldwidetelescope.org/favicon.ico">
+    <title>AAS WorldWide Telescope</title>
+  </head>
+  <body>
+    <noscript>
+      <strong>We're sorry but AAS WorldWide Telescope requires JavaScript to run.</strong>
+    </noscript>
+    <div id="app"></div>
+    <!-- built files will be auto injected -->
+  </body>
+</html>

--- a/embed/src/Embed.vue
+++ b/embed/src/Embed.vue
@@ -11,8 +11,8 @@
         <font-awesome-icon class="tooltip-target" icon="sliders-h" size="lg"></font-awesome-icon>
         <template slot="popover">
           <ul class="tooltip-content tool-menu">
-            <li><a href="#" @click="selectTool('crossfade')"><font-awesome-icon icon="adjust" /> Crossfade</a></li>
-            <li><a href="#" @click="selectTool('choose-background')"><font-awesome-icon icon="mountain" /> Choose background</a></li>
+            <li v-show="showCrossfader"><a href="#" v-close-popover @click="selectTool('crossfade')"><font-awesome-icon icon="adjust" /> Crossfade</a></li>
+            <li><a href="#" v-close-popover @click="selectTool('choose-background')"><font-awesome-icon icon="mountain" /> Choose background</a></li>
           </ul>
         </template>
       </v-popover>
@@ -26,7 +26,7 @@
       <template v-else-if="currentTool == 'choose-background'">
         <span>Background imagery:</span>
         <select v-model="curBackgroundImagesetName">
-          <option v-for="bg in backgroundImagesets" v-bind:value="bg.imagesetName">
+          <option v-for="bg in backgroundImagesets" v-bind:value="bg.imagesetName" v-bind:key="bg.imagesetName">
             {{ bg.displayName }}
           </option>
         </select>
@@ -107,6 +107,13 @@ export default class Embed extends WWTAwareComponent {
 
   set foregroundOpacity(o: number) {
     this.setForegroundOpacity(o);
+  }
+
+  get showCrossfader() {
+    if (this.wwtForegroundImageset == null || this.wwtForegroundImageset === undefined)
+      return false;
+
+    return this.wwtForegroundImageset != this.wwtBackgroundImageset;
   }
 
   created() {

--- a/embed/src/Embed.vue
+++ b/embed/src/Embed.vue
@@ -4,6 +4,9 @@
     <div id="overlays">
       <p v-show="embedSettings.showCoordinateReadout">{{ coordText }}</p>
     </div>
+    <div id="tools">
+      <font-awesome-icon icon="sliders-h" size="lg"/>
+    </div>
     <div id="credits" v-show="embedSettings.creditMode == CreditMode.Default">
       <p>Powered by <a href="https://worldwidetelescope.org/home/">AAS WorldWide
       Telescope</a>
@@ -151,6 +154,13 @@ body {
     padding: 0;
     line-height: 1;
   }
+}
+
+#tools {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  color: #FFF;
 }
 
 #credits {

--- a/embed/src/Embed.vue
+++ b/embed/src/Embed.vue
@@ -81,7 +81,6 @@ export default class Embed extends WWTAwareComponent {
   @Prop({ default: new EmbedSettings() }) readonly embedSettings!: EmbedSettings;
 
   backgroundImagesets: BackgroundImageset[] = [];
-  _curBackgroundImagesetName: string = "";
   currentTool: ToolType = null;
 
   get coordText() {
@@ -93,12 +92,13 @@ export default class Embed extends WWTAwareComponent {
   }
 
   get curBackgroundImagesetName() {
-    return this._curBackgroundImagesetName;
+    if (this.wwtBackgroundImageset == null)
+      return "";
+    return this.wwtBackgroundImageset.get_name();
   }
 
   set curBackgroundImagesetName(name: string) {
     this.setBackgroundImageByName(name);
-    this._curBackgroundImagesetName = name;
   }
 
   get foregroundOpacity() {
@@ -190,8 +190,6 @@ export default class Embed extends WWTAwareComponent {
       if (!foundBG) {
         this.backgroundImagesets.unshift(new BackgroundImageset(bgName, bgName));
       }
-
-      this._curBackgroundImagesetName = bgName;
     });
   }
 

--- a/embed/src/Embed.vue
+++ b/embed/src/Embed.vue
@@ -21,7 +21,7 @@
     <div id="tools">
       <div class="tool-container">
       <template v-if="currentTool == 'crossfade'">
-        <p>Crossfade!</p>
+        <span>Foreground opacity:</span> <input class="opacity-range" type="range" v-model="foregroundOpacity">
       </template>
       <template v-else-if="currentTool == 'choose-background'">
         <p>Choose background!</p>
@@ -55,7 +55,7 @@ export default class Embed extends WWTAwareComponent {
 
   @Prop({ default: new EmbedSettings() }) readonly embedSettings!: EmbedSettings;
 
-  @Prop({ default: null }) currentTool!: ToolType;
+  currentTool: ToolType = null;
 
   get coordText() {
     if (this.wwtRenderType == ImageSetType.sky) {
@@ -63,6 +63,14 @@ export default class Embed extends WWTAwareComponent {
     }
 
     return `${fmtDegLon(this.wwtRARad)} ${fmtDegLat(this.wwtDecRad)}`;
+  }
+
+  get foregroundOpacity() {
+    return this.wwtForegroundOpacity;
+  }
+
+  set foregroundOpacity(o: number) {
+    this.setForegroundOpacity(o);
   }
 
   created() {
@@ -203,13 +211,17 @@ body {
 
 #tools {
   position: absolute;
-  bottom: 2rem;
+  bottom: 3rem;
   left: 50%;
   color: #FFF;
 
   .tool-container {
     position: relative;
     left: -50%;
+  }
+
+  .opacity-range {
+    width: 50vw;
   }
 }
 
@@ -219,6 +231,12 @@ body {
   right: 1rem;
   color: #ddd;
   font-size: 70%;
+
+  p {
+    margin: 0;
+    padding: 0;
+    line-height: 1;
+  }
 
   a {
     text-decoration: none;
@@ -358,6 +376,8 @@ ul.tool-menu {
     a {
       text-decoration: none;
       color: inherit;
+      display: block;
+      width: 100%;
     }
 
     svg.svg-inline--fa {

--- a/embed/src/Embed.vue
+++ b/embed/src/Embed.vue
@@ -6,13 +6,13 @@
       <p v-show="embedSettings.showCoordinateReadout">{{ coordText }}</p>
     </div>
 
-    <div id="tool-menu">
+    <div id="tool-menu" v-show="showToolMenu">
       <v-popover>
         <font-awesome-icon class="tooltip-target" icon="sliders-h" size="lg"></font-awesome-icon>
         <template slot="popover">
           <ul class="tooltip-content tool-menu">
             <li v-show="showCrossfader"><a href="#" v-close-popover @click="selectTool('crossfade')"><font-awesome-icon icon="adjust" /> Crossfade</a></li>
-            <li><a href="#" v-close-popover @click="selectTool('choose-background')"><font-awesome-icon icon="mountain" /> Choose background</a></li>
+            <li v-show="showBackgroundChooser"><a href="#" v-close-popover @click="selectTool('choose-background')"><font-awesome-icon icon="mountain" /> Choose background</a></li>
           </ul>
         </template>
       </v-popover>
@@ -109,11 +109,21 @@ export default class Embed extends WWTAwareComponent {
     this.setForegroundOpacity(o);
   }
 
+  get showBackgroundChooser() {
+    // TODO: we should wire in choices for other modes!
+    return this.wwtRenderType == ImageSetType.sky;
+  }
+
   get showCrossfader() {
     if (this.wwtForegroundImageset == null || this.wwtForegroundImageset === undefined)
       return false;
 
     return this.wwtForegroundImageset != this.wwtBackgroundImageset;
+  }
+
+  get showToolMenu() {
+    // This should return true if there are any tools to show.
+    return this.showBackgroundChooser || this.showCrossfader;
   }
 
   created() {

--- a/embed/src/Embed.vue
+++ b/embed/src/Embed.vue
@@ -5,7 +5,12 @@
       <p v-show="embedSettings.showCoordinateReadout">{{ coordText }}</p>
     </div>
     <div id="tools">
-      <font-awesome-icon icon="sliders-h" size="lg"/>
+      <v-popover open>
+        <font-awesome-icon class="tooltip-target" icon="sliders-h" size="lg"></font-awesome-icon>
+        <template slot="popover">
+          <p class="tooltip-content">Some text?</p>
+        </template>
+      </v-popover>
     </div>
     <div id="credits" v-show="embedSettings.creditMode == CreditMode.Default">
       <p>Powered by <a href="https://worldwidetelescope.org/home/">AAS WorldWide
@@ -183,6 +188,116 @@ body {
     height: 24px;
     vertical-align: middle;
     margin: 2px;
+  }
+}
+
+/* Generic v-tooltip CSS derived from: https://github.com/Akryum/v-tooltip#sass--less */
+
+.tooltip {
+  display: block !important;
+  z-index: 10000;
+
+  .tooltip-inner {
+    background: black;
+    color: white;
+    border-radius: 16px;
+    padding: 5px 10px 4px;
+  }
+
+  .tooltip-arrow {
+    width: 0;
+    height: 0;
+    border-style: solid;
+    position: absolute;
+    margin: 5px;
+    border-color: black;
+    z-index: 1;
+  }
+
+  &[x-placement^="top"] {
+    margin-bottom: 5px;
+
+    .tooltip-arrow {
+      border-width: 5px 5px 0 5px;
+      border-left-color: transparent !important;
+      border-right-color: transparent !important;
+      border-bottom-color: transparent !important;
+      bottom: -5px;
+      left: calc(50% - 5px);
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+
+  &[x-placement^="bottom"] {
+    margin-top: 5px;
+
+    .tooltip-arrow {
+      border-width: 0 5px 5px 5px;
+      border-left-color: transparent !important;
+      border-right-color: transparent !important;
+      border-top-color: transparent !important;
+      top: -5px;
+      left: calc(50% - 5px);
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+
+  &[x-placement^="right"] {
+    margin-left: 5px;
+
+    .tooltip-arrow {
+      border-width: 5px 5px 5px 0;
+      border-left-color: transparent !important;
+      border-top-color: transparent !important;
+      border-bottom-color: transparent !important;
+      left: -5px;
+      top: calc(50% - 5px);
+      margin-left: 0;
+      margin-right: 0;
+    }
+  }
+
+  &[x-placement^="left"] {
+    margin-right: 5px;
+
+    .tooltip-arrow {
+      border-width: 5px 0 5px 5px;
+      border-top-color: transparent !important;
+      border-right-color: transparent !important;
+      border-bottom-color: transparent !important;
+      right: -5px;
+      top: calc(50% - 5px);
+      margin-left: 0;
+      margin-right: 0;
+    }
+  }
+
+  &.popover {
+    .popover-inner {
+      background: #f9f9f9;
+      color: black;
+      padding: 24px;
+      border-radius: 5px;
+      box-shadow: 0 5px 30px rgba(black, .1);
+    }
+
+    .popover-arrow {
+      border-color: #f9f9f9;
+    }
+  }
+
+  &[aria-hidden='true'] {
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity .15s, visibility .15s;
+  }
+
+  &[aria-hidden='false'] {
+    visibility: visible;
+    opacity: 1;
+    transition: opacity .15s;
   }
 }
 </style>

--- a/embed/src/Embed.vue
+++ b/embed/src/Embed.vue
@@ -1,17 +1,34 @@
 <template>
   <div id="app">
     <WorldWideTelescope wwt-namespace="wwt-embed"></WorldWideTelescope>
+
     <div id="overlays">
       <p v-show="embedSettings.showCoordinateReadout">{{ coordText }}</p>
     </div>
-    <div id="tools">
-      <v-popover open>
+
+    <div id="tool-menu">
+      <v-popover>
         <font-awesome-icon class="tooltip-target" icon="sliders-h" size="lg"></font-awesome-icon>
         <template slot="popover">
-          <p class="tooltip-content">Some text?</p>
+          <ul class="tooltip-content tool-menu">
+            <li><a href="#" @click="selectTool('crossfade')"><font-awesome-icon icon="adjust" /> Crossfade</a></li>
+            <li><a href="#" @click="selectTool('choose-background')"><font-awesome-icon icon="mountain" /> Choose background</a></li>
+          </ul>
         </template>
       </v-popover>
     </div>
+
+    <div id="tools">
+      <div class="tool-container">
+      <template v-if="currentTool == 'crossfade'">
+        <p>Crossfade!</p>
+      </template>
+      <template v-else-if="currentTool == 'choose-background'">
+        <p>Choose background!</p>
+      </template>
+      </div>
+    </div>
+
     <div id="credits" v-show="embedSettings.creditMode == CreditMode.Default">
       <p>Powered by <a href="https://worldwidetelescope.org/home/">AAS WorldWide
       Telescope</a>
@@ -30,11 +47,15 @@ import { ImageSetType } from "@wwtelescope/engine-types";
 import { SetupForImagesetOptions, WWTAwareComponent } from "@wwtelescope/engine-vuex";
 import { CreditMode, EmbedSettings } from "@wwtelescope/embed-common";
 
+type ToolType = "crossfade" | "choose-background" | null;
+
 @Component
 export default class Embed extends WWTAwareComponent {
   CreditMode = CreditMode
 
   @Prop({ default: new EmbedSettings() }) readonly embedSettings!: EmbedSettings;
+
+  @Prop({ default: null }) currentTool!: ToolType;
 
   get coordText() {
     if (this.wwtRenderType == ImageSetType.sky) {
@@ -112,6 +133,14 @@ export default class Embed extends WWTAwareComponent {
       }
     });
   }
+
+  selectTool(name: ToolType) {
+    if (this.currentTool == name) {
+      this.currentTool = null;
+    } else {
+      this.currentTool = name;
+    }
+  }
 }
 </script>
 
@@ -161,11 +190,27 @@ body {
   }
 }
 
-#tools {
+#tool-menu {
   position: absolute;
   top: 0.5rem;
   right: 0.5rem;
   color: #FFF;
+
+  .tooltip-target {
+    cursor: pointer;
+  }
+}
+
+#tools {
+  position: absolute;
+  bottom: 2rem;
+  left: 50%;
+  color: #FFF;
+
+  .tool-container {
+    position: relative;
+    left: -50%;
+  }
 }
 
 #credits {
@@ -278,9 +323,8 @@ body {
     .popover-inner {
       background: #f9f9f9;
       color: black;
-      padding: 24px;
+      padding: 8px;
       border-radius: 5px;
-      box-shadow: 0 5px 30px rgba(black, .1);
     }
 
     .popover-arrow {
@@ -300,4 +344,31 @@ body {
     transition: opacity .15s;
   }
 }
+
+/* Specialized styling for popups */
+
+ul.tool-menu {
+  list-style-type: none;
+  margin: 0px;
+  padding: 0px;
+
+  li {
+    padding: 3px;
+
+    a {
+      text-decoration: none;
+      color: inherit;
+    }
+
+    svg.svg-inline--fa {
+      width: 1.5em;
+    }
+
+    &:hover {
+      background-color: #000;
+      color: #FFF;
+    }
+  }
+}
+
 </style>

--- a/embed/src/main.ts
+++ b/embed/src/main.ts
@@ -1,4 +1,5 @@
 import Vue from "vue";
+import VTooltip from "v-tooltip";
 import Vuex from "vuex";
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faSlidersH } from '@fortawesome/free-solid-svg-icons'
@@ -11,6 +12,7 @@ import Embed from "./Embed.vue";
 
 Vue.config.productionTip = false;
 
+Vue.use(VTooltip);
 Vue.use(Vuex);
 
 const store = new Vuex.Store({});

--- a/embed/src/main.ts
+++ b/embed/src/main.ts
@@ -1,5 +1,8 @@
 import Vue from "vue";
 import Vuex from "vuex";
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { faSlidersH } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
 import { createPlugin } from "@wwtelescope/engine-vuex";
 import { EmbedSettings } from "@wwtelescope/embed-common";
@@ -16,6 +19,9 @@ Vue.use(createPlugin(), {
   store,
   namespace: "wwt-embed"
 });
+
+library.add(faSlidersH);
+Vue.component('font-awesome-icon', FontAwesomeIcon);
 
 const queryParams = new URLSearchParams(window.location.search);
 const settings = EmbedSettings.fromQueryParams(queryParams.entries());

--- a/embed/src/main.ts
+++ b/embed/src/main.ts
@@ -2,7 +2,7 @@ import Vue from "vue";
 import VTooltip from "v-tooltip";
 import Vuex from "vuex";
 import { library } from '@fortawesome/fontawesome-svg-core'
-import { faSlidersH } from '@fortawesome/free-solid-svg-icons'
+import { faAdjust, faMountain, faSlidersH } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
 import { createPlugin } from "@wwtelescope/engine-vuex";
@@ -22,6 +22,8 @@ Vue.use(createPlugin(), {
   namespace: "wwt-embed"
 });
 
+library.add(faAdjust);
+library.add(faMountain);
 library.add(faSlidersH);
 Vue.component('font-awesome-icon', FontAwesomeIcon);
 

--- a/embed/src/v-tooltip.d.ts
+++ b/embed/src/v-tooltip.d.ts
@@ -1,0 +1,10 @@
+declare module "v-tooltip" {
+  import Vue, { VueConstructor, DirectiveOptions, PluginFunction } from 'vue';
+
+  export const vToolTip: PluginFunction<any>;
+  export default vToolTip;
+
+  export const VPopover: VueConstructor<Vue>;
+  export const VClosePopover: DirectiveOptions;
+  export const VTooltip: DirectiveOptions;
+}

--- a/embed/src/v-tooltip.d.ts
+++ b/embed/src/v-tooltip.d.ts
@@ -1,7 +1,7 @@
 declare module "v-tooltip" {
   import Vue, { VueConstructor, DirectiveOptions, PluginFunction } from 'vue';
 
-  export const vToolTip: PluginFunction<any>;
+  export const vToolTip: PluginFunction<any>;  // eslint-disable-line @typescript-eslint/no-explicit-any
   export default vToolTip;
 
   export const VPopover: VueConstructor<Vue>;

--- a/engine-helpers/src/index.ts
+++ b/engine-helpers/src/index.ts
@@ -349,6 +349,14 @@ export class WWTInstance {
     this.ctl.setForegroundImageByName(imagesetName);
   }
 
+  /** Set the opacity with which the foreground imageset is rendered.
+   *
+   * @param opacity The opacity, between 0 (invisible) and 100 (fully opaque).
+   */
+  setForegroundOpacity(opacity: number): void {
+    this.si.setForegroundOpacity(opacity);
+  }
+
   /** Set up the view to instantaneously display the specified imageset.
    *
    * This function aspires to provide a one-stop shop for configuring the engine

--- a/engine-vuex/src/Component.vue
+++ b/engine-vuex/src/Component.vue
@@ -59,7 +59,11 @@ export default class WWTComponent extends Vue {
   mounted() {
     this.wwt = new WWTInstance({
       elId: this.uniqueId,
-      startInternalRenderLoop: false
+      startInternalRenderLoop: false,
+
+      // Start at the Galactic Center by default. RA of the GC ~= 266.4 deg; in WWT, lng = 360 - RA.
+      startLatDeg: -28.9,
+      startLngDeg: 93.6,
     });
 
     this.internalLinkToInstance(this.wwt);

--- a/engine-vuex/src/Component.vue
+++ b/engine-vuex/src/Component.vue
@@ -6,7 +6,6 @@
 import { Component, Vue, Prop } from "vue-property-decorator";
 import { createNamespacedHelpers } from "vuex";
 
-import { D2R, H2R } from "@wwtelescope/astro";
 import { ImageSetType } from "@wwtelescope/engine-types";
 import { WWTInstance } from "@wwtelescope/engine-helpers";
 
@@ -42,10 +41,7 @@ export default class WWTComponent extends Vue {
       ...mapMutations([
         "internalLinkToInstance",
         "internalUnlinkFromInstance",
-        "internalUpdateRA",
-        "internalUpdateDec",
-        "internalUpdateCurrentTime",
-        "internalUpdateRenderType",
+        "internalUpdate",
       ]),
       ...mapActions([
         "waitForReady",
@@ -73,21 +69,7 @@ export default class WWTComponent extends Vue {
 
       this.renderLoopId = window.requestAnimationFrame(render);
       wwt.ctl.renderOneFrame();
-
-      const raRad = wwt.si.getRA() * H2R;
-      if (this.raRad != raRad)
-        this.internalUpdateRA(raRad);
-
-      const decRad = wwt.si.getDec() * D2R;
-      if (this.decRad != decRad)
-        this.internalUpdateDec(decRad);
-
-      const time = wwt.stc.get_now();
-      if (this.currentTime != time)
-        this.internalUpdateCurrentTime(time);
-
-      if (this.renderType != wwt.ctl.renderType)
-        this.internalUpdateRenderType(wwt.ctl.renderType);
+      this.internalUpdate();
     };
 
     // Wait for the WWT engine to signal readiness, then wait another tick, then
@@ -117,10 +99,7 @@ export default class WWTComponent extends Vue {
   renderType!: ImageSetType;
   internalLinkToInstance!: (_wwt: WWTInstance) => void;
   internalUnlinkFromInstance!: () => void;
-  internalUpdateRA!: (_newRARad: number) => void;
-  internalUpdateDec!: (_newDecRad: number) => void;
-  internalUpdateCurrentTime!: (_newTime: Date) => void;
-  internalUpdateRenderType!: (_newType: ImageSetType) => void;
+  internalUpdate!: () => void;
   waitForReady!: () => Promise<void>;
 }
 </script>

--- a/engine-vuex/src/store.ts
+++ b/engine-vuex/src/store.ts
@@ -49,6 +49,11 @@ export interface WWTEngineVuexState {
 
   /** The current mode of the renderer */
   renderType: ImageSetType;
+
+  /** The opacity with which the foreground imageset is rendered; valid
+   * values are between 0 and 100 (inclusive).
+   */
+  foregroundOpacity: number;
 }
 
 /** The parameters for the [[WWTEngineVuexModule.gotoRADecZoom]] action. */
@@ -87,6 +92,7 @@ export class WWTEngineVuexModule extends VuexModule implements WWTEngineVuexStat
   decRad = 0.0;
   currentTime = new Date();
   renderType = ImageSetType.sky;
+  foregroundOpacity = 100;
 
   get lookupImageset() {
     // This is how you create a parametrized getter in vuex-module-decorators:
@@ -146,6 +152,14 @@ export class WWTEngineVuexModule extends VuexModule implements WWTEngineVuexStat
     if (Vue.$wwt.inst === null)
       throw new Error('cannot setForegroundImageByName without linking to WWTInstance');
     Vue.$wwt.inst.setForegroundImageByName(imagesetName);
+  }
+
+  @Mutation
+  setForegroundOpacity(opacity: number): void {
+    if (Vue.$wwt.inst === null)
+      throw new Error('cannot setForegroundOpacity without linking to WWTInstance');
+    Vue.$wwt.inst.setForegroundOpacity(opacity);
+    this.foregroundOpacity = opacity;
   }
 
   @Mutation

--- a/engine-vuex/src/wwtaware.ts
+++ b/engine-vuex/src/wwtaware.ts
@@ -27,7 +27,9 @@ export class WWTAwareComponent extends Vue {
       ...mapState({
         wwtRARad: (state, _getters) => (state as WWTEngineVuexState).raRad,
         wwtDecRad: (state, _getters) => (state as WWTEngineVuexState).decRad,
+        wwtBackgroundImageset: (state, _getters) => (state as WWTEngineVuexState).backgroundImageset,
         wwtCurrentTime: (state, _getters) => (state as WWTEngineVuexState).currentTime,
+        wwtForegroundImageset: (state, _getters) => (state as WWTEngineVuexState).foregroundImageset,
         wwtForegroundOpacity: (state, _getters) => (state as WWTEngineVuexState).foregroundOpacity,
         wwtRenderType: (state, _getters) => (state as WWTEngineVuexState).renderType,
       }),
@@ -62,7 +64,9 @@ export class WWTAwareComponent extends Vue {
   // Teach TypeScript about everything we wired up. State:
   wwtRARad!: number;
   wwtDecRad!: number;
+  wwtBackgroundImageset!: Imageset | null;
   wwtCurrentTime!: Date;
+  wwtForegroundImageset!: Imageset | null;
   wwtForegroundOpacity!: number;
   wwtRenderType!: ImageSetType;
 

--- a/engine-vuex/src/wwtaware.ts
+++ b/engine-vuex/src/wwtaware.ts
@@ -28,6 +28,7 @@ export class WWTAwareComponent extends Vue {
         wwtRARad: (state, _getters) => (state as WWTEngineVuexState).raRad,
         wwtDecRad: (state, _getters) => (state as WWTEngineVuexState).decRad,
         wwtCurrentTime: (state, _getters) => (state as WWTEngineVuexState).currentTime,
+        wwtForegroundOpacity: (state, _getters) => (state as WWTEngineVuexState).foregroundOpacity,
         wwtRenderType: (state, _getters) => (state as WWTEngineVuexState).renderType,
       }),
       ...mapGetters([
@@ -52,6 +53,7 @@ export class WWTAwareComponent extends Vue {
         "applySetting",
         "setBackgroundImageByName",
         "setForegroundImageByName",
+        "setForegroundOpacity",
         "setupForImageset",
       ]),
     };
@@ -61,6 +63,7 @@ export class WWTAwareComponent extends Vue {
   wwtRARad!: number;
   wwtDecRad!: number;
   wwtCurrentTime!: Date;
+  wwtForegroundOpacity!: number;
   wwtRenderType!: ImageSetType;
 
   // Getters
@@ -70,6 +73,7 @@ export class WWTAwareComponent extends Vue {
   applySetting!: (_s: WWTSetting) => void;
   setBackgroundImageByName!: (_n: string) => void;
   setForegroundImageByName!: (_n: string) => void;
+  setForegroundOpacity!: (o: number) => void;
   setupForImageset!: (o: SetupForImagesetOptions) => void;
 
   // Actions

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -459,9 +459,15 @@ export class ScriptInterface {
    *
    * [wtml]: https://docs.worldwidetelescope.org/data-guide/1/data-file-formats/collections/
    *
-   * @param url: The URL of the WTML collection file to load.
+   * @param url The URL of the WTML collection file to load.
    */
   loadImageCollection(url: string): void;
+
+  /** Set the opacity with which the foreground imageset is rendered.
+   *
+   * @param opacity The opacity, between 0 (invisible) and 100 (fully opaque).
+   */
+  setForegroundOpacity(opacity: number): void;
 }
 
 /** A variety of settings for the WWT rendering engine. */

--- a/engine/wwtlib/RenderContext.cs
+++ b/engine/wwtlib/RenderContext.cs
@@ -273,7 +273,7 @@ namespace wwtlib
         public double targetAlt = 0;
         public double targetAz = 0;
 
-        Imageset backgroundImageset;
+        Imageset backgroundImageset = null;
 
         public Imageset BackgroundImageset
         {
@@ -290,7 +290,7 @@ namespace wwtlib
             }
         }
 
-        Imageset foregroundImageset;
+        Imageset foregroundImageset = null;
 
         public Imageset ForegroundImageset
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -285,6 +285,32 @@
         }
       }
     },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.28.tgz",
+      "integrity": "sha512-gtis2/5yLdfI6n0ia0jH7NJs5i/Z/8M/ZbQL6jXQhCthEOe5Cr5NcQPhgTvFxNOtURE03/ZqUcEskdn2M+QaBg=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.28",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.28.tgz",
+      "integrity": "sha512-4LeaNHWvrneoU0i8b5RTOJHKx7E+y7jYejplR7uSVB34+mp3Veg7cbKk7NBCLiI4TyoWS1wh9ZdoyLJR8wSAdg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.28"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.13.0.tgz",
+      "integrity": "sha512-IHUgDJdomv6YtG4p3zl1B5wWf9ffinHIvebqQOmV3U+3SLw4fC+LUCCgwfETkbTtjy5/Qws2VoVf6z/ETQpFpg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.28"
+      }
+    },
+    "@fortawesome/vue-fontawesome": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.9.tgz",
+      "integrity": "sha512-h/emhmZz+DfB2zOGLWawNwXq82UYhn9waTfUjLLmeaIqtnIyNt6kYlpQT/vzJjLZRDRvY2IEJAh1di5qKpKVpA=="
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -2893,6 +2919,10 @@
     "@wwtelescope/embed": {
       "version": "file:embed",
       "requires": {
+        "@fortawesome/fontawesome-svg-core": "^1.2.28",
+        "@fortawesome/free-solid-svg-icons": "^5.13.0",
+        "@fortawesome/vue-fontawesome": "^0.1.9",
+        "@wwtelescope/embed-common": "0.0.0-dev",
         "@wwtelescope/engine": "0.0.0-dev",
         "@wwtelescope/engine-vuex": "0.0.0-dev",
         "vue": "^2.6.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2925,8 +2925,21 @@
         "@wwtelescope/embed-common": "0.0.0-dev",
         "@wwtelescope/engine": "0.0.0-dev",
         "@wwtelescope/engine-vuex": "0.0.0-dev",
+        "v-tooltip": "=2.0.2",
         "vue": "^2.6.11",
         "vuex": "^3.1.3"
+      },
+      "dependencies": {
+        "v-tooltip": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/v-tooltip/-/v-tooltip-2.0.2.tgz",
+          "integrity": "sha512-xQ+qzOFfywkLdjHknRPgMMupQNS8yJtf9Utd5Dxiu/0n4HtrxqsgDtN2MLZ0LKbburtSAQgyypuE/snM8bBZhw==",
+          "requires": {
+            "lodash": "^4.17.11",
+            "popper.js": "^1.15.0",
+            "vue-resize": "^0.4.5"
+          }
+        }
       }
     },
     "@wwtelescope/embed-common": {
@@ -10692,8 +10705,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -16707,6 +16719,11 @@
       "requires": {
         "vue-class-component": "^7.1.0"
       }
+    },
+    "vue-resize": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-0.4.5.tgz",
+      "integrity": "sha512-bhP7MlgJQ8TIkZJXAfDf78uJO+mEI3CaLABLjv0WNzr4CcGRGPIAItyWYnP6LsPA4Oq0WE+suidNs6dgpO4RHg=="
     },
     "vue-style-loader": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lint": "lerna run lint",
     "test": "lerna run test",
     "graduate": "node graduate.js",
-    "serve-creator": "concurrently \"cd embed && npm run serve -- --port=23000\" \"cd embed-creator && npm run serve -- --port=8080\""
+    "serve-creator": "concurrently \"cd embed && npm run serve -- --port=23000\" \"cd embed-creator && npm run serve -- --port=8080\"",
+    "serve-embed": "cd embed && npm run serve"
   },
   "dependencies": {
     "@wwtelescope/astro": "file:astro",


### PR DESCRIPTION
We add an icon with a popup menu that provides a few tools for playing with the WWT view. The initial offerings are:

- Image crossfader, when there's a foreground image
- Background chooser, when in sky mode.

Plus plumbing to make it all possible and robust, I hope.

Also make the embed view default to point at the Galactic center.