### PR TITLE
build: fix commit references

### DIFF
--- a/embed-creator/package.json
+++ b/embed-creator/package.json
@@ -36,7 +36,7 @@
     "@vue/cli-plugin-typescript": "~4.3.0"
   },
   "localDepRequiredCommits": {
-    "@wwtelescope/embed-common": "a78d6075a59c64fa6e9523a7f6639a75a71c4fdd"
+    "@wwtelescope/embed-common": "6bd7f0b05da4663f35373f2a422e30fa84bae13b"
   },
   "publishConfig": {
     "access": "public"

--- a/embed/package.json
+++ b/embed/package.json
@@ -37,9 +37,9 @@
     "@vue/cli-plugin-vuex": "~4.3.0"
   },
   "localDepRequiredCommits": {
-    "@wwtelescope/embed-common": "a78d6075a59c64fa6e9523a7f6639a75a71c4fdd",
-    "@wwtelescope/engine": "5210ecd43527927168236a1eed1a4aac231d6f31",
-    "@wwtelescope/engine-vuex": "e56538f26354ec342949e0eadea9e228b985344b"
+    "@wwtelescope/embed-common": "6bd7f0b05da4663f35373f2a422e30fa84bae13b",
+    "@wwtelescope/engine": "07cc74557e8d5448ab125f0f8330abac9323df3a",
+    "@wwtelescope/engine-vuex": "a832fc00c20145003c0c9794b6be19505595d439"
   },
   "publishConfig": {
     "access": "public"

--- a/engine-helpers/package.json
+++ b/engine-helpers/package.json
@@ -26,7 +26,7 @@
   },
   "localDepRequiredCommits": {
     "@wwtelescope/astro": "f67c4bb8bbe05af1eb2b20c26a575374c53d3d01",
-    "@wwtelescope/engine": "5210ecd43527927168236a1eed1a4aac231d6f31",
+    "@wwtelescope/engine": "07cc74557e8d5448ab125f0f8330abac9323df3a",
     "@wwtelescope/engine-types": "020de599379d176e11f9e7132d1c00ede70bfea0"
   },
   "publishConfig": {

--- a/engine-vuex/package.json
+++ b/engine-vuex/package.json
@@ -34,8 +34,8 @@
     "@vue/cli-plugin-vuex": "~4.3.0"
   },
   "localDepRequiredCommits": {
-    "@wwtelescope/engine": "5210ecd43527927168236a1eed1a4aac231d6f31",
-    "@wwtelescope/engine-helpers": "7f9a72405bd13f4b64ee1e1986be32dc50b8360a"
+    "@wwtelescope/engine": "07cc74557e8d5448ab125f0f8330abac9323df3a",
+    "@wwtelescope/engine-helpers": "f233bc983967d2825682f6f351780cef25754c59"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Sigh. I rewrote history to get a minimal set of changes to merge into `release` in order to make the `tours` branch mergeable, but I didn't think that would invalidate all of the commit ID's that I embedded in the local package version requirements. Fix those up.