### PR TITLE
azure-pipelines.yml: publish engine JS to /$major/, not /$major.$minor/

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -213,8 +213,8 @@ jobs:
       if ($engineVers.IndexOf("-beta") -ne -1) {
         Write-Host "##vso[task.setvariable variable=engineVersionText;]latest"
       } else {
-        $majmin = ($engineVers -Split '\.')[0..1] -Join '.'
-        Write-Host "##vso[task.setvariable variable=engineVersionText;]$majmin"
+        $major = ($engineVers -Split '\.')[0]
+        Write-Host "##vso[task.setvariable variable=engineVersionText;]$major"
       }
     condition: and(succeeded(), ne(variables['publishedEngineVersion'], ''))
     displayName: Set @wwtelescope/engine deployment variables


### PR DESCRIPTION
We're trying to preserve semver and we want users to get the latest stuff, so it will be much more convenient to not need to update them every time a minor release comes out. With semver semantics, we expect our version numbers to evolve as `tiny.large.small`, not `tiny.small.large`.