### PR TITLE
engine/wwtlib/Place.cs: use GetInnerText to get Place.Description text

### DIFF
--- a/engine/wwtlib/Place.cs
+++ b/engine/wwtlib/Place.cs
@@ -565,7 +565,7 @@ namespace wwtlib
             XmlNode descriptionNode = Util.SelectSingleNode(place, "Description");
             if (descriptionNode != null)
             {
-                newPlace.HtmlDescription = descriptionNode.Value;
+                newPlace.HtmlDescription = Util.GetInnerText(descriptionNode);
             }
 
             XmlNode backgroundImageSet = Util.SelectSingleNode(place, "BackgroundImageSet");


### PR DESCRIPTION
This was using `descriptionNode.Value`, which translates to `descriptionNode.nodeValue` in JavaScript. This just doesn't work, because for element nodes that value is always null. I believe this was inherited from the Windows implementation, where the description content is an XML CDATA section, which sometimes requires special handling. But really CDATAs ought to be fully transparent to us. Just use our existing `GetInnerText` utility.

I'm not 100.00% sure that this doesn't break compatibility with the old code, but nothing in production has ever used this field, so I'm comfortable going for it.