### PR TITLE
Release pipeline fix, take 2

### DIFF
--- a/ci/azure-deployment.yml
+++ b/ci/azure-deployment.yml
@@ -270,11 +270,23 @@ jobs:
       parameters:
         setupBuild: true
         setupNpm: true
+
     - bash: npm run build
       displayName: NPM build
+
+    # Very important! Revert the `cranko npm lerna-workaround` (in
+    # azure-job-setup.yml) that's needed for the build to work reliably.
+    # Nothing about the build process should be embedding the hacked
+    # internal version requirements anywhere that will linger in our
+    # published artifacts.
+
+    - bash: git reset --hard release
+      displayName: Undo Lerna-driven internal requirement mods
+
     - bash: |
         set -xeou pipefail
         cranko npm foreach-released npm publish
       displayName: Publish to NPM
+
     - bash: shred ~/.npmrc
       displayName: Clean up credentials

--- a/ci/azure-job-setup.yml
+++ b/ci/azure-job-setup.yml
@@ -70,14 +70,14 @@ steps:
     inputs:
       versionSpec: '>=12'
 
-  ## - bash: npm cache clean -f
-  ##   displayName: npm cache clean
-
   - bash: |
       set -xeuo pipefail
       mkdir -p engine/wwtlib/bin
       cp $PIPELINE_WORKSPACE/scriptsharp/wwtlib.js engine/wwtlib/bin/
     displayName: Restore ScriptSharp wwtlib.js
+
+  - bash: cranko npm lerna-workaround
+    displayName: Fake internal version requirements for Lerna
 
   - bash: npx lerna bootstrap --concurrency=1
     displayName: Lerna NPM setup

--- a/ci/azure-main-build.yml
+++ b/ci/azure-main-build.yml
@@ -23,7 +23,12 @@ jobs:
     displayName: NPM build
 
   # Create and stage our panoply of artifacts. (No reason not to do this ASAP --
-  # these can help debug build problems.)
+  # these can help debug build problems.) The `git reset` is to revert the
+  # `cranko npm lerna-workaround` (in azure-job-setup.yml) that's needed for the
+  # build to work reliably.
+
+  - bash: git reset --hard release
+    displayName: Undo Lerna-driven internal requirement mods
 
   - bash: npm run pack
     displayName: NPM pack
@@ -80,6 +85,10 @@ jobs:
       targetPath: $(Build.ArtifactStagingDirectory)/embed-creator
 
   # Test
+  #
+  # In principle we could/should reapply the Lerna workaround here, but correct
+  # ordering shouldn't matter for the tests. Likewise for the other NPM commands
+  # in this file.
 
   - bash: npm run test
     displayName: NPM test

--- a/ci/azure-scriptsharp-build.yml
+++ b/ci/azure-scriptsharp-build.yml
@@ -20,20 +20,14 @@ jobs:
       echo "##vso[task.prependpath]$d"
     displayName: Install latest Cranko (Windows)
 
-  - task: NodeTool@0
-    displayName: Set up node.js
-    inputs:
-      versionSpec: '>=12'
-
   - bash: |
       set -xeuo pipefail
       git status # seems to help with mysterious Windows dirtiness issue
       cranko release-workflow apply-versions
-      npm install # update package-lock.json
       git add .
       cranko release-workflow commit
       git show
-    displayName: Generate release commit
+    displayName: Apply versions and generate release commit
 
   # Publish release commit as an artifact -- the next stages will need it.
 


### PR DESCRIPTION
My first fix attempt didn't work. I think I have a better idea of what's happening now — Lerna is a bit simple and was confused by our internal version requirements. Hopefully this will fix things for real, although I don't think I can fully find out without attempting another release.