### PR TITLE
Simple FITS HiPS support using JavaScript parsing

### DIFF
--- a/engine/wwtlib/HealpixTile.cs
+++ b/engine/wwtlib/HealpixTile.cs
@@ -617,8 +617,23 @@ namespace wwtlib
                     catalogData.Send();
                 }
             }
-            else
+            else if (GetHipsFileExtention() == ".fits")
             {
+                if(!Downloading && !ReadyToRender)
+                {
+                    Downloading = true;
+                    FitsImage image = FitsImage.CreateHipsTile(URL, delegate (WcsImage wcsImage)
+                    {
+                        texReady = true;
+                        Downloading = false;
+                        errored = false;
+                        ReadyToRender = texReady && (DemReady || !demTile);
+                        RequestPending = false;
+                        TileCache.RemoveFromQueue(this.Key, true);
+                        texture2d = wcsImage.GetBitmap().GetTexture();
+                    });
+                }
+            } else {
                 base.RequestImage();
             }
 

--- a/engine/wwtlib/Layers/FitsImage.cs
+++ b/engine/wwtlib/Layers/FitsImage.cs
@@ -21,6 +21,15 @@ namespace wwtlib
         public static FitsImage Last = null;
 
         private WcsLoaded callBack;
+
+        public bool isHipsTile = false;
+        public static FitsImage CreateHipsTile(string file, WcsLoaded callMeBack)
+        {
+            FitsImage fits = new FitsImage(file, null, callMeBack);
+            fits.isHipsTile = true;
+            return fits;
+        }
+
         public FitsImage(string file, Blob blob, WcsLoaded callMeBack)
         {
             Last = this;
@@ -50,7 +59,7 @@ namespace wwtlib
         {
             if (webFile.State == StateType.Error)
             {
-                Script.Literal("alert({0})", webFile.Message);
+                Script.Literal("console.log({0})", webFile.Message);
             }
             else if (webFile.State == StateType.Received)
             {
@@ -262,7 +271,10 @@ namespace wwtlib
                 }
                 sizeX = Width = AxisSize[0];
                 sizeY = Height = AxisSize[1];
-                ComputeWcs();
+                if (!isHipsTile)
+                {
+                    ComputeWcs();
+                }
                 Histogram = ComputeHistogram(256);
                 HistogramMaxCount = Histogram[256];
             }


### PR DESCRIPTION
As expected it is quite slow, but it is technically working. 

There seem to be a bug in FitsImage.cs when dealing with the "no data" pixels of the FITS files. For some tiles they are grey, and other they are black. I have not investigated the issue as this entire PR is just a proof of concept for the real solution of reading the data from the shader. 