### PR TITLE
Add catalog HiPS by imageset

### DIFF
--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -2559,6 +2559,11 @@ namespace wwtlib
             }
         }
 
+        public void AddCatalogHips(Imageset catalogHips)
+        {
+            RenderContext.AddCatalogHips(catalogHips, null);
+        }
+
         public void AddCatalogHipsByName(string name)
         {
             AddCatalogHipsByNameWithCallback(name, null);


### PR DESCRIPTION
Since the engine only loads a subset of the imagesets, it is required to add catalog HiPS by sending the entire imageset instead of just the name.

Needed for this one
https://github.com/WorldWideTelescope/wwt-web-client/pull/344