### PR TITLE
OpenSpace patch

### DIFF
--- a/embed/src/Embed.vue
+++ b/embed/src/Embed.vue
@@ -251,7 +251,8 @@ export default class Embed extends WWTAwareComponent {
       if (this.embedSettings.wtmlUrl.length) {
         prom = prom.then(async () => {
           const folder = await this.loadImageCollection({
-            url: this.embedSettings.wtmlUrl
+            url: this.embedSettings.wtmlUrl,
+            loadChildFolders: false
           });
 
           if (this.embedSettings.wtmlPlace) {

--- a/engine-helpers/src/index.ts
+++ b/engine-helpers/src/index.ts
@@ -285,9 +285,11 @@ export interface GotoTargetOptions {
   trackObject: boolean;
 }
 
-/** Options for [[WWTInstance.loadFitsLayer]]. */
-export interface LoadFitsLayerOptions {
-  /** The URL of the FITS file. */
+/** Options for [[WWTInstance.addImageSetLayer]]. */
+export interface AddImageSetLayerOptions {
+  /** The URL of the FITS file 
+   * OR The URL of the desired image set. This should mach an image set url
+   * previously loaded with [[LoadImageCollection]]. */
   url: string;
 
   /** A name to use for the new layer. */
@@ -546,29 +548,29 @@ export class WWTInstance {
   private collectionLoadedPromises: SavedPromise<string, Folder>[] = [];
   private collectionRequests: Map<string, Folder | null> = new Map();
 
-   /** Load a WTML collection and the imagesets that it contains.
-   *
-   * This function triggers a download of the specified URL, which should return
-   * an XML document in the [WTML collection][wtml] format. Any `ImageSet`
-   * entries in the collection, or `Place` entries containing image sets, will
-   * be added to the WWT instance’s list of available imagery. Subsequent calls
-   * to functions like [[setForegroundImageByName]] will be able to locate the
-   * new imagesets and display them to the user.
-   *
-   * Each unique URL is only requested once. Once a given URL has been
-   * successfully loaded, the promise returned by additional calls will resolve
-   * immediately. URL uniqueness is tested with simple string equality, so if
-   * you really want to load the same URL more than once you could add a
-   * fragment specifier.
-   *
-   * If the URL is not accessible due to CORS restrictions, the request will
-   * automatically be routed through the WWT’s CORS proxying service.
-   *
-   * [wtml]: https://docs.worldwidetelescope.org/data-guide/1/data-file-formats/collections/
-   *
-   * @param url: The URL of the WTML collection file to load.
-   * @returns: A promise that resolves to an initialized Folder object.
-   */
+  /** Load a WTML collection and the imagesets that it contains.
+  *
+  * This function triggers a download of the specified URL, which should return
+  * an XML document in the [WTML collection][wtml] format. Any `ImageSet`
+  * entries in the collection, or `Place` entries containing image sets, will
+  * be added to the WWT instance’s list of available imagery. Subsequent calls
+  * to functions like [[setForegroundImageByName]] will be able to locate the
+  * new imagesets and display them to the user.
+  *
+  * Each unique URL is only requested once. Once a given URL has been
+  * successfully loaded, the promise returned by additional calls will resolve
+  * immediately. URL uniqueness is tested with simple string equality, so if
+  * you really want to load the same URL more than once you could add a
+  * fragment specifier.
+  *
+  * If the URL is not accessible due to CORS restrictions, the request will
+  * automatically be routed through the WWT’s CORS proxying service.
+  *
+  * [wtml]: https://docs.worldwidetelescope.org/data-guide/1/data-file-formats/collections/
+  *
+  * @param url: The URL of the WTML collection file to load.
+  * @returns: A promise that resolves to an initialized Folder object.
+  */
   async loadImageCollection(url: string): Promise<Folder> {
     const curState = this.collectionRequests.get(url);
 
@@ -621,14 +623,16 @@ export class WWTInstance {
 
   // Layers
 
-  /** Load a remote FITS file into a data layer and display it.
+  /** Load an image set or a remote FITS file into a data layer and display it.
    *
    * The FITS file must be downloaded and processed, so this API is
    * asynchronous, and is not appropriate for files that might be large.
+   * 
+   * The image set must have previously been created with [[loadImageCollection]]
    */
-  async loadFitsLayer(options: LoadFitsLayerOptions): Promise<ImageSetLayer> {
+  async addImageSetLayer(options: AddImageSetLayerOptions): Promise<ImageSetLayer> {
     return new Promise((resolve, _reject) => {
-      this.si.loadFitsLayer(options.url, options.name, options.gotoTarget, (layer) => {
+      this.si.addImageSetLayer(options.url, options.name, options.gotoTarget, (layer) => {
         resolve(layer);
       })
     });

--- a/engine-helpers/src/index.ts
+++ b/engine-helpers/src/index.ts
@@ -285,19 +285,38 @@ export interface GotoTargetOptions {
   trackObject: boolean;
 }
 
+
+/** Deprecated, use AddImageSetLayerOptions instead.
+ *  Options for [[WWTInstance.addImageSetLayer]]. */
+export interface LoadFitsLayerOptions {
+  /** The URL of the FITS file. */
+  url: string;
+  
+  /** A name to use for the new layer. */
+  name: string;
+
+  /** Whether to seek the view to the positon of the FITS file on the sky,
+   * if/when it successfully loads. */
+  gotoTarget: boolean;
+}
+
 /** Options for [[WWTInstance.addImageSetLayer]]. */
 export interface AddImageSetLayerOptions {
   /** The URL of the FITS file 
    * OR The URL of the desired image set. This should mach an image set url
    * previously loaded with [[LoadImageCollection]]. */
   url: string;
+  
+  /** Tell WWT what type of layer you are Adding.
+   * OR let WWT try to autodetect the type of the data.
+   * Default, autodetect. */
+  mode: "autodetect" | "fits" | "preloaded";
 
   /** A name to use for the new layer. */
   name: string;
 
   /** Whether to seek the view to the positon of the FITS file on the sky,
-   * if/when it successfully loads.
-   */
+   * if/when it successfully loads. */
   gotoTarget: boolean;
 }
 

--- a/engine-helpers/src/index.ts
+++ b/engine-helpers/src/index.ts
@@ -569,9 +569,11 @@ export class WWTInstance {
   * [wtml]: https://docs.worldwidetelescope.org/data-guide/1/data-file-formats/collections/
   *
   * @param url: The URL of the WTML collection file to load.
+  * @param loadChildFolders When true, this method will recursively
+  * download and unpack the content of all [[Folder]]s contained in the WTML file.
   * @returns: A promise that resolves to an initialized Folder object.
   */
-  async loadImageCollection(url: string): Promise<Folder> {
+  async loadImageCollection(url: string, loadChildFolders?: boolean): Promise<Folder> {
     const curState = this.collectionRequests.get(url);
 
     // If we've already loaded the folder, insta-resolve to it.
@@ -589,7 +591,11 @@ export class WWTInstance {
       // the function.
       const holder: { f: Folder | null } = { f: null };
 
-      holder.f = Wtml.getWtmlFile(url, () => {
+      if (loadChildFolders === undefined) {
+        loadChildFolders = false;
+      }
+
+      holder.f = Wtml.getWtmlFile(url, loadChildFolders, () => {
         // The folder at this URL is now fully loaded.
         const f = holder.f as Folder;
         this.collectionRequests.set(url, f);

--- a/engine-helpers/src/index.ts
+++ b/engine-helpers/src/index.ts
@@ -595,7 +595,7 @@ export class WWTInstance {
         loadChildFolders = false;
       }
 
-      holder.f = Wtml.getWtmlFile(url, loadChildFolders, () => {
+      holder.f = Wtml.getWtmlFile(url, () => {
         // The folder at this URL is now fully loaded.
         const f = holder.f as Folder;
         this.collectionRequests.set(url, f);
@@ -609,7 +609,7 @@ export class WWTInstance {
           // Don't filter out promises for other URLs.
           return true;
         });
-      });
+      }, loadChildFolders);
     }
 
     return new Promise((resolve, reject) => {

--- a/engine-helpers/src/index.ts
+++ b/engine-helpers/src/index.ts
@@ -540,7 +540,7 @@ export class WWTInstance {
       decRad * R2D,
       zoomDeg,
       instant,
-      rollRad === undefined ? undefined : rollRad * R2D
+      rollRad
     );
     return this.makeArrivePromise(instant);
   }

--- a/engine-helpers/src/index.ts
+++ b/engine-helpers/src/index.ts
@@ -657,7 +657,7 @@ export class WWTInstance {
    */
   async addImageSetLayer(options: AddImageSetLayerOptions): Promise<ImageSetLayer> {
     return new Promise((resolve, _reject) => {
-      this.si.addImageSetLayer(options.url, options.name, options.gotoTarget, (layer) => {
+      this.si.addImageSetLayer(options.url, options.mode, options.name, options.gotoTarget, (layer) => {
         resolve(layer);
       })
     });

--- a/engine-vuex/src/store.ts
+++ b/engine-vuex/src/store.ts
@@ -26,7 +26,7 @@ import {
   ApplyFitsLayerSettingsOptions,
   ApplyTableLayerSettingsOptions,
   GotoTargetOptions,
-  LoadFitsLayerOptions,
+  AddImageSetLayerOptions,
   SetFitsLayerColormapOptions,
   SetupForImagesetOptions,
   StretchFitsLayerOptions,
@@ -511,12 +511,12 @@ export class WWTEngineVuexModule extends VuexModule implements WWTEngineVuexStat
   }
 
   @Action({ rawError: true })
-  async loadFitsLayer(
-    options: LoadFitsLayerOptions
+  async addImageSetLayer(
+    options: AddImageSetLayerOptions
   ): Promise<ImageSetLayer> {
     if (Vue.$wwt.inst === null)
-      throw new Error('cannot loadFitsLayer without linking to WWTInstance');
-    return Vue.$wwt.inst.loadFitsLayer(options);
+      throw new Error('cannot addImageSetLayer without linking to WWTInstance');
+    return Vue.$wwt.inst.addImageSetLayer(options);
   }
 
   @Mutation

--- a/engine-vuex/src/store.ts
+++ b/engine-vuex/src/store.ts
@@ -205,7 +205,7 @@ export interface LoadTourParams {
 export interface LoadImageCollectionParams {
   /** The WTML URL to load. */
   url: string;
-  /** Recursively load any child folders. */
+  /** Optional, Recursively load any child folders. Defaults to false*/
   loadChildFolders?: boolean;
 }
 

--- a/engine-vuex/src/store.ts
+++ b/engine-vuex/src/store.ts
@@ -205,6 +205,8 @@ export interface LoadTourParams {
 export interface LoadImageCollectionParams {
   /** The WTML URL to load. */
   url: string;
+  /** Recursively load any child folders. */
+  loadChildFolders?: boolean;
 }
 
 @Module({
@@ -503,11 +505,11 @@ export class WWTEngineVuexModule extends VuexModule implements WWTEngineVuexStat
 
   @Action({ rawError: true })
   async loadImageCollection(
-    {url}: LoadImageCollectionParams
+    {url, loadChildFolders}: LoadImageCollectionParams
   ): Promise<Folder> {
     if (Vue.$wwt.inst === null)
       throw new Error('cannot loadImageCollection without linking to WWTInstance');
-    return Vue.$wwt.inst.loadImageCollection(url);
+    return Vue.$wwt.inst.loadImageCollection(url, loadChildFolders);
   }
 
   @Action({ rawError: true })

--- a/engine-vuex/src/store.ts
+++ b/engine-vuex/src/store.ts
@@ -27,6 +27,7 @@ import {
   ApplyTableLayerSettingsOptions,
   GotoTargetOptions,
   AddImageSetLayerOptions,
+  LoadFitsLayerOptions,
   SetFitsLayerColormapOptions,
   SetupForImagesetOptions,
   StretchFitsLayerOptions,
@@ -519,6 +520,22 @@ export class WWTEngineVuexModule extends VuexModule implements WWTEngineVuexStat
     if (Vue.$wwt.inst === null)
       throw new Error('cannot addImageSetLayer without linking to WWTInstance');
     return Vue.$wwt.inst.addImageSetLayer(options);
+  }
+
+  @Action({ rawError: true })
+  async loadFitsLayer(
+    options: LoadFitsLayerOptions
+  ): Promise<ImageSetLayer> {
+    if (Vue.$wwt.inst === null)
+      throw new Error('cannot loadFitsLayer without linking to WWTInstance');
+    const addImageSetLayerOptions: AddImageSetLayerOptions = {
+      url: options.url, 
+      mode: "fits",
+      name: options.name,
+      gotoTarget: options.gotoTarget
+    };
+    
+    return Vue.$wwt.inst.addImageSetLayer(addImageSetLayerOptions);
   }
 
   @Mutation

--- a/engine-vuex/src/wwtaware.ts
+++ b/engine-vuex/src/wwtaware.ts
@@ -20,7 +20,7 @@ import {
   ApplyFitsLayerSettingsOptions,
   ApplyTableLayerSettingsOptions,
   GotoTargetOptions,
-  LoadFitsLayerOptions,
+  AddImageSetLayerOptions,
   SetFitsLayerColormapOptions,
   SetupForImagesetOptions,
   StretchFitsLayerOptions,
@@ -164,7 +164,7 @@ import {
  *
  * Actions:
  *
- * - [[loadFitsLayer]]
+ * - [[addImageSetLayer]]
  *
  * #### Tabular Data Layers
  *
@@ -264,7 +264,7 @@ export class WWTAwareComponent extends Vue {
         "gotoRADecZoom",
         "gotoTarget",
         "loadImageCollection",
-        "loadFitsLayer",
+        "addImageSetLayer",
         "loadTour",
         "waitForReady",
       ]),
@@ -616,12 +616,12 @@ export class WWTAwareComponent extends Vue {
    */
   loadImageCollection!: (_o: LoadImageCollectionParams) => Promise<Folder>;
 
-  /** Request the creation of a FITS image layer.
+  /** Request the creation of a image layer. Either a single FITS or an image set.
    *
    * The action resolves to a new [ImageSetLayer](../../engine/classes/imagesetlayer.html) instance.
-   * It’s asynchronous because the requested FITS file has to be downloaded.
+   * It’s asynchronous because the requested url has to be downloaded.
    */
-  loadFitsLayer!: (_o: LoadFitsLayerOptions) => Promise<ImageSetLayer>;
+  addImageSetLayer!: (_o: AddImageSetLayerOptions) => Promise<ImageSetLayer>;
 
   /** Request the engine to load a tour file.
    *

--- a/engine-vuex/src/wwtaware.ts
+++ b/engine-vuex/src/wwtaware.ts
@@ -21,6 +21,7 @@ import {
   ApplyTableLayerSettingsOptions,
   GotoTargetOptions,
   AddImageSetLayerOptions,
+  LoadFitsLayerOptions,
   SetFitsLayerColormapOptions,
   SetupForImagesetOptions,
   StretchFitsLayerOptions,
@@ -264,6 +265,7 @@ export class WWTAwareComponent extends Vue {
         "gotoRADecZoom",
         "gotoTarget",
         "loadImageCollection",
+        "loadFitsLayer",
         "addImageSetLayer",
         "loadTour",
         "waitForReady",
@@ -615,6 +617,14 @@ export class WWTAwareComponent extends Vue {
    * It’s asynchronous because the specified WTML file has to be downloaded.
    */
   loadImageCollection!: (_o: LoadImageCollectionParams) => Promise<Folder>;
+
+  /** Deprecated. Use addImageSetLayer instead.
+   * Request the creation of a FITS image layer.
+   *
+   * The action resolves to a new [ImageSetLayer](../../engine/classes/imagesetlayer.html) instance.
+   * It’s asynchronous because the requested FITS file has to be downloaded.
+   */
+   loadFitsLayer!: (_o: LoadFitsLayerOptions) => Promise<ImageSetLayer>;
 
   /** Request the creation of a image layer. Either a single FITS or an image set.
    *

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -975,11 +975,14 @@ export class ScriptInterface {
    *
    * @param url The URL of a single-file FITS or
    * the URL of an image set as specified in the WTML used in loadImageCollection.
+   * @param mode Tell WWT what type of layer you are Adding.
+   * OR let WWT try to autodetect the type of the data.
    * @param name The name of the image set layer.
    * @param gotoTarget If true, camera will move to the center position of the image.
    */
   addImageSetLayer(
     url: string,
+    mode: string,
     name: string,
     gotoTarget: boolean,
     callback: ImagesetLoadedCallback

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -948,9 +948,10 @@ export class ScriptInterface {
    * [wtml]: https://docs.worldwidetelescope.org/data-guide/1/data-file-formats/collections/
    *
    * @param url The URL of the WTML collection file to load.
-   * @param loadChildFolders Recursively load any child folders.
+   * @param loadChildFolders Optional, Recursively load any child folders.
+   * Defaults to False
    */
-  loadImageCollection(url: string, loadChildFolders: boolean): void;
+  loadImageCollection(url: string, loadChildFolders?: boolean): void;
 
   /** Set the opacity with which the foreground imageset is rendered.
    *

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -948,8 +948,9 @@ export class ScriptInterface {
    * [wtml]: https://docs.worldwidetelescope.org/data-guide/1/data-file-formats/collections/
    *
    * @param url The URL of the WTML collection file to load.
+   * @param loadChildFolders Recursively load any child folders.
    */
-  loadImageCollection(url: string): void;
+  loadImageCollection(url: string, loadChildFolders: boolean): void;
 
   /** Set the opacity with which the foreground imageset is rendered.
    *
@@ -957,17 +958,26 @@ export class ScriptInterface {
    */
   setForegroundOpacity(opacity: number): void;
 
-  /** Initiate the loading of a single-file FITS layer
-   *
+  /** Initiate the loading of a image set or single-file FITS layer.
+   * 
+   * If the specified URL already exists in the image set collection, i.e. it
+   * has previously been created with [[loadImageCollection]], then this image set
+   * is added to the view.
+   * 
+   * If the specified URL is pointing to a FITS file, it will be downloaded and parsed.
+   * This API is therefore insufficient for large datasets, since they become
+   * impractical to download as whole files.
+   * 
    * Although this function will return an ImageSetLayer object immediately, the
-   * FITS information won't be ready until the FITS file is downloaded and
-   * parsed. The callback will be called after this completes.
+   * FITS / image set information won't be ready until the FITS file / image set
+   * is downloaded and parsed. The callback will be called after this completes.
    *
-   * The specified URL will be downloaded and parsed as a FITS file. This API is
-   * therefore insufficient for large datasets, since they become impractical to
-   * download as whole files.
+   * @param url The URL of a single-file FITS or
+   * the URL of an image set as specified in the WTML used in loadImageCollection.
+   * @param name The name of the image set layer.
+   * @param gotoTarget If true, camera will move to the center position of the image.
    */
-  loadFitsLayer(
+  addImageSetLayer(
     url: string,
     name: string,
     gotoTarget: boolean,
@@ -2126,11 +2136,13 @@ export namespace Wtml {
    * callback will be called.
    *
    * @param url The URL from which to retrieve the WTML data.
-   * @param complete A callback to be called after the folder is successfully
-   * loaded.
+   * @param loadChildFolders When true, this method will recursively 
+   * download and unpack all [[Folder]]s contained in the original WTML file.
+   * @param complete A callback to be called after the folder (and all child
+   * folders, if loadChildFolders is set to true) is successfully loaded.
    * @returns A folder object that will be populated asynchronously.
    */
-  export function getWtmlFile(url: string, complete: Action): Folder;
+  export function getWtmlFile(url: string, loadChildFolders: boolean, complete: Action): Folder;
 }
 
 export namespace WWTControl {

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -2136,13 +2136,14 @@ export namespace Wtml {
    * callback will be called.
    *
    * @param url The URL from which to retrieve the WTML data.
-   * @param loadChildFolders When true, this method will recursively 
-   * download and unpack all [[Folder]]s contained in the original WTML file.
    * @param complete A callback to be called after the folder (and all child
    * folders, if loadChildFolders is set to true) is successfully loaded.
+   * @param loadChildFolders Optional, When true, this method will recursively 
+   * download and unpack all [[Folder]]s contained in the original WTML file.
+   * Defaults to false.
    * @returns A folder object that will be populated asynchronously.
    */
-  export function getWtmlFile(url: string, loadChildFolders: boolean, complete: Action): Folder;
+  export function getWtmlFile(url: string, complete: Action, loadChildFolders?: boolean): Folder;
 }
 
 export namespace WWTControl {

--- a/engine/wwtlib/Folder.cs
+++ b/engine/wwtlib/Folder.cs
@@ -54,6 +54,14 @@ namespace wwtlib
 
         WebFile webFile;
         Action onComplete;
+        Action onError;
+
+        public void LoadFromUrlWithErrorCallback(string url, Action complete, Action onError)
+        {
+            this.onError = onError;
+            this.LoadFromUrl(url, complete);
+        }
+
         public void LoadFromUrl(string url, Action complete)
         {
             onComplete = complete;
@@ -68,7 +76,11 @@ namespace wwtlib
         {
             if (webFile.State == StateType.Error)
             {
-                Script.Literal("alert({0})", webFile.Message);
+                Script.Literal("console.error({0})", webFile.Message);
+                if(onError != null)
+                {
+                    onError();
+                }
             }
             else if (webFile.State == StateType.Received)
             {
@@ -275,7 +287,7 @@ namespace wwtlib
                 proxyFolder.Parent = Parent;
             }
 
-            proxyFolder.LoadFromUrl(urlField, childReadyCallback);
+            proxyFolder.LoadFromUrlWithErrorCallback(urlField, childReadyCallback, childReadyCallback);
             childReadyCallback = null;
         }
 
@@ -357,7 +369,7 @@ namespace wwtlib
                     // TOdo add add Move Complete Auto Update
                     // todo add URL formating for Ambient Parameters
                     // TODO remove true when perth fixes refresh type on server
-                    if (true || RefreshType == FolderRefreshType.ConditionalGet || proxyFolder == null ||
+                    if (RefreshType == FolderRefreshType.ConditionalGet || proxyFolder == null ||
                         (this.RefreshType == FolderRefreshType.Interval && (int.Parse(refreshIntervalField) < ts)))
                     {
                         Refresh();

--- a/engine/wwtlib/Folder.cs
+++ b/engine/wwtlib/Folder.cs
@@ -288,7 +288,7 @@ namespace wwtlib
             }
 
             //Also listening to errors, to make sure clients do not wait forever in the case of a 404 or similar.
-            //Especially useful for recursive downloads, where potentially dussins of URL's are downloaded.
+            //Especially useful for recursive downloads, where potentially dozens of URL's are downloaded.
             //In case of errors during downloads, the clients will have an empty folder during the callback.
             proxyFolder.LoadFromUrlWithErrorCallback(urlField, childReadyCallback, childReadyCallback);
             childReadyCallback = null;

--- a/engine/wwtlib/Folder.cs
+++ b/engine/wwtlib/Folder.cs
@@ -287,6 +287,9 @@ namespace wwtlib
                 proxyFolder.Parent = Parent;
             }
 
+            //Also listening to errors, to make sure clients do not wait forever in the case of a 404 or similar.
+            //Especially useful for recursive downloads, where potentially dussins of URL's are downloaded.
+            //In case of errors during downloads, the clients will have an empty folder during the callback.
             proxyFolder.LoadFromUrlWithErrorCallback(urlField, childReadyCallback, childReadyCallback);
             childReadyCallback = null;
         }

--- a/engine/wwtlib/Layers/LayerManager.cs
+++ b/engine/wwtlib/Layers/LayerManager.cs
@@ -443,25 +443,29 @@ namespace wwtlib
 
         private static string getNextName(string type){
             int currentNumber = 0;
-            foreach (Layer layer in AllMaps["Sky"].Layers)
+            foreach (string key in AllMaps.Keys)
             {
-                if (layer.Name.StartsWith(type + " "))
+                foreach (Layer layer in AllMaps[key].Layers)
                 {
-                    string number = layer.Name.Replace(type + " ", "");
-                    try
+                    if (layer.Name.StartsWith(type + " "))
                     {
-                        int num = Int32.Parse(number);
-                        if (num > currentNumber)
+                        string number = layer.Name.Replace(type + " ", "");
+                        try
                         {
-                            currentNumber = num;
+                            int num = Int32.Parse(number);
+                            if (num > currentNumber)
+                            {
+                                currentNumber = num;
+                            }
                         }
-                    }
-                    catch
-                    {
+                        catch
+                        {
 
+                        }
                     }
                 }
             }
+
             return string.Format("{0} {1}", type, currentNumber + 1);
         }
 

--- a/engine/wwtlib/Layers/LayerManager.cs
+++ b/engine/wwtlib/Layers/LayerManager.cs
@@ -433,12 +433,21 @@ namespace wwtlib
 
         public static string GetNextFitsName()
         {
+            return getNextName("Fits Image");
+        }
+
+        public static string GetNextImageSetName()
+        {
+            return getNextName("Image Set");
+        }
+
+        private static string getNextName(string type){
             int currentNumber = 0;
             foreach (Layer layer in AllMaps["Sky"].Layers)
             {
-                if (layer.Name.StartsWith("Fits Image "))
+                if (layer.Name.StartsWith(type + " "))
                 {
-                    string number = layer.Name.Replace("Fits Image ", "");
+                    string number = layer.Name.Replace(type + " ", "");
                     try
                     {
                         int num = Int32.Parse(number);
@@ -453,7 +462,7 @@ namespace wwtlib
                     }
                 }
             }
-            return string.Format("Fits Image {0}", currentNumber + 1);
+            return string.Format("{0} {1}", type, currentNumber + 1);
         }
 
         internal static void CloseAllTourLoadedLayers()

--- a/engine/wwtlib/ScriptInterface.cs
+++ b/engine/wwtlib/ScriptInterface.cs
@@ -320,65 +320,93 @@ namespace wwtlib
 
         public ImageSetLayer LoadFitsLayer(string url, string name, bool gotoTarget, ImagesetLoaded loaded)
         {
-            if (string.IsNullOrWhiteSpace(name))
+            return AddImageSetLayer(url, name, gotoTarget, loaded);
+        }
+
+        public ImageSetLayer AddImageSetLayer(string url, string name, bool gotoTarget, ImagesetLoaded loaded)
+        {
+            Imageset imageset = WWTControl.Singleton.GetImageSetByUrl(url);
+            if (imageset != null)
             {
-                name = LayerManager.GetNextFitsName();
-            }
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    name = LayerManager.GetNextImageSetName();
+                }
+                ImageSetLayer imagesetLayer = LayerManager.AddImageSetLayer(imageset, name);
 
-            ImageSetLayer imagesetLayer = new ImageSetLayer();
-
-            FitsImage img = new FitsImage(url, null, delegate (WcsImage wcsImage)
-            {
-                int width = (int)wcsImage.SizeX;
-                int height = (int)wcsImage.SizeY;
-
-                Imageset imageset = Imageset.Create(
-                            wcsImage.Description,
-                            Util.GetHashCode(wcsImage.Filename).ToString(),
-                            ImageSetType.Sky,
-                            BandPass.Visible,
-                            ProjectionType.SkyImage,
-                            Util.GetHashCode(wcsImage.Filename),
-                            0,
-                            0,
-                            256,
-                            wcsImage.ScaleY,
-                            ".tif",
-                            wcsImage.ScaleX > 0,
-                            "",
-                            wcsImage.CenterX,
-                            wcsImage.CenterY,
-                            wcsImage.Rotation,
-                            false,
-                            "",
-                            false,
-                            false,
-                            1,
-                            wcsImage.ReferenceX,
-                            wcsImage.ReferenceY,
-                            wcsImage.Copyright,
-                            wcsImage.CreditsUrl,
-                            "",
-                            "",
-                            0,
-                            ""
-                            );
-
-                imageset.WcsImage = wcsImage;
-                imagesetLayer.ImageSet = imageset;
-                LayerManager.AddFitsImageSetLayer(imagesetLayer, name);
-                LayerManager.LoadTree();
                 if (gotoTarget)
                 {
-                    WWTControl.Singleton.GotoRADecZoom(wcsImage.CenterX / 15, wcsImage.CenterY, 10 * wcsImage.ScaleY * height, false, null);
+                    WWTControl.Singleton.GotoRADecZoom(imageset.CenterX / 15, imageset.CenterY, 
+                        WWTControl.Singleton.RenderContext.ViewCamera.Zoom, false, null);
                 }
                 if (loaded != null)
                 {
                     loaded(imagesetLayer);
                 }
-            });
 
-            return imagesetLayer;
+                return imagesetLayer;
+            } else
+            {
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    name = LayerManager.GetNextFitsName();
+                }
+
+                ImageSetLayer imagesetLayer = new ImageSetLayer();
+
+                FitsImage img = new FitsImage(url, null, delegate (WcsImage wcsImage)
+                {
+                    int width = (int)wcsImage.SizeX;
+                    int height = (int)wcsImage.SizeY;
+
+                    imageset = Imageset.Create(
+                                wcsImage.Description,
+                                Util.GetHashCode(wcsImage.Filename).ToString(),
+                                ImageSetType.Sky,
+                                BandPass.Visible,
+                                ProjectionType.SkyImage,
+                                Util.GetHashCode(wcsImage.Filename),
+                                0,
+                                0,
+                                256,
+                                wcsImage.ScaleY,
+                                ".tif",
+                                wcsImage.ScaleX > 0,
+                                "",
+                                wcsImage.CenterX,
+                                wcsImage.CenterY,
+                                wcsImage.Rotation,
+                                false,
+                                "",
+                                false,
+                                false,
+                                1,
+                                wcsImage.ReferenceX,
+                                wcsImage.ReferenceY,
+                                wcsImage.Copyright,
+                                wcsImage.CreditsUrl,
+                                "",
+                                "",
+                                0,
+                                ""
+                                );
+
+                    imageset.WcsImage = wcsImage;
+                    imagesetLayer.ImageSet = imageset;
+                    LayerManager.AddFitsImageSetLayer(imagesetLayer, name);
+                    LayerManager.LoadTree();
+                    if (gotoTarget)
+                    {
+                        WWTControl.Singleton.GotoRADecZoom(wcsImage.CenterX / 15, wcsImage.CenterY, 10 * wcsImage.ScaleY * height, false, null);
+                    }
+                    if (loaded != null)
+                    {
+                        loaded(imagesetLayer);
+                    }
+                });
+
+                return imagesetLayer;
+            }
         }
 
 

--- a/engine/wwtlib/ScriptInterface.cs
+++ b/engine/wwtlib/ScriptInterface.cs
@@ -441,12 +441,10 @@ namespace wwtlib
         }
 
         private string imageUrl;
-        public void LoadImageCollection(string url, bool loadChildFolders)
+        public void LoadImageCollection(string url, bool? loadChildFolders)
         {
-
             imageUrl = url;
-            Wtml.GetWtmlFile(url, loadChildFolders, delegate { FireCollectionLoaded(url); });
-
+            Wtml.GetWtmlFile(url, delegate { FireCollectionLoaded(url); }, loadChildFolders);
         }
 
         private void ImageFileLoaded()

--- a/engine/wwtlib/ScriptInterface.cs
+++ b/engine/wwtlib/ScriptInterface.cs
@@ -440,14 +440,12 @@ namespace wwtlib
             }
         }
 
-        private Folder imageFolder;
         private string imageUrl;
-        public void LoadImageCollection(string url)
+        public void LoadImageCollection(string url, bool loadChildFolders)
         {
 
             imageUrl = url;
-            imageFolder = new Folder();
-            imageFolder.LoadFromUrl(url, delegate { Wtml.LoadImagesets(imageFolder); FireCollectionLoaded(url); });
+            Wtml.GetWtmlFile(url, loadChildFolders, delegate { FireCollectionLoaded(url); });
 
         }
 

--- a/engine/wwtlib/Utilities/Histogram.cs
+++ b/engine/wwtlib/Utilities/Histogram.cs
@@ -71,7 +71,10 @@ namespace wwtlib
         public static void UpdateImage(ImageSetLayer isl, double z)
         {
             FitsImage image = isl.ImageSet.WcsImage as FitsImage;
-            if(image == null) { return; }
+            if(image == null) 
+            { 
+                return; 
+            }
             SkyImageTile Tile = (SkyImageTile)TileCache.GetTile(0, 0, 0, isl.ImageSet, null);
             double low = image.lastBitmapMin;
             double hi = image.lastBitmapMax;
@@ -81,7 +84,10 @@ namespace wwtlib
         public static void UpdateScale(ImageSetLayer isl, ScaleTypes scale, double low, double hi)
         {
             FitsImage image = isl.ImageSet.WcsImage as FitsImage;
-            if(image == null) { return; }
+            if (image == null)
+            {
+                return;
+            }
             SkyImageTile Tile = (SkyImageTile)TileCache.GetTile(0, 0, 0, isl.ImageSet, null);
             int z = image.lastBitmapZ;
             string colorMapperName = image.lastBitmapColorMapperName;
@@ -91,7 +97,10 @@ namespace wwtlib
         public static void UpdateColorMapper(ImageSetLayer isl, string colorMapperName)
         {
             FitsImage image = isl.ImageSet.WcsImage as FitsImage;
-            if(image == null) { return; }
+            if (image == null)
+            {
+                return;
+            }
             SkyImageTile Tile = (SkyImageTile)TileCache.GetTile(0, 0, 0, isl.ImageSet, null);
             double low = image.lastBitmapMin;
             double hi = image.lastBitmapMax;

--- a/engine/wwtlib/Utilities/Histogram.cs
+++ b/engine/wwtlib/Utilities/Histogram.cs
@@ -71,6 +71,7 @@ namespace wwtlib
         public static void UpdateImage(ImageSetLayer isl, double z)
         {
             FitsImage image = isl.ImageSet.WcsImage as FitsImage;
+            if(image == null) { return; }
             SkyImageTile Tile = (SkyImageTile)TileCache.GetTile(0, 0, 0, isl.ImageSet, null);
             double low = image.lastBitmapMin;
             double hi = image.lastBitmapMax;
@@ -80,6 +81,7 @@ namespace wwtlib
         public static void UpdateScale(ImageSetLayer isl, ScaleTypes scale, double low, double hi)
         {
             FitsImage image = isl.ImageSet.WcsImage as FitsImage;
+            if(image == null) { return; }
             SkyImageTile Tile = (SkyImageTile)TileCache.GetTile(0, 0, 0, isl.ImageSet, null);
             int z = image.lastBitmapZ;
             string colorMapperName = image.lastBitmapColorMapperName;
@@ -89,6 +91,7 @@ namespace wwtlib
         public static void UpdateColorMapper(ImageSetLayer isl, string colorMapperName)
         {
             FitsImage image = isl.ImageSet.WcsImage as FitsImage;
+            if(image == null) { return; }
             SkyImageTile Tile = (SkyImageTile)TileCache.GetTile(0, 0, 0, isl.ImageSet, null);
             double low = image.lastBitmapMin;
             double hi = image.lastBitmapMax;

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -28,11 +28,27 @@ namespace wwtlib
             SpaceTimeController.UpdateClock();
         }
 
-        public static List<Imageset> ImageSets = new List<Imageset>();
+        private static List<Imageset> ImageSets = new List<Imageset>();
         public static Folder ExploreRoot = new Folder();
         public static string ImageSetName = "";
 
         public IUiController uiController = null;
+
+        public static void AddImageSet(Imageset imagesetToAdd)
+        {
+            foreach(Imageset imageset in ImageSets){
+                if(imageset.ImageSetID == imagesetToAdd.ImageSetID)
+                {
+                    return;
+                }
+            }
+            ImageSets.Add(imagesetToAdd);
+        }
+
+        public static List<Imageset> GetImageSets()
+        {
+            return ImageSets;
+        }
 
         List<Annotation> annotations = new List<Annotation>();
         internal void AddAnnotation(Annotation annotation)
@@ -1705,7 +1721,6 @@ namespace wwtlib
         public static ScriptInterface scriptInterface;
         CanvasElement foregroundCanvas = null;
         CanvasContext2D fgDevice = null;
-        Folder webFolder;
 
         // For backwards compatibility, we preserve the semantics that calling
         // this function kicks off the rendering loop.
@@ -1906,16 +1921,15 @@ namespace wwtlib
                 fgDevice = (CanvasContext2D)foregroundCanvas.GetContext(Rendering.Render2D);
             }
 
-            webFolder = new Folder();
-            webFolder.LoadFromUrl(
+            Wtml.GetWtmlFile(
                 URLHelpers.singleton.engineAssetUrl("builtin-image-sets.wtml"),
+                true,
                 SetupComplete
             );
         }
 
         void SetupComplete()
         {
-            Wtml.LoadImagesets(webFolder);
             scriptInterface.FireReady();
         }
 
@@ -2542,6 +2556,18 @@ namespace wwtlib
             foreach (Imageset imageset in ImageSets)
             {
                 if (imageset.Name.ToLowerCase().IndexOf(name.ToLowerCase()) > -1)
+                {
+                    return imageset;
+                }
+            }
+            return null;
+        }
+
+        public Imageset GetImageSetByUrl(string url)
+        {
+            foreach (Imageset imageset in ImageSets)
+            {
+                if (imageset.Url.ToLowerCase() == url.ToLowerCase())
                 {
                     return imageset;
                 }

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -34,7 +34,7 @@ namespace wwtlib
 
         public IUiController uiController = null;
 
-        public static void AddImageSet(Imageset imagesetToAdd)
+        public static void AddImageSetToRepository(Imageset imagesetToAdd)
         {
             foreach(Imageset imageset in ImageSets){
                 if(imageset.ImageSetID == imagesetToAdd.ImageSetID)

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -1923,8 +1923,8 @@ namespace wwtlib
 
             Wtml.GetWtmlFile(
                 URLHelpers.singleton.engineAssetUrl("builtin-image-sets.wtml"),
-                true,
-                SetupComplete
+                SetupComplete,
+                true
             );
         }
 
@@ -2567,7 +2567,7 @@ namespace wwtlib
         {
             foreach (Imageset imageset in ImageSets)
             {
-                if (imageset.Url.ToLowerCase() == url.ToLowerCase())
+                if (imageset.Url == url)
                 {
                     return imageset;
                 }

--- a/engine/wwtlib/Wtml.cs
+++ b/engine/wwtlib/Wtml.cs
@@ -39,11 +39,15 @@ namespace wwtlib
     public class Wtml
     {
 
-        static public Folder GetWtmlFile(string url, bool loadChildFolders, Action complete)
+        static public Folder GetWtmlFile(string url, Action complete, bool? loadChildFolders)
         {
+            if (loadChildFolders == null)
+            {
+                loadChildFolders = false;
+            }
             Folder folder = new Folder();
             folder.Url = url;
-            FolderDownloadAction folderDownloadAction = new FolderDownloadAction(complete, loadChildFolders);
+            FolderDownloadAction folderDownloadAction = new FolderDownloadAction(complete, (bool)loadChildFolders);
             folderDownloadAction.StartingNewFolderLoad(folder);
             return folder;
         }

--- a/engine/wwtlib/Wtml.cs
+++ b/engine/wwtlib/Wtml.cs
@@ -61,19 +61,19 @@ namespace wwtlib
                 if (child is Imageset)
                 {
                     Imageset imageSet = (Imageset)child;
-                    WWTControl.AddImageSet(imageSet);
+                    WWTControl.AddImageSetToRepository(imageSet);
                 }
                 if (child is Place)
                 {
                     Place place = (Place)child;
                     if (place.StudyImageset != null)
                     {
-                        WWTControl.AddImageSet(place.StudyImageset);
+                        WWTControl.AddImageSetToRepository(place.StudyImageset);
                     }
                     
                     if (place.BackgroundImageset != null)
                     {
-                        WWTControl.AddImageSet(place.BackgroundImageset);
+                        WWTControl.AddImageSetToRepository(place.BackgroundImageset);
                     }
                 }
                 if (child is Folder && folderDownloadAction.loadChildFolders)

--- a/research-app-messages/src/classic_pywwt.ts
+++ b/research-app-messages/src/classic_pywwt.ts
@@ -240,7 +240,7 @@ export interface LoadImageCollectionMessage {
   /** The URL of the collection to load. */
   url: string;
 
-  /** Recursively load any child folders. */
+  /** Optional, Recursively load any child folders. Defaults to False*/
   loadChildFolders: boolean;
 }
 

--- a/research-app-messages/src/classic_pywwt.ts
+++ b/research-app-messages/src/classic_pywwt.ts
@@ -196,10 +196,35 @@ export interface CreateImageSetLayerMessage {
 
   /** The URL from which to obtain the FITS file or image set. */
   url: string;
-}
+
+  /** Tell WWT what type of layer you are Adding.
+   * OR let WWT try to autodetect the type of the data.
+   * Default, autodetect. */
+  mode: "autodetect" | "fits" | "preloaded";
+  }
 
 /** Type guard function for CreateImageSetLayerMessage. */
 export function isCreateImageSetLayerMessage(o: any): o is CreateImageSetLayerMessage {  // eslint-disable-line @typescript-eslint/no-explicit-any
+  return typeof o.event === "string" &&
+    o.event == "image_layer_create" &&
+    typeof o.id === "string" &&
+    typeof o.url === "string" &&
+    typeof o.mode  === "string";
+}
+
+/** Deprecated, use CreateImageSetLayerMessage instead.
+ *  A command to create a fits layer. */
+export interface CreateFitsLayerMessage {
+  /** The tag identifying this message type. */
+  event: "image_layer_create";
+  /** An identifier for referring to this fits layer later. */
+  id: string;
+  /** The URL from which to obtain the FITS file. */
+  url: string;
+}
+
+/** Type guard function for CreateFitsLayerMessage. */
+export function isCreateFitsLayerMessage(o: any): o is CreateFitsLayerMessage {  // eslint-disable-line @typescript-eslint/no-explicit-any
   return typeof o.event === "string" &&
     o.event == "image_layer_create" &&
     typeof o.id === "string" &&

--- a/research-app-messages/src/classic_pywwt.ts
+++ b/research-app-messages/src/classic_pywwt.ts
@@ -238,14 +238,18 @@ export interface LoadImageCollectionMessage {
   event: "load_image_collection";
 
   /** The URL of the collection to load. */
-  url: string
+  url: string;
+
+  /** Recursively load any child folders. */
+  loadChildFolders: boolean;
 }
 
 /** Type guard function for LoadImageCollectionMessage. */
 export function isLoadImageCollectionMessage(o: any): o is LoadImageCollectionMessage {  // eslint-disable-line @typescript-eslint/no-explicit-any
   return typeof o.event === "string" &&
     o.event == "load_image_collection" &&
-    typeof o.url === "string");
+    typeof o.url === "string" &&
+    (o.loadChildFolders === undefined || typeof o.loadChildFolders === "boolean");
 }
 
 

--- a/research-app-messages/src/classic_pywwt.ts
+++ b/research-app-messages/src/classic_pywwt.ts
@@ -15,11 +15,11 @@
  * - [[SetViewerModeMessage]]
  * - [[TrackObjectMessage]]
  *
- * ### FITS Image Layers
+ * ### Image set Layers
  *
- * - [[CreateFitsLayerMessage]]
+ * - [[CreateImageSetLayerMessage]]
  * - [[ModifyFitsLayerMessage]]
- * - [[RemoveFitsLayerMessage]]
+ * - [[RemoveImageSetLayerMessage]]
  * - [[SetFitsLayerColormapMessage]]
  * - [[StretchFitsLayerMessage]]
  *
@@ -148,7 +148,6 @@ export function isCenterOnCoordinatesMessage(o: any): o is CenterOnCoordinatesMe
     (o.roll === undefined || typeof o.roll === "number");
 }
 
-
 /** A command to clear all of the current annotations. */
 export interface ClearAnnotationsMessage {
   /** The tag identifying this message type. */
@@ -187,21 +186,20 @@ export function isCreateAnnotationMessage(o: any): o is CreateAnnotationMessage 
 }
 
 
-/** A command to create an image layer corresponding to a web-accessible FITS
- * file. */
-export interface CreateFitsLayerMessage {
+/** A command to create an image set layer. */
+export interface CreateImageSetLayerMessage {
   /** The tag identifying this message type. */
   event: "image_layer_create";
 
   /** An identifier for referring to this image layer later. */
   id: string;
 
-  /** The URL from which to obtain the FITS file. */
+  /** The URL from which to obtain the FITS file or image set. */
   url: string;
 }
 
-/** Type guard function for CreateFitsLayerMessage. */
-export function isCreateFitsLayerMessage(o: any): o is CreateFitsLayerMessage {  // eslint-disable-line @typescript-eslint/no-explicit-any
+/** Type guard function for CreateImageSetLayerMessage. */
+export function isCreateImageSetLayerMessage(o: any): o is CreateImageSetLayerMessage {  // eslint-disable-line @typescript-eslint/no-explicit-any
   return typeof o.event === "string" &&
     o.event == "image_layer_create" &&
     typeof o.id === "string" &&
@@ -240,14 +238,14 @@ export interface LoadImageCollectionMessage {
   event: "load_image_collection";
 
   /** The URL of the collection to load. */
-  url: string;
+  url: string
 }
 
 /** Type guard function for LoadImageCollectionMessage. */
 export function isLoadImageCollectionMessage(o: any): o is LoadImageCollectionMessage {  // eslint-disable-line @typescript-eslint/no-explicit-any
   return typeof o.event === "string" &&
     o.event == "load_image_collection" &&
-    typeof o.url === "string";
+    typeof o.url === "string");
 }
 
 
@@ -419,8 +417,8 @@ export function isRemoveAnnotationMessage(o: any): o is RemoveAnnotationMessage 
 }
 
 
-/** A command to remove a FITS layer. */
-export interface RemoveFitsLayerMessage {
+/** A command to remove a image set layer. */
+export interface RemoveImageSetLayerMessage {
   /** The tag identifying this message type. */
   event: "image_layer_remove";
 
@@ -428,8 +426,8 @@ export interface RemoveFitsLayerMessage {
   id: string;
 }
 
-/** Type guard function for RemoveFitsLayerMessage. */
-export function isRemoveFitsLayerMessage(o: any): o is RemoveFitsLayerMessage {  // eslint-disable-line @typescript-eslint/no-explicit-any
+/** Type guard function for RemoveImageSetLayerMessage. */
+export function isRemoveImageSetLayerMessage(o: any): o is RemoveImageSetLayerMessage {  // eslint-disable-line @typescript-eslint/no-explicit-any
   return typeof o.event === "string" &&
     o.event == "image_layer_remove" &&
     typeof o.id === "string";
@@ -711,7 +709,7 @@ export type PywwtMessage =
   CenterOnCoordinatesMessage |
   ClearAnnotationsMessage |
   CreateAnnotationMessage |
-  CreateFitsLayerMessage |
+  CreateImageSetLayerMessage |
   CreateTableLayerMessage |
   LoadImageCollectionMessage |
   LoadTourMessage |
@@ -722,7 +720,7 @@ export type PywwtMessage =
   PauseTimeMessage |
   PauseTourMessage |
   RemoveAnnotationMessage |
-  RemoveFitsLayerMessage |
+  RemoveImageSetLayerMessage |
   RemoveTableLayerMessage |
   ResumeTourMessage |
   ResumeTimeMessage |
@@ -750,7 +748,7 @@ export type PywwtMessage =
  * function enables. The input is modified in-place.
 */
 export function applyBaseUrlIfApplicable(o: any, baseurl: string): void {  // eslint-disable-line @typescript-eslint/no-explicit-any
-  if (isCreateFitsLayerMessage(o)) {
+  if (isCreateImageSetLayerMessage(o)) {
     o.url = new URL(o.url, baseurl).toString();
   } else if (isLoadImageCollectionMessage(o)) {
     o.url = new URL(o.url, baseurl).toString();

--- a/research-app-messages/src/classic_pywwt.ts
+++ b/research-app-messages/src/classic_pywwt.ts
@@ -209,7 +209,7 @@ export function isCreateImageSetLayerMessage(o: any): o is CreateImageSetLayerMe
     o.event == "image_layer_create" &&
     typeof o.id === "string" &&
     typeof o.url === "string" &&
-    typeof o.mode  === "string";
+    (o.mode == "autodetect" || o.mode == "fits" || o.mode == "preloaded");
 }
 
 /** Deprecated, use CreateImageSetLayerMessage instead.

--- a/research-app-messages/src/classic_pywwt.ts
+++ b/research-app-messages/src/classic_pywwt.ts
@@ -241,7 +241,7 @@ export interface LoadImageCollectionMessage {
   url: string;
 
   /** Optional, Recursively load any child folders. Defaults to False*/
-  loadChildFolders: boolean;
+  loadChildFolders?: boolean;
 }
 
 /** Type guard function for LoadImageCollectionMessage. */

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -474,7 +474,7 @@ export default class App extends WWTAwareComponent {
 
   onMessage(msg: any) {  // eslint-disable-line @typescript-eslint/no-explicit-any
     if (classicPywwt.isLoadImageCollectionMessage(msg)) {
-      this.loadImageCollection({ url: msg.url });
+      this.loadImageCollection({ url: msg.url, loadChildFolders: msg.loadChildFolders });
     } else if (classicPywwt.isSetBackgroundByNameMessage(msg)) {
       this.setBackgroundImageByName(msg.name);
     } else if (classicPywwt.isSetForegroundByNameMessage(msg)) {

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -117,8 +117,10 @@ class ImageSetLayerMessageHandler {
       return;
     }
 
+    const mode = msg.mode || "autodetect";
     this.owner.addImageSetLayer({
       url: msg.url,
+      mode: mode,
       name: msg.id,
       gotoTarget: true, // pywwt expected behavior
     }).then((layer) => this.layerInitialized(layer));
@@ -503,6 +505,14 @@ export default class App extends WWTAwareComponent {
       }
     } else if (classicPywwt.isCreateImageSetLayerMessage(msg)) {
       this.getFitsLayerHandler(msg).handleCreateMessage(msg);
+    } else if (classicPywwt.isCreateFitsLayerMessage(msg)) {
+      const creatImageSetMessage: classicPywwt.CreateImageSetLayerMessage = {
+        event: msg.event,
+        url: msg.url,
+        id: msg.id,
+        mode: "fits",
+      }
+      this.getFitsLayerHandler(creatImageSetMessage).handleCreateMessage(creatImageSetMessage);
     } else if (classicPywwt.isStretchFitsLayerMessage(msg)) {
       this.getFitsLayerHandler(msg).handleStretchMessage(msg);
     } else if (classicPywwt.isSetFitsLayerColormapMessage(msg)) {

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -113,7 +113,9 @@ class ImageSetLayerMessageHandler {
   }
 
   handleCreateMessage(msg: classicPywwt.CreateImageSetLayerMessage) {
-    if (this.created) {return;}
+    if (this.created) {
+      return;
+    }
 
     this.owner.addImageSetLayer({
       url: msg.url,


### PR DESCRIPTION
1. Option to recursively download Folders in a WTML
2. Added optional parameter to set roll of camera
3. Can now add regular image sets to LayerManager via postMessage / research-app messages
4. Disallowed duplicate image sets (pointing to the same URL) & started using image set url as a semi user friendly identifier

@pkgw Do you know what the TODO comment in Folder.cs:371 is referring to? I removed the "true" thing mentioned in the TODO, so it may cause some problem.