### PR TITLE
Add keyboard support for WWT viewer control

### DIFF
--- a/engine-vuex/src/store.ts
+++ b/engine-vuex/src/store.ts
@@ -349,6 +349,20 @@ export class WWTEngineVuexModule extends VuexModule implements WWTEngineVuexStat
   }
 
   @Mutation
+  move(obj: { x: number; y: number }): void {
+    if (Vue.$wwt.inst === null)
+      throw new Error('cannot move without linking to WWTInstance');
+    Vue.$wwt.inst.ctl.move(obj.x, obj.y);
+  }
+
+  @Mutation
+  tilt(obj: { x: number; y: number}): void {
+    if (Vue.$wwt.inst === null)
+      throw new Error('cannot tilt without linking to WWTInstance');
+    Vue.$wwt.inst.ctl._tilt(obj.x, obj.y);
+  }
+
+  @Mutation
   setTime(time: Date): void {
     if (Vue.$wwt.inst === null)
       throw new Error('cannot setTime without linking to WWTInstance');

--- a/engine-vuex/src/wwtaware.ts
+++ b/engine-vuex/src/wwtaware.ts
@@ -295,7 +295,7 @@ export class WWTAwareComponent extends Vue {
         "updateTableLayer",
         "zoom",
         "move",
-        "tilt"
+        "tilt",
       ]),
     };
   }

--- a/engine-vuex/src/wwtaware.ts
+++ b/engine-vuex/src/wwtaware.ts
@@ -294,6 +294,8 @@ export class WWTAwareComponent extends Vue {
         "toggleTourPlayPauseState",
         "updateTableLayer",
         "zoom",
+        "move",
+        "tilt"
       ]),
     };
   }
@@ -581,6 +583,12 @@ export class WWTAwareComponent extends Vue {
    * [[gotoRADecZoom]].
    */
   zoom!: (f: number) => void;
+
+  /** Moves the position of the view */
+  move!: ({ x, y }: { x: number; y: number }) => void;
+
+  /** Tilts the position of the view */
+  tilt!: ({ x, y }: { x: number; y: number }) => void;
 
   // Actions
 

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -1961,6 +1961,12 @@ export class WWTControl {
    */
   zoom(factor: number): void;
 
+  /** Moves the position of the view */
+  move(x: number, y: number): void;
+
+  /** Tilts the position of the view */
+  _tilt(x: number, y: number): void;
+
   /** Look up an imageset by its name.
    *
    * The name matching is case-insensitive, matches on substrings, and moves

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -773,6 +773,15 @@ export default class App extends WWTAwareComponent {
       this.zoom(1.3);
     }
   }
+
+  doMove(x: number, y: number) {
+    this.move({ x: x, y: y});
+  }
+
+  doTilt(x: number, y: number) {
+    this.tilt({ x: x, y: y});
+  }
+  
 }
 </script>
 

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -427,11 +427,53 @@ class AnnotationMessageHandler {
   }
 }
 
+/** This simple class encapsulates how we handle key bindings */
+class KeyboardControlSettings {
+  zoomIn: string;
+  zoomOut: string;
+  moveUp: string;
+  moveDown: string;
+  moveLeft: string;
+  moveRight: string;
+  tiltCW: string;
+  tiltCCW: string;
+  moveAmount: number;
+  tiltAmount: number;
+
+  constructor({
+    zoomIn = "ArrowUp",
+    zoomOut = "ArrowDown",
+    moveUp = "w",
+    moveDown = "s",
+    moveLeft = "d",
+    moveRight = "a",
+    tiltCW = "ArrowLeft",
+    tiltCCW = "ArrowRight",
+    moveAmount = 20,
+    tiltAmount = 20
+  }) {
+    this.zoomIn = zoomIn;
+    this.zoomOut = zoomOut;
+    this.moveUp = moveUp;
+    this.moveDown = moveDown;
+    this.moveLeft = moveLeft;
+    this.moveRight = moveRight;
+    this.tiltCW = tiltCW;
+    this.tiltCCW = tiltCCW;
+    this.moveAmount = moveAmount;
+    this.tiltAmount = tiltAmount;
+  }
+}
+
 
 /** The main "research app" Vue component. */
 @Component
 export default class App extends WWTAwareComponent {
   @Prop({default: null}) readonly allowedOrigin!: string | null;
+
+  // For handling key presses
+  private _keyListener: ((e: KeyboardEvent) => void) | null = null;
+  private _keyboardControlSettings: KeyboardControlSettings | null = null;
 
   // Lifecycle management
 
@@ -461,6 +503,34 @@ export default class App extends WWTAwareComponent {
         this.onMessage(event.data);
       }
     }, false);
+
+    // Handling key presses
+    this._keyboardControlSettings = new KeyboardControlSettings({});
+    this._keyListener = function(e: KeyboardEvent) {
+      const kcs = this._keyboardControlSettings;
+      if (kcs == null || kcs == undefined) { return; }
+      const movementAmount = kcs.moveAmount;
+      const tiltAmount = kcs.tiltAmount;
+      if (e.key === kcs.zoomIn) {
+        this.doZoom(true);
+      } else if (e.key === kcs.zoomOut) {
+        this.doZoom(false);
+      } else if (e.key === kcs.tiltCW) {
+        this.doTilt(tiltAmount, 0);
+      } else if (e.key === kcs.tiltCCW) {
+        this.doTilt(-tiltAmount, 0);
+      } else if (e.key === kcs.moveUp) {
+        this.doMove(0, movementAmount);
+      } else if (e.key === kcs.moveDown) {
+        this.doMove(0, -movementAmount);
+      } else if (e.key === kcs.moveLeft) {
+        this.doMove(-movementAmount, 0);
+      } else if (e.key === kcs.moveRight) {
+        this.doMove(movementAmount, 0);
+      }
+    };
+    window.addEventListener('keydown', this._keyListener.bind(this as App));
+
   }
 
   destroyed() {
@@ -781,7 +851,7 @@ export default class App extends WWTAwareComponent {
   doTilt(x: number, y: number) {
     this.tilt({ x: x, y: y});
   }
-  
+
 }
 </script>
 


### PR DESCRIPTION
Adds keyboard support for zooming, moving, and tilting the WWT viewer. The mapping between keys and events is based on KeyboardEvent.key, which [per MDN](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) has support on all browsers.