### PR TITLE
Keyboard controls, plus a few extensions

### DIFF
--- a/engine-vuex/src/store.ts
+++ b/engine-vuex/src/store.ts
@@ -349,6 +349,20 @@ export class WWTEngineVuexModule extends VuexModule implements WWTEngineVuexStat
   }
 
   @Mutation
+  move(obj: { x: number; y: number }): void {
+    if (Vue.$wwt.inst === null)
+      throw new Error('cannot move without linking to WWTInstance');
+    Vue.$wwt.inst.ctl.move(obj.x, obj.y);
+  }
+
+  @Mutation
+  tilt(obj: { x: number; y: number}): void {
+    if (Vue.$wwt.inst === null)
+      throw new Error('cannot tilt without linking to WWTInstance');
+    Vue.$wwt.inst.ctl._tilt(obj.x, obj.y);
+  }
+
+  @Mutation
   setTime(time: Date): void {
     if (Vue.$wwt.inst === null)
       throw new Error('cannot setTime without linking to WWTInstance');

--- a/engine-vuex/src/wwtaware.ts
+++ b/engine-vuex/src/wwtaware.ts
@@ -295,7 +295,7 @@ export class WWTAwareComponent extends Vue {
         "updateTableLayer",
         "zoom",
         "move",
-        "tilt"
+        "tilt",
       ]),
     };
   }

--- a/engine-vuex/src/wwtaware.ts
+++ b/engine-vuex/src/wwtaware.ts
@@ -294,6 +294,8 @@ export class WWTAwareComponent extends Vue {
         "toggleTourPlayPauseState",
         "updateTableLayer",
         "zoom",
+        "move",
+        "tilt"
       ]),
     };
   }
@@ -581,6 +583,12 @@ export class WWTAwareComponent extends Vue {
    * [[gotoRADecZoom]].
    */
   zoom!: (f: number) => void;
+
+  /** Moves the position of the view */
+  move!: ({ x, y }: { x: number; y: number }) => void;
+
+  /** Tilts the position of the view */
+  tilt!: ({ x, y }: { x: number; y: number }) => void;
 
   // Actions
 

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -1961,6 +1961,12 @@ export class WWTControl {
    */
   zoom(factor: number): void;
 
+  /** Moves the position of the view */
+  move(x: number, y: number): void;
+
+  /** Tilts the position of the view */
+  _tilt(x: number, y: number): void;
+
   /** Look up an imageset by its name.
    *
    * The name matching is case-insensitive, matches on substrings, and moves

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -773,6 +773,15 @@ export default class App extends WWTAwareComponent {
       this.zoom(1.3);
     }
   }
+
+  doMove(x: number, y: number) {
+    this.move({ x: x, y: y});
+  }
+
+  doTilt(x: number, y: number) {
+    this.tilt({ x: x, y: y});
+  }
+  
 }
 </script>
 

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -582,8 +582,8 @@ export default class App extends WWTAwareComponent {
     window.addEventListener('keydown', this._kcs.makeListener("moveDown", () => this.doMove(0, -this._kcs.moveAmount)));
     window.addEventListener('keydown', this._kcs.makeListener("moveLeft", () => this.doMove(this._kcs.moveAmount, 0)));
     window.addEventListener('keydown', this._kcs.makeListener("moveRight", () => this.doMove(-this._kcs.moveAmount, 0)));
-    window.addEventListener('keydown', this._kcs.makeListener("tiltLeft", () => this.doTilt(-this._kcs.tiltAmount, 0)));
-    window.addEventListener('keydown', this._kcs.makeListener("tiltRight", () => this.doTilt(this._kcs.tiltAmount, 0)));
+    window.addEventListener('keydown', this._kcs.makeListener("tiltLeft", () => this.doTilt(this._kcs.tiltAmount, 0)));
+    window.addEventListener('keydown', this._kcs.makeListener("tiltRight", () => this.doTilt(-this._kcs.tiltAmount, 0)));
     window.addEventListener('keydown', this._kcs.makeListener("tiltUp", () => this.doTilt(0, this._kcs.tiltAmount)));
     window.addEventListener('keydown', this._kcs.makeListener("tiltDown", () => this.doTilt(0, -this._kcs.tiltAmount)));
     window.addEventListener('keydown', this._kcs.makeListener("zoomIn", () => this.doZoom(true)));

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -427,11 +427,53 @@ class AnnotationMessageHandler {
   }
 }
 
+/** This simple class encapsulates how we handle key bindings */
+class KeyboardControlSettings {
+  zoomIn: string;
+  zoomOut: string;
+  moveUp: string;
+  moveDown: string;
+  moveLeft: string;
+  moveRight: string;
+  tiltCW: string;
+  tiltCCW: string;
+  moveAmount: number;
+  tiltAmount: number;
+
+  constructor({
+    zoomIn = "ArrowUp",
+    zoomOut = "ArrowDown",
+    moveUp = "w",
+    moveDown = "s",
+    moveLeft = "d",
+    moveRight = "a",
+    tiltCW = "ArrowLeft",
+    tiltCCW = "ArrowRight",
+    moveAmount = 20,
+    tiltAmount = 20
+  }) {
+    this.zoomIn = zoomIn;
+    this.zoomOut = zoomOut;
+    this.moveUp = moveUp;
+    this.moveDown = moveDown;
+    this.moveLeft = moveLeft;
+    this.moveRight = moveRight;
+    this.tiltCW = tiltCW;
+    this.tiltCCW = tiltCCW;
+    this.moveAmount = moveAmount;
+    this.tiltAmount = tiltAmount;
+  }
+}
+
 
 /** The main "research app" Vue component. */
 @Component
 export default class App extends WWTAwareComponent {
   @Prop({default: null}) readonly allowedOrigin!: string | null;
+
+  // For handling key presses
+  private _keyListener: ((e: KeyboardEvent) => void) | null = null;
+  private _keyboardControlSettings: KeyboardControlSettings | null = null;
 
   // Lifecycle management
 
@@ -461,6 +503,34 @@ export default class App extends WWTAwareComponent {
         this.onMessage(event.data);
       }
     }, false);
+
+    // Handling key presses
+    this._keyboardControlSettings = new KeyboardControlSettings({});
+    this._keyListener = function(e: KeyboardEvent) {
+      const kcs = this._keyboardControlSettings;
+      if (kcs == null || kcs == undefined) { return; }
+      const movementAmount = kcs.moveAmount;
+      const tiltAmount = kcs.tiltAmount;
+      if (e.key === kcs.zoomIn) {
+        this.doZoom(true);
+      } else if (e.key === kcs.zoomOut) {
+        this.doZoom(false);
+      } else if (e.key === kcs.tiltCW) {
+        this.doTilt(tiltAmount, 0);
+      } else if (e.key === kcs.tiltCCW) {
+        this.doTilt(-tiltAmount, 0);
+      } else if (e.key === kcs.moveUp) {
+        this.doMove(0, movementAmount);
+      } else if (e.key === kcs.moveDown) {
+        this.doMove(0, -movementAmount);
+      } else if (e.key === kcs.moveLeft) {
+        this.doMove(-movementAmount, 0);
+      } else if (e.key === kcs.moveRight) {
+        this.doMove(movementAmount, 0);
+      }
+    };
+    window.addEventListener('keydown', this._keyListener.bind(this as App));
+
   }
 
   destroyed() {
@@ -781,7 +851,7 @@ export default class App extends WWTAwareComponent {
   doTilt(x: number, y: number) {
     this.tilt({ x: x, y: y});
   }
-  
+
 }
 </script>
 

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -463,8 +463,13 @@ class KeyboardControlSettings {
   tiltDown: KeyPressInfo[];
   tiltLeft: KeyPressInfo[];
   tiltRight: KeyPressInfo[];
+  bigMoveUp: KeyPressInfo[];
+  bigMoveDown: KeyPressInfo[];
+  bigMoveLeft: KeyPressInfo[];
+  bigMoveRight: KeyPressInfo[];
   moveAmount: number;
   tiltAmount: number;
+  bigMoveFactor: number;
 
   constructor({
     zoomIn = [
@@ -507,8 +512,25 @@ class KeyboardControlSettings {
       new KeyPressInfo("KeyL", { alt: true }),
       new KeyPressInfo("ArrowRight", { alt: true }),
     ],
+    bigMoveUp = [
+      new KeyPressInfo("KeyI", { shift: true }),
+      new KeyPressInfo("ArrowUp", { shift: true }),
+    ],
+    bigMoveDown = [
+      new KeyPressInfo("KeyK", { shift: true }),
+      new KeyPressInfo("ArrowDown", { shift: true }),
+    ],
+    bigMoveLeft = [
+      new KeyPressInfo("KeyJ", { shift: true }),
+      new KeyPressInfo("ArrowLeft", { shift: true }),
+    ],
+    bigMoveRight = [
+      new KeyPressInfo("KeyL", { shift: true }),
+      new KeyPressInfo("ArrowRight", { shift: true }),
+    ],
     moveAmount = 20,
     tiltAmount = 20,
+    bigMoveFactor = 6,
   }) {
     this.zoomIn = zoomIn;
     this.zoomOut = zoomOut;
@@ -520,12 +542,32 @@ class KeyboardControlSettings {
     this.tiltDown = tiltDown;
     this.tiltLeft = tiltLeft;
     this.tiltRight = tiltRight;
+    this.bigMoveUp = bigMoveUp;
+    this.bigMoveDown = bigMoveDown;
+    this.bigMoveLeft = bigMoveLeft;
+    this.bigMoveRight = bigMoveRight;
     this.moveAmount = moveAmount;
     this.tiltAmount = tiltAmount;
+    this.bigMoveFactor = bigMoveFactor;
   }
 
   // This is to make sure that we can't make a listener for an action type that doesn't exist
-  readonly actionTypes = [ "zoomIn", "zoomOut", "moveUp", "moveDown", "moveLeft", "moveRight", "tiltUp", "tiltDown", "tiltLeft", "tiltRight" ] as const;
+  readonly actionTypes = [
+    "zoomIn",
+    "zoomOut",
+    "moveUp",
+    "moveDown",
+    "moveLeft",
+    "moveRight",
+    "tiltUp",
+    "tiltDown",
+    "tiltLeft",
+    "tiltRight",
+    "bigMoveUp",
+    "bigMoveDown",
+    "bigMoveLeft",
+    "bigMoveRight",
+  ] as const;
 
   makeListener(actionName: KeyboardControlSettings["actionTypes"][number], action: () => void): (e: KeyboardEvent) => void {
     return (e) => {
@@ -536,7 +578,6 @@ class KeyboardControlSettings {
       }
     }
   }
-
 }
 
 
@@ -578,6 +619,8 @@ export default class App extends WWTAwareComponent {
 
     // Handling key presses
 
+    window.addEventListener('keydown', this._kcs.makeListener("zoomIn", () => this.doZoom(true)));
+    window.addEventListener('keydown', this._kcs.makeListener("zoomOut", () => this.doZoom(false)));
     window.addEventListener('keydown', this._kcs.makeListener("moveUp", () => this.doMove(0, this._kcs.moveAmount)));
     window.addEventListener('keydown', this._kcs.makeListener("moveDown", () => this.doMove(0, -this._kcs.moveAmount)));
     window.addEventListener('keydown', this._kcs.makeListener("moveLeft", () => this.doMove(this._kcs.moveAmount, 0)));
@@ -586,9 +629,10 @@ export default class App extends WWTAwareComponent {
     window.addEventListener('keydown', this._kcs.makeListener("tiltRight", () => this.doTilt(-this._kcs.tiltAmount, 0)));
     window.addEventListener('keydown', this._kcs.makeListener("tiltUp", () => this.doTilt(0, this._kcs.tiltAmount)));
     window.addEventListener('keydown', this._kcs.makeListener("tiltDown", () => this.doTilt(0, -this._kcs.tiltAmount)));
-    window.addEventListener('keydown', this._kcs.makeListener("zoomIn", () => this.doZoom(true)));
-    window.addEventListener('keydown', this._kcs.makeListener("zoomOut", () => this.doZoom(false)));
-
+    window.addEventListener('keydown', this._kcs.makeListener("bigMoveUp", () => this.doMove(0, this._kcs.bigMoveFactor * this._kcs.moveAmount)));
+    window.addEventListener('keydown', this._kcs.makeListener("bigMoveDown", () => this.doMove(0, this._kcs.bigMoveFactor * -this._kcs.moveAmount)));
+    window.addEventListener('keydown', this._kcs.makeListener("bigMoveLeft", () => this.doMove(this._kcs.bigMoveFactor * this._kcs.moveAmount, 0)));
+    window.addEventListener('keydown', this._kcs.makeListener("bigMoveRight", () => this.doMove(this._kcs.bigMoveFactor * -this._kcs.moveAmount, 0)));
   }
 
   destroyed() {

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -550,8 +550,8 @@ export default class App extends WWTAwareComponent {
 
     window.addEventListener('keydown', this._kcs.makeListener("moveUp", () => this.doMove(0, this._kcs.moveAmount)));
     window.addEventListener('keydown', this._kcs.makeListener("moveDown", () => this.doMove(0, -this._kcs.moveAmount)));
-    window.addEventListener('keydown', this._kcs.makeListener("moveLeft", () => this.doMove(-this._kcs.moveAmount, 0)));
-    window.addEventListener('keydown', this._kcs.makeListener("moveRight", () => this.doMove(this._kcs.moveAmount, 0)));
+    window.addEventListener('keydown', this._kcs.makeListener("moveLeft", () => this.doMove(this._kcs.moveAmount, 0)));
+    window.addEventListener('keydown', this._kcs.makeListener("moveRight", () => this.doMove(-this._kcs.moveAmount, 0)));
     window.addEventListener('keydown', this._kcs.makeListener("tiltLeft", () => this.doTilt(-this._kcs.tiltAmount, 0)));
     window.addEventListener('keydown', this._kcs.makeListener("tiltRight", () => this.doTilt(this._kcs.tiltAmount, 0)));
     window.addEventListener('keydown', this._kcs.makeListener("tiltUp", () => this.doTilt(0, this._kcs.tiltAmount)));

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -434,7 +434,7 @@ class KeyPressInfo {
   shift: boolean;
   meta: boolean;
 
-  constructor(code: string, modifiers?: { ctrl?: boolean, alt?: boolean, shift?: boolean, meta?: boolean } ) {
+  constructor(code: string, modifiers?: { ctrl?: boolean; alt?: boolean; shift?: boolean; meta?: boolean } ) {
     this.code = code;
     this.ctrl = modifiers?.ctrl ?? false;
     this.alt = modifiers?.alt ?? false;
@@ -443,7 +443,7 @@ class KeyPressInfo {
   }
 
   matches(event: KeyboardEvent): boolean {
-    return event.code === this.code 
+    return event.code === this.code
         && event.ctrlKey === this.ctrl
         && event.altKey === this.alt
         && event.shiftKey === this.shift
@@ -467,16 +467,46 @@ class KeyboardControlSettings {
   tiltAmount: number;
 
   constructor({
-    zoomIn = [ new KeyPressInfo("KeyZ") ],
-    zoomOut = [ new KeyPressInfo("KeyX") ],
-    moveUp = [ new KeyPressInfo("KeyI") ],
-    moveDown = [ new KeyPressInfo("KeyK") ],
-    moveLeft = [ new KeyPressInfo("KeyJ") ],
-    moveRight = [ new KeyPressInfo("KeyL") ],
-    tiltUp = [ new KeyPressInfo("KeyI", { alt: true }) ],
-    tiltDown = [ new KeyPressInfo("KeyK", { alt: true }) ],
-    tiltLeft = [ new KeyPressInfo("KeyJ", { alt: true }) ],
-    tiltRight = [ new KeyPressInfo("KeyL", { alt: true }) ],
+    zoomIn = [
+      new KeyPressInfo("KeyZ"),
+      new KeyPressInfo("PageUp"),
+    ],
+    zoomOut = [
+      new KeyPressInfo("KeyX"),
+      new KeyPressInfo("PageDown"),
+    ],
+    moveUp = [
+      new KeyPressInfo("KeyI"),
+      new KeyPressInfo("ArrowUp"),
+    ],
+    moveDown = [
+      new KeyPressInfo("KeyK"),
+      new KeyPressInfo("ArrowDown"),
+    ],
+    moveLeft = [
+      new KeyPressInfo("KeyJ"),
+      new KeyPressInfo("ArrowLeft"),
+    ],
+    moveRight = [
+      new KeyPressInfo("KeyL"),
+      new KeyPressInfo("ArrowRight"),
+    ],
+    tiltUp = [
+      new KeyPressInfo("KeyI", { alt: true }),
+      new KeyPressInfo("ArrowUp", { alt: true }),
+    ],
+    tiltDown = [
+      new KeyPressInfo("KeyK", { alt: true }),
+      new KeyPressInfo("ArrowDown", { alt: true }),
+    ],
+    tiltLeft = [
+      new KeyPressInfo("KeyJ", { alt: true }),
+      new KeyPressInfo("ArrowLeft", { alt: true }),
+    ],
+    tiltRight = [
+      new KeyPressInfo("KeyL", { alt: true }),
+      new KeyPressInfo("ArrowRight", { alt: true }),
+    ],
     moveAmount = 20,
     tiltAmount = 20,
   }) {

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -545,7 +545,7 @@ class KeyboardControlSettings {
 export default class App extends WWTAwareComponent {
   @Prop({default: null}) readonly allowedOrigin!: string | null;
 
-  @Prop({default: new KeyboardControlSettings({})}) private _kcs!: KeyboardControlSettings;
+  @Prop({default: () => new KeyboardControlSettings({})}) private _kcs!: KeyboardControlSettings;
 
   // Lifecycle management
 


### PR DESCRIPTION
This is pull request #99 by @Carifio24, plus a couple of tweaks. Normally GitHub lets me add new commits directly onto the branch that's sourcing the pull request, but I'm not allowed to do that in #99, I think because it's being sourced from `master` and not from a feature branch.

Tweaks are:

- Oops, the parity on the left/right keyboard controls was swapped!
- Additional keybindings building on the nice framework we now have:
  - Arrow keys for pans
  - Alt+(arrow keys) for rolls and titls
  - Shift+(arrow keys) and Shift+(IJKL) for "big" pans, six times the size of the default ones
- Also swap the parity for the left/right rolls; the new way feels more "right" to me
- Fix a warning issued by Vue in the browser console saying that the default value for the keyboard controls struct should be created by a factory function 