### PR TITLE
Fixups

### DIFF
--- a/engine-vuex/package.json
+++ b/engine-vuex/package.json
@@ -19,8 +19,8 @@
   },
   "homepage": "https://worldwidetelescope.org/home/",
   "internalDepVersions": {
-    "@wwtelescope/engine": "68f56f0585354ec471ffe8efd2a8f6236ad82c27",
-    "@wwtelescope/engine-helpers": "68f56f0585354ec471ffe8efd2a8f6236ad82c27"
+    "@wwtelescope/engine": "thiscommit:2021-06-03:PoIPPv9",
+    "@wwtelescope/engine-helpers": "37e2cf42895becd14698bf9d2058594bfc61d53f"
   },
   "keywords": [
     "AAS WorldWide Telescope"

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -28,7 +28,9 @@ namespace wwtlib
             SpaceTimeController.UpdateClock();
         }
 
-        private static List<Imageset> ImageSets = new List<Imageset>();
+        // Note: ImageSets must remain public because there is JS code in the
+        // wild that accesses `WWTControl.imageSets`.
+        public static List<Imageset> ImageSets = new List<Imageset>();
         public static Folder ExploreRoot = new Folder();
         public static string ImageSetName = "";
 

--- a/research-app/package.json
+++ b/research-app/package.json
@@ -29,11 +29,11 @@
   "homepage": "https://worldwidetelescope.org/home/",
   "internalDepVersions": {
     "@wwtelescope/astro": "manual:^0.1.0",
-    "@wwtelescope/engine": "68f56f0585354ec471ffe8efd2a8f6236ad82c27",
-    "@wwtelescope/engine-helpers": "68f56f0585354ec471ffe8efd2a8f6236ad82c27",
-    "@wwtelescope/engine-types": "b56a5e9844beaa427aae4496cc865a1d60f376b7",
-    "@wwtelescope/engine-vuex": "68f56f0585354ec471ffe8efd2a8f6236ad82c27",
-    "@wwtelescope/research-app-messages": "68f56f0585354ec471ffe8efd2a8f6236ad82c27"
+    "@wwtelescope/engine": "thiscommit:2021-06-03:LsnTHkJ",
+    "@wwtelescope/engine-helpers": "37e2cf42895becd14698bf9d2058594bfc61d53f",
+    "@wwtelescope/engine-types": "fe25c086751bf45aad29fda93bdb2cc1f4c6e3ef",
+    "@wwtelescope/engine-vuex": "thiscommit:2021-06-03:5oi4JVl",
+    "@wwtelescope/research-app-messages": "f39ce5b29e0284d252ccc8d24a8e4f51e24ace99"
   },
   "keywords": [
     "AAS WorldWide Telescope"


### PR DESCRIPTION
- Unintentional API break
- Update Cranko internal versioning requirements

The API break manifested as the webclient "imagery" selector being empty. Here's the webclient code that relies on the old name:

https://github.com/WorldWideTelescope/wwt-web-client/blob/0177832de60978790287cfa346e845bcf2c153c0/controllers/MainController.js#L203

There are deployed forks of the webclient out there, so it will be easier to undo the API break than to try to update them all.