### PR TITLE
Adjust z-indexes to fix #107 

### DIFF
--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -1132,7 +1132,6 @@ body {
 
 #tools {
   position: absolute;
-  z-index: 10;
   top: 0.5rem;
   left: 50%;
   color: #FFF;
@@ -1140,6 +1139,7 @@ body {
   .tool-container {
     position: relative;
     left: -50%;
+    z-index: 10;
   }
 
   .opacity-range {


### PR DESCRIPTION
This fixes the issue of the controls being blocked, as the `.tool-container` won't overlap the controls unless the screen is small. I need to think about the CSS to handle small screens (in which case the selection element itself will overlap the controls), but that's for another time.