### PR TITLE
Undefined check for ServiceWorker

### DIFF
--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -663,8 +663,9 @@ export default class App extends WWTAwareComponent {
         // destinations, but let's start simple. TypeScript currently requires
         // us to do an odd type guard here.
         if (this.statusMessageDestination === null) {
-          if (!(event.source instanceof MessagePort) && !(event.source instanceof ServiceWorker)) {
-            this.statusMessageDestination = event.source;
+          //ServiceWorker is only defined on https connections and localhost
+          if (!(event.source instanceof MessagePort) && (typeof ServiceWorker === 'undefined' || !(event.source instanceof ServiceWorker))) {
+            this.statusMessageDestination = event.source as Window;
             // Hardcode the status update rate to max out at 5 Hz.
             this.updateIntervalId = window.setInterval(() => this.maybeUpdateStatus(), 200);
           }


### PR DESCRIPTION
OpenSpace encountered an intreresting issue when deploying the research app to an http server.
See browser console here:
http://www.winterway.eu/wwt-http-problem/index.html?origin=http://www.winterway.eu

The short story is that ServiceWorker is undefined if a user connects with http instead of https, as you can see by connecting to the same code with https:
https://www.winterway.eu/wwt-http-problem/index.html?origin=https://www.winterway.eu

I tested this PR here, and it seems to be working fine on http:
http://www.winterway.eu/wwt/index.html?origin=http://www.winterway.eu

(ServiceWorker is defined on http conenction if the host is localhost, that's why at least I haven't seen the issue before)

@pkgw Do you remember the reasoning behind the `!instanceof MessagePort && !instanceof ServiceWorker`? By looking at the ts code it looks like a simple `event.source instanceof Window` would be enough, but maybe I am missing something?
