### PR TITLE
Simplified type guard

### DIFF
--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -660,12 +660,10 @@ export default class App extends WWTAwareComponent {
     window.addEventListener('message', (event) => {
       if (this.allowedOrigin !== null && event.origin == this.allowedOrigin) {
         // You could imagine wanting to send status updates to multiple
-        // destinations, but let's start simple. TypeScript currently requires
-        // us to do an odd type guard here.
+        // destinations, but let's start simple.
         if (this.statusMessageDestination === null) {
-          //ServiceWorker is only defined on https connections and localhost
-          if (!(event.source instanceof MessagePort) && (typeof ServiceWorker === 'undefined' || !(event.source instanceof ServiceWorker))) {
-            this.statusMessageDestination = event.source as Window;
+          if (event.source instanceof Window) {
+            this.statusMessageDestination = event.source;
             // Hardcode the status update rate to max out at 5 Hz.
             this.updateIntervalId = window.setInterval(() => this.maybeUpdateStatus(), 200);
           }


### PR DESCRIPTION
Follow up to:
https://github.com/WorldWideTelescope/wwt-webgl-engine/pull/111 

I just tested this simplified type guard and it seems to be working fine.

I have not seen any compiler warnings or errors (at least with my setup), so maybe the issue requiring the odd type guard has been fixed.
