### PR TITLE
Add support for panorama images to the embed app

### DIFF
--- a/embed/src/Embed.vue
+++ b/embed/src/Embed.vue
@@ -282,7 +282,6 @@ export default class Embed extends WWTAwareComponent {
           const img = this.lookupImageset(this.embedSettings.foregroundImagesetName);
 
           if (img !== null) {
-
             // If the imageset is a panorama, we want to set it to be the background
             const isPanorama = img.get_dataSetType() == ImageSetType.panorama;
             const options: SetupForImagesetOptions = { foreground: img };
@@ -304,7 +303,6 @@ export default class Embed extends WWTAwareComponent {
 
             this.setupForImageset(options);
           }
-
         }
 
         if (!backgroundWasInitialized) {

--- a/embed/src/Embed.vue
+++ b/embed/src/Embed.vue
@@ -282,11 +282,19 @@ export default class Embed extends WWTAwareComponent {
           const img = this.lookupImageset(this.embedSettings.foregroundImagesetName);
 
           if (img !== null) {
+
+            // If the imageset is a panorama, we want to set it to be the background
+            const isPanorama = img.get_dataSetType() == ImageSetType.panorama;
             const options: SetupForImagesetOptions = { foreground: img };
+            if (isPanorama) {
+              options.background = img;
+              backgroundWasInitialized = true;
+            }
 
             // For setup of planetary modes to work, we need to pass the specified
             // background imageset to setupForImageset().
-            if (bgName.length) {
+            // For a panorama, we've already set the imageset itself as the background
+            if (!isPanorama && bgName.length) {
               const bkg = this.lookupImageset(bgName);
               if (bkg !== null) {
                 options.background = bkg;
@@ -296,6 +304,7 @@ export default class Embed extends WWTAwareComponent {
 
             this.setupForImageset(options);
           }
+
         }
 
         if (!backgroundWasInitialized) {


### PR DESCRIPTION
Adds support for panorama images in the embed app. If the given image in the WTML is a panorama, it's set as both the foreground and background images, since a foreground image is required for SetupForImagesetOptions.