### PR TITLE
Posting image_collection_loaded event on folder load complete

### DIFF
--- a/research-app-messages/src/classic_pywwt.ts
+++ b/research-app-messages/src/classic_pywwt.ts
@@ -32,6 +32,7 @@
  *
  * ### Image Sets
  *
+ * - [[ImageCollectionLoadedMessage]]
  * - [[LoadImageCollectionMessage]]
  * - [[SetBackgroundByNameMessage]]
  * - [[SetForegroundByNameMessage]]
@@ -302,6 +303,14 @@ export function isLoadImageCollectionMessage(o: any): o is LoadImageCollectionMe
     (o.loadChildFolders === undefined || typeof o.loadChildFolders === "boolean");
 }
 
+
+/** A message sent to the user when an image collection has finished loading, and is available for use. */
+export interface LoadImageCollectionCompletedMessage {
+  /** The tag identifying this message type. */
+  event: "load_image_collection_completed";
+  /** The URL of the loaded collection. */
+  url: string;
+}
 
 /** A command to load and play a WWT guided tour file. */
 export interface LoadTourMessage {
@@ -766,6 +775,7 @@ export type PywwtMessage =
   CreateImageSetLayerMessage |
   CreateTableLayerMessage |
   LoadImageCollectionMessage |
+  LoadImageCollectionCompletedMessage |
   LoadTourMessage |
   ModifyAnnotationMessage |
   ModifyFitsLayerMessage |

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -707,7 +707,13 @@ export default class App extends WWTAwareComponent {
   onMessage(msg: any) {  // eslint-disable-line @typescript-eslint/no-explicit-any
     if (classicPywwt.isLoadImageCollectionMessage(msg)) {
       this.loadImageCollection({ url: msg.url, loadChildFolders: msg.loadChildFolders }).then(()=> {
-        this.statusMessageDestination.postMessage({event: "image_collection_loaded", url: msg.url}, this.allowedOrigin);
+        if(this.statusMessageDestination != null && this.allowedOrigin != null){
+          const completedMessage: classicPywwt.LoadImageCollectionCompletedMessage = {
+            event: "load_image_collection_completed",
+            url: msg.url
+          };
+          this.statusMessageDestination.postMessage(completedMessage, this.allowedOrigin);
+        }
       });
     } else if (classicPywwt.isSetBackgroundByNameMessage(msg)) {
       this.setBackgroundImageByName(msg.name);

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -706,7 +706,9 @@ export default class App extends WWTAwareComponent {
 
   onMessage(msg: any) {  // eslint-disable-line @typescript-eslint/no-explicit-any
     if (classicPywwt.isLoadImageCollectionMessage(msg)) {
-      this.loadImageCollection({ url: msg.url, loadChildFolders: msg.loadChildFolders });
+      this.loadImageCollection({ url: msg.url, loadChildFolders: msg.loadChildFolders }).then(()=> {
+        this.statusMessageDestination.postMessage({event: "image_collection_loaded", url: msg.url}, this.allowedOrigin);
+      });
     } else if (classicPywwt.isSetBackgroundByNameMessage(msg)) {
       this.setBackgroundImageByName(msg.name);
     } else if (classicPywwt.isSetForegroundByNameMessage(msg)) {


### PR DESCRIPTION
Doing something more generic is also an idea, like this for example:
`this.statusMessageDestination.postMessage({event: msg.event + "_completed", originalMessage: msg}, this.allowedOrigin);`
Then the same style could be used for all async events, where the client may want to know when something has completed.