### PR TITLE
Research App messages to support Jupyter/ipywidgets implementation

### DIFF
--- a/docs/engine/research-app-messages-index.md
+++ b/docs/engine/research-app-messages-index.md
@@ -35,3 +35,10 @@ research app’s window with an event type of `message`.
 
 [ViewStateMessage]: ./interfaces/viewstatemessage.html
 [listen]: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#the_dispatched_event
+
+The [PingPongMessage] interface is also special. If you send this message to the
+app, it will reply with an identical message. This is useful for checking
+whether the app has started up, because usually there is no alternative to
+polling it.
+
+[PingPongMessage]: ./interfaces/pingpongmessage.html

--- a/research-app-messages/src/classic_pywwt.ts
+++ b/research-app-messages/src/classic_pywwt.ts
@@ -291,8 +291,17 @@ export interface LoadImageCollectionMessage {
   /** The URL of the collection to load. */
   url: string;
 
-  /** Optional, Recursively load any child folders. Defaults to False*/
+  /** Optional, Recursively load any child folders. Defaults to False. */
   loadChildFolders?: boolean;
+
+  /** An optional, arbitrary "thread" identifier that will be included in the
+   * reply message.
+   *
+   * The client can set this field so that it can properly associate response
+   * messages with the particular app and request that caused it. This
+   * disambiguation is needed when one client is talking to multiple apps.
+   * */
+  threadId?: string;
 }
 
 /** Type guard function for LoadImageCollectionMessage. */
@@ -300,16 +309,30 @@ export function isLoadImageCollectionMessage(o: any): o is LoadImageCollectionMe
   return typeof o.event === "string" &&
     o.event == "load_image_collection" &&
     typeof o.url === "string" &&
-    (o.loadChildFolders === undefined || typeof o.loadChildFolders === "boolean");
+    (o.loadChildFolders === undefined || typeof o.loadChildFolders === "boolean") &&
+    (o.threadId === undefined || typeof o.threadId === "string");
 }
 
 
-/** A message sent to the user when an image collection has finished loading, and is available for use. */
+/** A message sent to the user when an image collection has finished loading,
+ * and is available for use. */
 export interface LoadImageCollectionCompletedMessage {
   /** The tag identifying this message type. */
   event: "load_image_collection_completed";
+
   /** The URL of the loaded collection. */
   url: string;
+
+  /** The thread ID of the triggering message, if it was provided. */
+  threadId?: string;
+}
+
+/** Type guard function for [[LoadImageCollectionCompletedMessage]]. */
+export function isLoadImageCollectionCompletedMessage(o: any): o is LoadImageCollectionCompletedMessage {  // eslint-disable-line @typescript-eslint/no-explicit-any
+  return typeof o.event === "string" &&
+    o.event == "load_image_collection_completed" &&
+    typeof o.url === "string" &&
+    (o.threadId === undefined || typeof o.threadId === "string");
 }
 
 /** A command to load and play a WWT guided tour file. */

--- a/research-app-messages/src/classic_pywwt.ts
+++ b/research-app-messages/src/classic_pywwt.ts
@@ -32,8 +32,8 @@
  *
  * ### Image Sets
  *
- * - [[ImageCollectionLoadedMessage]]
  * - [[LoadImageCollectionMessage]]
+ * - [[LoadImageCollectionCompletedMessage]]
  * - [[SetBackgroundByNameMessage]]
  * - [[SetForegroundByNameMessage]]
  * - [[SetForegroundOpacityMessage]]

--- a/research-app-messages/src/index.ts
+++ b/research-app-messages/src/index.ts
@@ -140,5 +140,5 @@ export function isPingPongMessage(o: any): o is PingPongMessage {  // eslint-dis
   return typeof o.type === "string" &&
     o.type == "wwt_ping_pong" &&
     typeof o.threadId === "string" &&
-    (typeof o.sessionId === "undefined" || typeof o.sessionId === "string");
+    (o.sessionId === undefined || typeof o.sessionId === "string");
 }

--- a/research-app-messages/src/index.ts
+++ b/research-app-messages/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2020 the .NET Foundation
+// Copyright 2020-2021 the .NET Foundation
 // Licensed under the MIT License
 
 // Toplevel documentation found at @/docs/engine/research-app-messages-index.md
@@ -82,4 +82,52 @@ export function isViewStateMessage(o: any): o is ViewStateMessage {  // eslint-d
     typeof o.engineClockISOT === "string" &&
     typeof o.systemClockISOT === "string" &&
     typeof o.engineClockRateFactor === "number";
+}
+
+
+/** A "ping" or "pong" message.
+ *
+ * If you send this message to the app, it will reply with its own
+ * [[PingPongMessage]] that repeats your [[threadId]] and [[sessionId]].
+ *
+ * If you're trying to communicate with the WWT research app through the
+ * [postMessage()] web API, there's no surefire way to know that the app is
+ * actually receiving your messages. This is a particular issue when the app is
+ * starting up. The least-bad way to account for this is to periodically send
+ * pings and wait until you start getting replies. The [[threadId]] parameter
+ * makes it possible to distinguish messages between multiple instances of the
+ * app and multiple app clients.
+ *
+ * [postMessage()]:
+ * https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
+ *
+ * This message also includes a [[sessionId]] field that allows clients to set
+ * up customized tagging in [[ViewStateMessage]] updates, which is helpful when
+ * a client is messaging with multiple apps and needs to distinguish their
+ * replies.
+ * */
+export interface PingPongMessage {
+  /** The tag identifying this message type. */
+  type: "wwt_ping_pong";
+
+  /** Arbitrary text that will be included in message responses. */
+  threadId: string;
+
+  /** A client session identifier string.
+   *
+   * If specified, the app will start sending [[ViewStateMessage]] updates to
+   * the sender of this ping-pong message, and those updates will be tagged with
+   * this session ID. This is useful if a client is communicating with multiple
+   * apps and its messaging transport mechanism prevents it from identifying the
+   * origin of the various messages that it receives.
+   */
+  sessionId?: string;
+}
+
+/** Type guard function for [[PingPongMessage]]. */
+export function isPingPongMessage(o: any): o is PingPongMessage {  // eslint-disable-line @typescript-eslint/no-explicit-any
+  return typeof o.type === "string" &&
+    o.type == "wwt_ping_pong" &&
+    typeof o.threadId === "string" &&
+    (typeof o.sessionId === "undefined" || typeof o.sessionId === "string");
 }

--- a/research-app-messages/src/index.ts
+++ b/research-app-messages/src/index.ts
@@ -5,7 +5,6 @@
 
 import * as classicPywwt from './classic_pywwt';
 
-/** The "classic" message formats used by pywwt. */
 export { classicPywwt };
 
 

--- a/research-app-messages/src/index.ts
+++ b/research-app-messages/src/index.ts
@@ -46,6 +46,16 @@ export interface ViewStateMessage {
   /** A message type identifier. */
   type: "wwt_view_state";
 
+  /** An app/client session identifier.
+   *
+   * If a single client is communicating with multiple apps, it needs to be able
+   * to tell which app is the source of any update messages. This session
+   * identifier allows clients to do so. The default value is "default". But if
+   * a client sends a [[PingPongMessage]] with a customized ``sessionId`` field,
+   * that value will start appearing in these view state update messages.
+   */
+  sessionId: string;
+
   /** The current right ascension of the view, in radians. */
   raRad: number;
 
@@ -76,6 +86,7 @@ export interface ViewStateMessage {
 export function isViewStateMessage(o: any): o is ViewStateMessage {  // eslint-disable-line @typescript-eslint/no-explicit-any
   return typeof o.type === "string" &&
     o.type == "wwt_view_state" &&
+    typeof o.sessionId === "string" &&
     typeof o.raRad === "number" &&
     typeof o.decRad === "number" &&
     typeof o.fovDeg === "number" &&

--- a/research-app/package.json
+++ b/research-app/package.json
@@ -33,7 +33,7 @@
     "@wwtelescope/engine-helpers": "37e2cf42895becd14698bf9d2058594bfc61d53f",
     "@wwtelescope/engine-types": "fe25c086751bf45aad29fda93bdb2cc1f4c6e3ef",
     "@wwtelescope/engine-vuex": "7a4dec277f30efb6d217ff0c8f0c41276c0fb25c",
-    "@wwtelescope/research-app-messages": "7aee43eaada4d7cec8a06ed313bf490f26a0060d"
+    "@wwtelescope/research-app-messages": "thiscommit:2021-07-15:Wyhny8H"
   },
   "keywords": [
     "AAS WorldWide Telescope"

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -799,12 +799,14 @@ export default class App extends WWTAwareComponent {
 
   onMessage(msg: any) {  // eslint-disable-line @typescript-eslint/no-explicit-any
     if (classicPywwt.isLoadImageCollectionMessage(msg)) {
-      this.loadImageCollection({ url: msg.url, loadChildFolders: msg.loadChildFolders }).then(()=> {
-        if(this.statusMessageDestination != null && this.allowedOrigin != null){
+      this.loadImageCollection({ url: msg.url, loadChildFolders: msg.loadChildFolders }).then(() => {
+        if (this.statusMessageDestination != null && this.allowedOrigin != null){
           const completedMessage: classicPywwt.LoadImageCollectionCompletedMessage = {
             event: "load_image_collection_completed",
+            threadId: msg.threadId,
             url: msg.url
           };
+
           this.statusMessageDestination.postMessage(completedMessage, this.allowedOrigin);
         }
       });


### PR DESCRIPTION
In order to make the Research App work well as a replacement for the hand-coded ipywidgets viewer in pywwt, we need to add and modify some messages:

- a "ping-pong" API for the Jupyter client to poll when the app has started up. The JupyterLab extension should also be using this.
- a "session ID" field for the unsolicited view-state messages, to allow the client to figure out which view those messages came from
- a "thread ID" field for the load-image-collection request and response, for similar reasons

The basic thing going on here is that in the ipywidgets case, we might have multiple widgets, each of which can have multiple app "views", and the widget bridge code can't tell whose messages came from where. Also, AFAICT there's no way for the client to know when the app is ready to handle messages besides just sending something and seeing if it gets a response.