### PR TITLE
research-app: tighten up the panel presentation a bit

### DIFF
--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -16,7 +16,7 @@
       </transition>
       <div id="layers-container" v-if="haveLayers">
         <div class="display-section-header">
-          <label>Layers:</label>
+          <label>Layers</label>
         </div>
         <div v-if="showLayers">
           <catalog-item
@@ -29,7 +29,7 @@
       </div>
       <div id="sources-container" v-if="haveSources">
         <div class="display-section-header">
-          <label>Sources:</label>
+          <label>Sources</label>
         </div>
         <div v-if="showSources">
           <source-item
@@ -2051,7 +2051,7 @@ body {
 }
 
 #overlays {
-  margin: 10px;
+  margin: 5px;
 }
 
 #controls {
@@ -2112,10 +2112,13 @@ body {
   left: 0.5rem;
   width: 25vw;
   border-radius: 5px;
-  opacity: 0.6;
   color: white;
   font-weight: bold;
-  background: #404040;
+  background: rgba(65, 65, 65, 0.6);
+
+  p {
+    margin: 0;
+  }
 }
 
 #add-catalog {
@@ -2137,10 +2140,31 @@ body {
 }
 
 .display-section-header {
-  width: 100%;
-  font-size: 18pt;
-  text-align: center;
-  padding: 5px 0px;
+  font-size: 70%;
+  padding: 2px 5px;
+
+  /* Some tomfoolery to give a little strikethrough effect
+  * in the section header presentation */
+
+  display: flex;
+  align-items: center;
+
+  &::before,
+  &::after {
+    content: "";
+    height: 1px;
+    background-color: white;
+  }
+
+  &::before {
+    margin-right: 0.5rem;
+    width: 1rem;
+  }
+
+  &::after {
+    margin-left: 0.5rem;
+    flex-grow: 1;
+  }
 }
 
 .last-row {

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -2152,7 +2152,7 @@ body {
   &::before,
   &::after {
     content: "";
-    height: 1px;
+    height: 2px;
     background-color: white;
   }
 

--- a/research-app/src/CatalogItem.vue
+++ b/research-app/src/CatalogItem.vue
@@ -10,6 +10,7 @@
       <label
         focusable="false"
         id="name-label"
+        class="ellipsize"
         @click="isSelected = !isSelected"
         @keyup.enter="isSelected = !isSelected"
         >{{ catalog.name }}</label
@@ -33,7 +34,7 @@
       <div v-if="isSelected" class="detail-container">
         <div class="detail-row">
           <span class="prompt">URL:</span
-          ><span class="url-holder">{{ catalog.url }}</span>
+          ><span class="ellipsize">{{ catalog.url }}</span>
         </div>
         <div class="detail-row" v-if="catalog.description.length > 0">
           <span class="prompt">Description:</span
@@ -198,12 +199,15 @@ export default class CatalogItem extends Vue {
 
 <style scoped lang="less">
 #root-container {
-  background: #404040;
   color: white;
   font-weight: bold;
   font-size: 12pt;
   padding: 0px;
   overflow: hidden;
+
+  &:hover {
+    background: #999999;
+  }
 }
 
 #main-container {
@@ -211,13 +215,14 @@ export default class CatalogItem extends Vue {
   padding: 5px;
 }
 
-#main-container:hover {
-  background: #999999;
-}
-
 #name-label {
   display: inline-block;
   width: 75%;
+  vertical-align: middle;
+
+  &:hover {
+    cursor: pointer;
+  }
 }
 
 #buttons-container {
@@ -226,13 +231,16 @@ export default class CatalogItem extends Vue {
 
 .circle-popover {
   display: inline;
+
+  &:hover {
+    cursor: pointer;
+  }
 }
 
 .detail-container {
   font-size: 9pt;
   margin: 0px 5px;
   padding-left: 15px;
-  background: #404040;
 }
 
 .icon {
@@ -246,11 +254,6 @@ export default class CatalogItem extends Vue {
   background: #404040;
 }
 
-.url-holder {
-  overflow-wrap: break-word;
-  word-wrap: break-word;
-}
-
 .prompt {
   font-size: 11pt;
   font-weight: bold;
@@ -258,7 +261,13 @@ export default class CatalogItem extends Vue {
 }
 
 .detail-row {
-  padding: 5px 0px;
+  padding: 1px 0px;
+}
+
+.ellipsize {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 // For styling the nested vue-color component

--- a/research-app/src/SourceItem.vue
+++ b/research-app/src/SourceItem.vue
@@ -10,7 +10,7 @@
       <label
         v-show="!editing"
         focusable="false"
-        class="name-label"
+        class="name-label ellipsize"
         @click="isSelected = !isSelected"
         @keyup.enter="isSelected = !isSelected"
         >{{ source.name }}</label
@@ -209,14 +209,17 @@ export default class SourceItem extends Vue {
 }
 </script>
 
-<style scoped>
+<style scoped lang="less">
 #root-container {
-  background: #404040;
   color: white;
   font-weight: bold;
   font-size: 12pt;
   padding: 0px;
   overflow: hidden;
+
+  &:hover {
+    background: #999999;
+  }
 }
 
 #main-container {
@@ -224,13 +227,14 @@ export default class SourceItem extends Vue {
   padding: 5px;
 }
 
-#main-container:hover {
-  background: #999999;
-}
-
 .name-label {
   display: inline-block;
   width: 62%;
+  vertical-align: middle;
+
+  &:hover {
+    cursor: pointer;
+  }
 }
 
 .name-input {
@@ -250,11 +254,16 @@ a:visited {
   color: lightcoral;
 }
 
+.ellipsize {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .detail-container {
   font-size: 9pt;
   margin: 0px 5px;
   padding-left: 15px;
-  background: #404040;
 }
 
 .icon {
@@ -269,7 +278,6 @@ a:visited {
 
 .icon-link {
   height: 100%;
-  background: #404040;
 }
 
 .prompt {
@@ -279,6 +287,6 @@ a:visited {
 }
 
 .detail-row {
-  padding: 5px 0px;
+  padding: 1px 0px;
 }
 </style>


### PR DESCRIPTION
@Carifio24 Here are some suggested changes to try to tighten up the presentation of the research app panel:

- Give the panel a transparent background, as opposed to giving the whole thing a 60% opacity. The latter approach makes it so that nothing within the panel shows up at full intensity
- Tighten up the internal margins. `<p>` elements have to have their margins zeroed so as not to add undue vertical spacing
- Downscale the section headings ("Sources:" etc), using a little inline rule effect instead
- Ellipsize catalog and source names rather than letting them wrap
- Give them a `vertical-align: middle` to even out their presentation by a few pixels
- Kill redundant background settings in the catalog and source item components
- Add some extra `cursor: pointers` when hovering over catalog/source item labels (to expand the items) and the color selector
- Reduce internal padding in the detail rows

The catalog URL doesn't show up nicely in this version. It gets truncated, but the element width isn't limited so you don't get a nice ellipsis. We should probably add a "Copy URL to clipboard" button — I think ellipsization + that is nicer than showing the full URL.

Also, a lot of the layout here might benefit from using CSS "flexbox" layout. It's helpful for seemingly-simple cases like the icons that come after the catalog/source names. And I think it will probably help make the layout reflow more naturally for narrow layouts.