### PR TITLE
Add a scale factor control for HiPS catalogs

### DIFF
--- a/research-app/src/CatalogItem.vue
+++ b/research-app/src/CatalogItem.vue
@@ -88,7 +88,7 @@
             <input
               type="text"
               class="scale-factor-input"
-              v-model="scaleFactorDbText"
+              v-model.lazy="scaleFactorDbText"
             />
             <font-awesome-icon
               class="icon icon-button"

--- a/research-app/src/main.ts
+++ b/research-app/src/main.ts
@@ -10,23 +10,25 @@ import Chrome from 'vue-color/src/components/Chrome.vue';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import {
   faAdjust,
+  faChevronDown,
+  faChevronUp,
+  faCircle,
   faCompress,
   faExpand,
+  faEye,
+  faEyeSlash,
+  faMapMarkedAlt,
+  faMapMarkerAlt,
+  faMinusCircle,
   faMountain,
+  faPencilAlt,
+  faPlus,
+  faPlusCircle,
   faSearchMinus,
   faSearchPlus,
   faSlidersH,
-  faEyeSlash,
-  faEye,
-  faChevronDown,
-  faChevronUp,
-  faPlus,
-  faWindowClose,
   faTimes,
-  faMapMarkedAlt,
-  faCircle,
-  faMapMarkerAlt,
-  faPencilAlt,
+  faWindowClose,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
@@ -53,23 +55,25 @@ Vue.use(createPlugin(), {
 });
 
 library.add(faAdjust);
+library.add(faChevronDown);
+library.add(faChevronUp);
+library.add(faCircle);
 library.add(faCompress);
 library.add(faExpand);
+library.add(faEye);
+library.add(faEyeSlash);
+library.add(faMapMarkedAlt);
+library.add(faMapMarkerAlt);
+library.add(faMinusCircle);
 library.add(faMountain);
+library.add(faPencilAlt);
+library.add(faPlus);
+library.add(faPlusCircle);
 library.add(faSearchMinus);
 library.add(faSearchPlus);
 library.add(faSlidersH);
-library.add(faEyeSlash);
-library.add(faEye);
-library.add(faChevronUp);
-library.add(faChevronDown);
-library.add(faPlus);
-library.add(faWindowClose);
 library.add(faTimes);
-library.add(faMapMarkedAlt);
-library.add(faCircle);
-library.add(faMapMarkerAlt);
-library.add(faPencilAlt);
+library.add(faWindowClose);
 Vue.component('font-awesome-icon', FontAwesomeIcon);
 Vue.component("v-select", vSelect);
 Vue.component('catalog-item', CatalogItem);


### PR DESCRIPTION
I spent a surprisingly long time trying to figure out the UI here. I started with a slider, but I couldn't figure out a way to make that work given the large dynamic range needed by the scale-factor parameter. Then for numeric inputs, the basic web browser styling is dissatisfactory, but I couldn't find an powered-up Vue input widget with good TypeScript bindings. So I slightly rolled my own.