### PR TITLE
Research app selection messaging

### DIFF
--- a/research-app-messages/src/index.ts
+++ b/research-app-messages/src/index.ts
@@ -13,6 +13,14 @@ export {
   settings,
 };
 
+export interface Source {
+  ra: number;
+  dec: number;
+  name: string;
+  catalogName: string;
+  zoomDeg?: number;
+}
+
 /** Information about the current position of the WWT view.
  *
  * Frontends (e.g., [embedded WWT apps][embed]) periodically send this
@@ -211,11 +219,8 @@ export interface SelectionStateMessage {
   sessionId: string;
 
   /** The most recent source that was added to the selection list. */
-  mostRecentSource?: string;
-
-  /** The list of HiPS catalogs that are currently selected. */
-  selectedCatalogs?: string[];
+  mostRecentSource?: Source;
 
   /** The list of sources that are currently selected. */
-  selectedSources?: string[];
+  selectedSources?: Source[];
 }

--- a/research-app-messages/src/index.ts
+++ b/research-app-messages/src/index.ts
@@ -197,10 +197,10 @@ export function isPingPongMessage(o: any): o is PingPongMessage {  // eslint-dis
 
 export interface SelectionStateMessage {
 
-    /** The tag identifying this message type. */
-    type: "wwt_selection_state";
+  /** The tag identifying this message type. */
+  type: "wwt_selection_state";
 
-    /** An app/client session identifier.
+  /** An app/client session identifier.
    *
    * If a single client is communicating with multiple apps, it needs to be able
    * to tell which app is the source of any update messages. This session
@@ -218,14 +218,4 @@ export interface SelectionStateMessage {
 
   /** The list of sources that are currently selected. */
   selectedSources?: string[];
-}
-
-/** Type guard function for [[SelectionStateMessage]] */
-export function isSelectionStateMessage(o: any): o is SelectionStateMessage { // eslint-disable-line @typescript-eslint/no-explicit-any
-  return typeof o.type === "string" &&
-    o.type == "wwt_selection_state" &&
-    typeof o.threadId === "string" &&
-    (o.sessionId === undefined || typeof o.sessionId === "string") &&
-    (o.mostRecentSource === undefined || typeof o.mostRecentSource === "string") &&
-    (o.selectedSources === undefined || typeof o.selectedSources === "string");
 }

--- a/research-app-messages/src/index.ts
+++ b/research-app-messages/src/index.ts
@@ -180,3 +180,52 @@ export function isPingPongMessage(o: any): o is PingPongMessage {  // eslint-dis
     typeof o.threadId === "string" &&
     (o.sessionId === undefined || typeof o.sessionId === "string");
 }
+
+/** Information about the current state of source and catalog selection
+ * inside the WWT application
+ * 
+ * This message is broadcasted by the application whenever one of the user's selection
+ * options inside of the application is adjusted. The Vue listeners for the selected 
+ * catalogs and sources are deep listeners, meaning that this message will be broadcasted
+ * whenever a property of one of their items changes.
+ * 
+ * Not all fields of this message will always be present, depending on the
+ * nature of the event triggering the emission of this message. A message
+ * missing a particular field should be treated as conveying no information
+ * about the state described by that field.
+ */
+
+export interface SelectionStateMessage {
+
+    /** The tag identifying this message type. */
+    type: "wwt_selection_state";
+
+    /** An app/client session identifier.
+   *
+   * If a single client is communicating with multiple apps, it needs to be able
+   * to tell which app is the source of any update messages. This session
+   * identifier allows clients to do so. The default value is "default". But if
+   * a client sends a [[PingPongMessage]] with a customized ``sessionId`` field,
+   * that value will start appearing in these view state update messages.
+   */
+  sessionId: string;
+
+  /** The most recent source that was added to the selection list. */
+  mostRecentSource?: string;
+
+  /** The list of HiPS catalogs that are currently selected. */
+  selectedCatalogs?: string[];
+
+  /** The list of sources that are currently selected. */
+  selectedSources?: string[];
+}
+
+/** Type guard function for [[SelectionStateMessage]] */
+export function isSelectionStateMessage(o: any): o is SelectionStateMessage { // eslint-disable-line @typescript-eslint/no-explicit-any
+  return typeof o.type === "string" &&
+    o.type == "wwt_selection_state" &&
+    typeof o.threadId === "string" &&
+    (o.sessionId === undefined || typeof o.sessionId === "string") &&
+    (o.mostRecentSource === undefined || typeof o.mostRecentSource === "string") &&
+    (o.selectedSources === undefined || typeof o.selectedSources === "string");
+}

--- a/research-app-messages/src/index.ts
+++ b/research-app-messages/src/index.ts
@@ -5,21 +5,15 @@
 
 import * as classicPywwt from './classic_pywwt';
 import * as layers from './layers';
+import * as selections from './selections';
 import * as settings from './settings';
 
 export {
   classicPywwt,
   layers,
+  selections,
   settings,
 };
-
-export interface Source {
-  ra: number;
-  dec: number;
-  name: string;
-  catalogName: string;
-  zoomDeg?: number;
-}
 
 /** Information about the current position of the WWT view.
  *
@@ -202,25 +196,3 @@ export function isPingPongMessage(o: any): o is PingPongMessage {  // eslint-dis
  * missing a particular field should be treated as conveying no information
  * about the state described by that field.
  */
-
-export interface SelectionStateMessage {
-
-  /** The tag identifying this message type. */
-  type: "wwt_selection_state";
-
-  /** An app/client session identifier.
-   *
-   * If a single client is communicating with multiple apps, it needs to be able
-   * to tell which app is the source of any update messages. This session
-   * identifier allows clients to do so. The default value is "default". But if
-   * a client sends a [[PingPongMessage]] with a customized ``sessionId`` field,
-   * that value will start appearing in these view state update messages.
-   */
-  sessionId: string;
-
-  /** The most recent source that was added to the selection list. */
-  mostRecentSource?: Source;
-
-  /** The list of sources that are currently selected. */
-  selectedSources?: Source[];
-}

--- a/research-app-messages/src/index.ts
+++ b/research-app-messages/src/index.ts
@@ -182,17 +182,3 @@ export function isPingPongMessage(o: any): o is PingPongMessage {  // eslint-dis
     typeof o.threadId === "string" &&
     (o.sessionId === undefined || typeof o.sessionId === "string");
 }
-
-/** Information about the current state of source and catalog selection
- * inside the WWT application
- * 
- * This message is broadcasted by the application whenever one of the user's selection
- * options inside of the application is adjusted. The Vue listeners for the selected 
- * catalogs and sources are deep listeners, meaning that this message will be broadcasted
- * whenever a property of one of their items changes.
- * 
- * Not all fields of this message will always be present, depending on the
- * nature of the event triggering the emission of this message. A message
- * missing a particular field should be treated as conveying no information
- * about the state described by that field.
- */

--- a/research-app-messages/src/selections.ts
+++ b/research-app-messages/src/selections.ts
@@ -4,18 +4,18 @@
  * `catalogName` gives the name of the associated HiPS catalog,
  * while `name` gives a string name for the source.
  */
- export interface Source {
-    ra: number;
-    dec: number;
-    name: string;
-    catalogName: string;
-    zoomDeg?: number;
-    catalogData: {
-      [field: string]: string | undefined;
-    }
-  }
+export interface Source {
+  ra: number;
+  dec: number;
+  name: string;
+  catalogName: string;
+  zoomDeg?: number;
+  catalogData: {
+    [field: string]: string | undefined;
+  };
+}
 
-  /** Information about the current state of source and catalog selection
+/** Information about the current state of source and catalog selection
  * inside the WWT application
  * 
  * This message is broadcasted by the application whenever one of the user's selection

--- a/research-app-messages/src/selections.ts
+++ b/research-app-messages/src/selections.ts
@@ -11,18 +11,25 @@
     catalogName: string;
   }
 
+  /** Information about the current state of source and catalog selection
+ * inside the WWT application
+ * 
+ * This message is broadcasted by the application whenever one of the user's selection
+ * options inside of the application is adjusted. The Vue listeners for the selected
+ * catalogs and sources are deep listeners, meaning that this message will be broadcasted
+ * whenever a property of one of their items changes.
+ * 
+ * Not all fields of this message will always be present, depending on the
+ * nature of the event triggering the emission of this message. A message
+ * missing a particular field should be treated as conveying no information
+ * about the state described by that field.
+ */
 export interface SelectionStateMessage {
 
     /** The tag identifying this message type. */
     type: "wwt_selection_state";
   
-    /** An app/client session identifier.
-     *
-     * If a single client is communicating with multiple apps, it needs to be able
-     * to tell which app is the source of any update messages. This session
-     * identifier allows clients to do so. The default value is "default". But if
-     * a client sends a [[PingPongMessage]] with a customized ``sessionId`` field,
-     * that value will start appearing in these view state update messages.
+    /** An app/client session identifier. See the description for [[ViewStateMessage.sessionId]].
      */
     sessionId: string;
   

--- a/research-app-messages/src/selections.ts
+++ b/research-app-messages/src/selections.ts
@@ -1,0 +1,35 @@
+/**
+ * Information about a selected source in the engine.
+ * The values for right ascension and declination are given in radians.
+ * `catalogName` gives the name of the associated HiPS catalog,
+ * while `name` gives a string name for the source.
+ */
+ export interface Source {
+    ra: number;
+    dec: number;
+    name: string;
+    catalogName: string;
+  }
+
+export interface SelectionStateMessage {
+
+    /** The tag identifying this message type. */
+    type: "wwt_selection_state";
+  
+    /** An app/client session identifier.
+     *
+     * If a single client is communicating with multiple apps, it needs to be able
+     * to tell which app is the source of any update messages. This session
+     * identifier allows clients to do so. The default value is "default". But if
+     * a client sends a [[PingPongMessage]] with a customized ``sessionId`` field,
+     * that value will start appearing in these view state update messages.
+     */
+    sessionId: string;
+  
+    /** The most recent source that was added to the selection list. */
+    mostRecentSource?: Source;
+  
+    /** The list of sources that are currently selected. */
+    selectedSources?: Source[];
+  }
+  

--- a/research-app-messages/src/selections.ts
+++ b/research-app-messages/src/selections.ts
@@ -9,6 +9,10 @@
     dec: number;
     name: string;
     catalogName: string;
+    zoomDeg?: number;
+    catalogData: {
+      [field: string]: string | undefined;
+    }
   }
 
   /** Information about the current state of source and catalog selection

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -1768,25 +1768,7 @@ export default class App extends WWTAwareComponent {
     const msg: SelectionStateMessage = {
       type: "wwt_selection_state",
       sessionId: this.statusMessageSessionId,
-      mostRecentSource: JSON.stringify(source),
-    };
-
-    this.statusMessageDestination.postMessage(msg, this.allowedOrigin);
-  }
-
-  @Watch("hipsCatalogs", {deep:true})
-  onSelectedCatalogsChanged(catalogs: ImagesetInfo[]) {
-    // Notify clients when the list of selected catalogs is changed
-    // By making this a deep watcher, it keeps of track of any change
-    // in the list - even events like a property of a list entry changing
-
-    if (this.statusMessageDestination === null || this.allowedOrigin === null)
-      return;
-
-    const msg: SelectionStateMessage = {
-      type: "wwt_selection_state",
-      sessionId: this.statusMessageSessionId,
-      selectedCatalogs: catalogs.map(catalog => JSON.stringify(catalog)),
+      mostRecentSource: source,
     };
 
     this.statusMessageDestination.postMessage(msg, this.allowedOrigin);
@@ -1804,7 +1786,7 @@ export default class App extends WWTAwareComponent {
     const msg: SelectionStateMessage = {
       type: "wwt_selection_state",
       sessionId: this.statusMessageSessionId,
-      selectedSources: sources.map(source => JSON.stringify(source)),
+      selectedSources: sources,
     };
 
     this.statusMessageDestination.postMessage(msg, this.allowedOrigin);

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -242,9 +242,9 @@ import {
   classicPywwt,
   isPingPongMessage,
   layers,
+  selections,
   settings,
   ApplicationStateMessage,
-  SelectionStateMessage,
   ViewStateMessage,
 } from "@wwtelescope/research-app-messages";
 
@@ -1765,7 +1765,7 @@ export default class App extends WWTAwareComponent {
     if (this.statusMessageDestination === null || this.allowedOrigin === null)
       return;
       
-    const msg: SelectionStateMessage = {
+    const msg: selections.SelectionStateMessage = {
       type: "wwt_selection_state",
       sessionId: this.statusMessageSessionId,
       mostRecentSource: source,
@@ -1783,7 +1783,7 @@ export default class App extends WWTAwareComponent {
     if (this.statusMessageDestination === null || this.allowedOrigin === null)
       return;
 
-    const msg: SelectionStateMessage = {
+    const msg: selections.SelectionStateMessage = {
       type: "wwt_selection_state",
       sessionId: this.statusMessageSessionId,
       selectedSources: sources,

--- a/research-app/src/store.ts
+++ b/research-app/src/store.ts
@@ -7,6 +7,9 @@ export interface Source {
   name: string;
   catalogName: string;
   zoomDeg?: number;
+  catalogData: {
+    [field: string]: string | undefined;
+  }
 }
 
 export interface HipsCatalogStatus {
@@ -45,7 +48,26 @@ function removeFromArray<T>(array: T[], item: T, equivalent: EquivalenceTest<T> 
 }
 
 function sourcesEqual(s1: Source, s2: Source) {
-  return (s1.ra === s2.ra) && (s1.dec === s2.dec) && (s1.name === s2.name) && (s1.catalogName === s2.catalogName);
+  return (s1.ra === s2.ra) && (s1.dec === s2.dec) && (s1.catalogName === s2.catalogName);
+}
+
+// Increment the counter by 1 every time this is called
+const newSourceName = (function () {
+  let count = 0;
+
+  return function () {
+    count += 1;
+    return `Source ${count}`;
+  };
+})();
+
+function nameForSource(catalogData: any, catalogName: string, catalogNameMappings: { [catalogName: string]: [string, string] }): string {
+  for (const [key, [from, to]] of Object.entries(catalogNameMappings)) {
+    if (from in catalogData && catalogName === key) {
+      return `${to}: ${catalogData[from]}`;
+    }
+  }
+  return newSourceName();
 }
 
 @Module({
@@ -105,6 +127,7 @@ export class WWTResearchAppModule extends VuexModule {
 
   @Mutation
   addSource(source: Source) {
+    source.name = nameForSource(source.catalogData, source.catalogName, this.catalogNameMappings);
     addToArrayWithoutDuplication(this.sources, source, sourcesEqual);
   }
 

--- a/research-app/src/store.ts
+++ b/research-app/src/store.ts
@@ -9,7 +9,7 @@ export interface Source {
   zoomDeg?: number;
   catalogData: {
     [field: string]: string | undefined;
-  }
+  };
 }
 
 export interface HipsCatalogStatus {
@@ -49,25 +49,6 @@ function removeFromArray<T>(array: T[], item: T, equivalent: EquivalenceTest<T> 
 
 function sourcesEqual(s1: Source, s2: Source) {
   return (s1.ra === s2.ra) && (s1.dec === s2.dec) && (s1.catalogName === s2.catalogName);
-}
-
-// Increment the counter by 1 every time this is called
-const newSourceName = (function () {
-  let count = 0;
-
-  return function () {
-    count += 1;
-    return `Source ${count}`;
-  };
-})();
-
-function nameForSource(catalogData: any, catalogName: string, catalogNameMappings: { [catalogName: string]: [string, string] }): string {
-  for (const [key, [from, to]] of Object.entries(catalogNameMappings)) {
-    if (from in catalogData && catalogName === key) {
-      return `${to}: ${catalogData[from]}`;
-    }
-  }
-  return newSourceName();
 }
 
 @Module({
@@ -127,7 +108,6 @@ export class WWTResearchAppModule extends VuexModule {
 
   @Mutation
   addSource(source: Source) {
-    source.name = nameForSource(source.catalogData, source.catalogName, this.catalogNameMappings);
     addToArrayWithoutDuplication(this.sources, source, sourcesEqual);
   }
 


### PR DESCRIPTION
This PR adds a new message type, `SelectionStateMessage`, to `research-app-messages`, as well as functionality in the research app to broadcast these messages at appropriate times. Currently, the items that are broadcast on a change are the list of selected HiPS catalogs, the list of selected sources, and the most recent selected source.

I'm not sure if this is exactly how we want to handle the most recent selected source (which would be useful for e.g. `glue-wwt`). As things are now, every time a new source is selected, messages are broadcast for both the list of sources and the most recent source, which feels redundant. The alternative, I think, would be to only broadcast the source list message, and leave it on the user to identify whether the last source in the list is new or not.