### PR TITLE
FITS UI part 2: engine features

### DIFF
--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -2403,6 +2403,20 @@ export class WWTControl {
    */
   renderType: ImageSetType;
 
+  /** Get the name of the reference frame associated with the current view.
+   *
+   * The current reference frame defines the physical coordinates of the view
+   * and the list of layers that are included in the current rendering process.
+   * The return value of this function can be indexed into
+   * [[LayerManager.get_allMaps]] to find the root [[LayerMap]] that is used to
+   * determine what gets rendered in the current view.
+   *
+   * In standard 2D sky mode, the return value will be `"Sky"`.
+   *
+   * @returns The name of the current reference frame.
+   */
+  getCurrentReferenceFrame(): string;
+
   /** Render the view.
    *
    * Note that there also exists a similar method named `render`, but it

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -1032,7 +1032,33 @@ export class Layer implements LayerSettingsInterface {
 export namespace LayerManager {
   export function get_tourLayers(): boolean;
   export function set_tourLayers(v: boolean): boolean;
-  //export function get_layerMaps(): {[name: string]: LayerMap}
+
+  /** Get the hierarchy of layers registered with the engine.
+   *
+   * This function returns a dictionary of [[LayerMap]] instances that define
+   * the engine’s rendering hierarchy. This top-level dictionary contains only
+   * the root reference frames used by the engine — typically, it has only two
+   * entries, named `"Sun"` and `"Sky"`. Below the `"Sun"` map (in its
+   * [[LayerMap.childMaps]] field) are found maps for the planets, and below
+   * those are maps for their moons.
+   *
+   * See also [[get_allMaps]], which returns the same collection of layer maps
+   * but in a flattened hierarchy.
+   */
+  export function get_layerMaps(): { [name: string]: LayerMap }
+
+  /** Get the flattened hierarchy of layers registered with the engine.
+   *
+   * This function returns a dictionary of [[LayerMap]] instances that define
+   * the engine’s rendering hierarchy. The dictionary contains an entry for
+   * every [[LayerMap]] registered with the engine. This is unlike the
+   * `get_layerMaps()` interface, which only returns the “root” layer maps.
+   * Because there is a layer map for every solar system planet and every known
+   * moon thereof, this dictionary is quite large.
+   *
+   * The keying is done such that `allMaps[map.get_name()] = map`.
+   */
+  export function get_allMaps(): { [name: string]: LayerMap }
 
   /** Get the collection of all layers registered with the engine.
    *
@@ -1076,6 +1102,28 @@ export namespace LayerManager {
 /** An alias for the type implicitly defined by the static
  * [[LayerManager]] namespace. */
 export type LayerManagerObject = typeof LayerManager;
+
+/** A collection of layers in a hierarchical tree.
+ *
+ * Each map includes a collection of zero or more [[Layer]]s rooted in its
+ * reference frame (the [[layers]] list) as well as a collection of zero or more
+ * child [[LayerMap]]s, which have reference frames that are defined relative to
+ * this layer's reference frame (the [[childMaps]] dictionary).
+ **/
+export class LayerMap {
+  childMaps: { [childName: string]: LayerMap };
+  parent: LayerMap | null;
+  layers: Layer[];
+  open: boolean;
+  enabled: boolean;
+  loadedFromTour: boolean;
+  //frame: ReferenceFrame;
+
+  addChild(child: LayerMap): void;
+
+  get_name(): string;
+  set_name(v: string): string;
+}
 
 /** The full LayerSetting type, which augments engine-types' BaseLayerSetting
  * with types that are only provided within the engine itself.

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -894,6 +894,9 @@ export class Imageset implements Thumbnail {
   get_url(): string;
   set_url(url: string): string;
 
+  get_wcsImage(): WcsImage | null;
+  set_wcsImage(w: WcsImage | null): WcsImage | null;
+
   get_widthFactor(): number;
   set_widthFactor(f: number): number;
 
@@ -946,7 +949,7 @@ export class ImageSetLayer extends Layer implements ImageSetLayerSettingsInterfa
   get_overrideDefaultLayer(): boolean;
   set_overrideDefaultLayer(v: boolean): boolean;
 
-  getFitsImage(): FitsImage | null;;
+  getFitsImage(): FitsImage | null;
   setImageScalePhysical(st: ScaleTypes, min: number, max: number): void;
   setImageScaleRaw(st: ScaleTypes, min: number, max: number): void;
   setImageZ(z: number): void;

--- a/engine/wwtlib/FitsProperties.cs
+++ b/engine/wwtlib/FitsProperties.cs
@@ -3,8 +3,14 @@ using System.Collections.Generic;
 
 namespace wwtlib
 {
+    public enum ScaleTypes {
+        Linear = 0,
+        Log = 1,
+        Power = 2,
+        SquareRoot = 3,
+        HistogramEqualization = 4
+    };
 
-    public enum ScaleTypes { Linear = 0, Log = 1, Power = 2, SquareRoot = 3, HistogramEqualization = 4 };
     public class FitsProperties
     {
         public double BZero = 0;
@@ -16,14 +22,43 @@ namespace wwtlib
         public double UpperCut = double.MinValue;
         public double LowerCut = double.MaxValue;
         public bool TransparentBlack = true;
-
         public string ColorMapName = "gray";
         public ScaleTypes ScaleType = ScaleTypes.Linear;
 
+        // This field exists to support non-HiPS tiled FITS imagesets. We need a
+        // mechanism to notify callers when the top-level tile is loaded,
+        // because only after that has happened is it possible to set up
+        // trustworthy values for properties like LowerCut here. *HiPS* tiled
+        // FITS imagesets don't need this because they have a separate top-level
+        // "properties" file that can be used to trigger a callback.
+        //
+        // We need to load the top-level tile to properly set up the properties
+        // here because (1) they can't be determined well from the level-0 tile
+        // data alone, (2) we want to give the dataset author a chance to
+        // customize them, and (3) the tiled FITS data-loaders don't calculate
+        // min/max from the data for performance reasons. And we'd prefer not to
+        // add the relevant values to the ImageSet XML definition.
+        //
+        // Anyway, the tangent tile image loading code will cause this action to
+        // be triggered when the level-0 tile loads successfully. It would make
+        // sense to also trigger this action for when a non-tiled FITS file is
+        // loaded, but in that use case the existing WcsLoaded callback
+        // suffices. The tiling framework already uses WcsLoaded so for that
+        // case we need to add this extra hook.
+        public Action<FitsImage> OnMainImageLoaded = null;
 
         public FitsProperties()
         {
         }
 
+        // See description of the OnMainImageLoaded field. This method exists to
+        // help non-HiPS tiled FITS datasets notify callers when the initial
+        // data have loaded and these FitsProperties can be trusted.
+        internal void FireMainImageLoaded(FitsImage image)
+        {
+            if (OnMainImageLoaded != null) {
+                OnMainImageLoaded(image);
+            }
+        }
     }
 }

--- a/engine/wwtlib/HealpixTile.cs
+++ b/engine/wwtlib/HealpixTile.cs
@@ -195,7 +195,7 @@ namespace wwtlib
 
         private string GetUrl(Imageset dataset, int level, int x, int y)
         {
-            string extention = GetHipsFileExtention();
+            string extension = GetHipsFileExtension();
 
             int tileTextureIndex = -1;
             if (level == 0)
@@ -210,14 +210,18 @@ namespace wwtlib
 
             int subDirIndex = Math.Floor(tileTextureIndex / 10000) * 10000;
 
-            return String.Format(dataset.Url, level.ToString(), subDirIndex.ToString(), tileTextureIndex.ToString() + extention);
+            return String.Format(dataset.Url, level.ToString(), subDirIndex.ToString(), tileTextureIndex.ToString() + extension);
         }
 
-        private string GetHipsFileExtention()
+        private string GetHipsFileExtension()
         {
-            // The extension will contain either a list of type or a single type
-            // The imageset can be set to the perfrered file type if desired IE: FITS will never be chosen if others are avaialbe,
-            // unless the FITS only is selected and saved into the extension field of the imageset.
+            // The extension will contain either a space-separated list of types
+            // or a single type. We currently match preferred filetypes
+            // greedily. The extension must be exactly ".fits" in order to
+            // render correctly -- not only because of the greedy matching here,
+            // but because there are other parts of the code that check for an
+            // exact match.
+
             //prioritize transparent Png over other image formats
             if (dataset.Extension.ToLowerCase().IndexOf("png") > -1)
             {
@@ -334,7 +338,7 @@ namespace wwtlib
                 {
                     if (Level < dataset.Levels)
                     {
-                        // make children 
+                        // make children
                         if (children[childIndex] == null)
                         {
                             children[childIndex] = TileCache.GetTile(Level + 1, x1, y1, dataset, this);
@@ -611,7 +615,7 @@ namespace wwtlib
                     PrepDevice.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
                     PrepDevice.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
 
-                    if (GetHipsFileExtention() == ".fits" && RenderContext.UseGlVersion2)
+                    if (GetHipsFileExtension() == ".fits" && RenderContext.UseGlVersion2)
                     {
                         PrepDevice.texImage2D(GL.TEXTURE_2D, 0, GL.R32F, (int)fitsImage.SizeX, (int)fitsImage.SizeY, 0, GL.RED, GL.FLOAT, fitsImage.dataUnit);
                         PrepDevice.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.NEAREST);
@@ -648,7 +652,7 @@ namespace wwtlib
                     catalogData.Send();
                 }
             }
-            else if (GetHipsFileExtention() == ".fits")
+            else if (GetHipsFileExtension() == ".fits")
             {
                 if (!Downloading && !ReadyToRender)
                 {
@@ -870,7 +874,7 @@ namespace wwtlib
          *        2   6   10
          *          1   5
          *            0
-         * 
+         *
          */
         private void PopulateVertexList(PositionTexture[] vertexList, int step)
         {

--- a/engine/wwtlib/Layers/ImageSetLayer.cs
+++ b/engine/wwtlib/Layers/ImageSetLayer.cs
@@ -47,9 +47,12 @@ namespace wwtlib
         // Test whether our underlying imagery is FITS based.
         //
         // This can come in two flavors: a single FITS image, or tiled FITS.
+        // Note that even though the FileType/Extension field can currently
+        // specify multiple file formats, the rendering code requires that the
+        // extension is exactly ".fits" for FITS rendering to kick in.
         bool IsFitsImageset() {
-            bool fitsExt = imageSet.Extension.ToLowerCase().StartsWith(".fit");
-            return imageSet.WcsImage is FitsImage || (imageSet.WcsImage == null && fitsExt);
+            bool hasFitsExt = imageSet.Extension == ".fits";
+            return imageSet.WcsImage is FitsImage || (imageSet.WcsImage == null && hasFitsExt);
         }
 
         public override void InitializeFromXml(XmlNode node)

--- a/engine/wwtlib/ScriptInterface.cs
+++ b/engine/wwtlib/ScriptInterface.cs
@@ -368,16 +368,18 @@ namespace wwtlib
             {
                 name = LayerManager.GetNextImageSetName();
             }
-            ImageSetLayer imagesetLayer = LayerManager.AddImageSetLayer(imageset, name);
+
+            ImageSetLayer imagesetLayer = LayerManager.AddImageSetLayerCallback(imageset, name, loaded);
 
             if (gotoTarget)
             {
-                WWTControl.Singleton.GotoRADecZoom(imageset.CenterX / 15, imageset.CenterY,
-                    WWTControl.Singleton.RenderContext.ViewCamera.Zoom, false, null);
-            }
-            if (loaded != null)
-            {
-                loaded(imagesetLayer);
+                WWTControl.Singleton.GotoRADecZoom(
+                    imageset.CenterX / 15,
+                    imageset.CenterY,
+                    WWTControl.Singleton.RenderContext.ViewCamera.Zoom,
+                    false,
+                    null
+                );
             }
 
             return imagesetLayer;

--- a/engine/wwtlib/ScriptInterface.cs
+++ b/engine/wwtlib/ScriptInterface.cs
@@ -373,10 +373,12 @@ namespace wwtlib
 
             if (gotoTarget)
             {
+                double zoom = imageset.GuessZoomSetting(WWTControl.Singleton.RenderContext.ViewCamera.Zoom);
+
                 WWTControl.Singleton.GotoRADecZoom(
                     imageset.CenterX / 15,
                     imageset.CenterY,
-                    WWTControl.Singleton.RenderContext.ViewCamera.Zoom,
+                    zoom,
                     false,
                     null
                 );
@@ -439,15 +441,26 @@ namespace wwtlib
                 imageset.WcsImage = wcsImage;
                 imagesetLayer.ImageSet = imageset;
                 LayerManager.AddFitsImageSetLayer(imagesetLayer, name);
+
                 if (gotoTarget)
                 {
-                    WWTControl.Singleton.GotoRADecZoom(wcsImage.CenterX / 15, wcsImage.CenterY, 10 * wcsImage.ScaleY * height, false, null);
+                    double zoom = imageset.GuessZoomSetting(WWTControl.Singleton.RenderContext.ViewCamera.Zoom);
+
+                    WWTControl.Singleton.GotoRADecZoom(
+                        wcsImage.CenterX / 15,
+                        wcsImage.CenterY,
+                        zoom,
+                        false,
+                        null
+                    );
                 }
+
                 if (loaded != null)
                 {
                     loaded(imagesetLayer);
                 }
             };
+
             if (string.IsNullOrWhiteSpace(name))
             {
                 name = LayerManager.GetNextFitsName();

--- a/engine/wwtlib/TangentTile.cs
+++ b/engine/wwtlib/TangentTile.cs
@@ -89,6 +89,14 @@ namespace wwtlib
                             TileCache.RemoveFromQueue(this.Key, true);
                             if (!fitsImage.errored)
                             {
+                                // For a non-HiPS tiled FITS, this is our
+                                // mechanism for notifying the layer creator
+                                // that the initial FITS data have loaded and
+                                // the FitsProperties can be trusted.
+                                if (Level == 0) {
+                                    dataset.FitsProperties.FireMainImageLoaded(fitsImage);
+                                }
+
                                 texReady = true;
                                 ReadyToRender = texReady && (DemReady || !demTile);
                                 RequestPending = false;
@@ -99,8 +107,14 @@ namespace wwtlib
                     }
                     else
                     {
-                        FitsImageJs image = FitsImageJs.CreateTiledFits(dataset, URL, delegate (WcsImage wcsImage)
+                        FitsImageJs image = null;
+
+                        image = FitsImageJs.CreateTiledFits(dataset, URL, delegate (WcsImage wcsImage)
                         {
+                            if (Level == 0) {
+                                dataset.FitsProperties.FireMainImageLoaded(fitsImage);
+                            }
+
                             texReady = true;
                             Downloading = false;
                             errored = false;
@@ -112,7 +126,6 @@ namespace wwtlib
                             ReadyToRender = true;
                         });
                     }
-
                 }
             }
             else

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -660,7 +660,7 @@ namespace wwtlib
                 {
                     foreach (Imageset imageset in RenderContext.CatalogHipsImagesets)
                     {
-                        if (imageset.HipsProperties.CatalogSpreadSheetLayer.Enabled 
+                        if (imageset.HipsProperties.CatalogSpreadSheetLayer.Enabled
                             && imageset.HipsProperties.CatalogSpreadSheetLayer.lastVersion == imageset.HipsProperties.CatalogSpreadSheetLayer.Version)
                         {
                             RenderContext.DrawImageSet(imageset, 100);
@@ -786,7 +786,7 @@ namespace wwtlib
             }
         }
 
-        private string GetCurrentReferenceFrame()
+        public string GetCurrentReferenceFrame()
         {
             if (RenderContext.BackgroundImageset == null)
             {
@@ -1772,7 +1772,7 @@ namespace wwtlib
                 {
                     RenderContext.UseGlVersion2 = true;
                 }
-                else 
+                else
                 {
                     Script.Literal("console.warn('This browser does not support WebGL 2.0. Some features will work suboptimally. To get the full AAS WWT experience, consider using the latest version of Chrome, Firefox or Edge. In case you would like to use Safari, we recommend that you enable WebGL 2.0')");
                     gl = (GL)(Object)canvas.GetContext((Rendering)(object)"webgl");
@@ -2671,7 +2671,7 @@ namespace wwtlib
                 Script.Literal("console.log({0} + ' not found')", imagesetName);
             }
         }
-        
+
 
         private SimpleLineList crossHairs = null;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,10 +58,12 @@
       }
     },
     "astro": {
+      "name": "@wwtelescope/astro",
       "version": "0.0.0-dev.0",
       "license": "MIT"
     },
     "embed": {
+      "name": "@wwtelescope/embed",
       "version": "0.0.0-dev.0",
       "license": "MIT",
       "dependencies": {
@@ -84,6 +86,7 @@
       }
     },
     "embed-common": {
+      "name": "@wwtelescope/embed-common",
       "version": "0.0.0-dev.0",
       "license": "MIT",
       "dependencies": {
@@ -91,6 +94,7 @@
       }
     },
     "embed-creator": {
+      "name": "@wwtelescope/embed-creator",
       "version": "0.0.0-dev.0",
       "license": "MIT",
       "dependencies": {
@@ -110,6 +114,7 @@
       }
     },
     "engine": {
+      "name": "@wwtelescope/engine",
       "version": "0.0.0-dev.0",
       "license": "MIT",
       "dependencies": {
@@ -117,6 +122,7 @@
       }
     },
     "engine-helpers": {
+      "name": "@wwtelescope/engine-helpers",
       "version": "0.0.0-dev.0",
       "license": "MIT",
       "dependencies": {
@@ -126,10 +132,12 @@
       }
     },
     "engine-types": {
+      "name": "@wwtelescope/engine-types",
       "version": "0.0.0-dev.0",
       "license": "MIT"
     },
     "engine-vuex": {
+      "name": "@wwtelescope/engine-vuex",
       "version": "0.0.0-dev.0",
       "license": "MIT",
       "dependencies": {
@@ -22605,6 +22613,7 @@
       "dev": true
     },
     "research-app": {
+      "name": "@wwtelescope/research-app",
       "version": "0.0.0-dev.0",
       "license": "MIT",
       "dependencies": {
@@ -22630,6 +22639,7 @@
       }
     },
     "research-app-messages": {
+      "name": "@wwtelescope/research-app-messages",
       "version": "0.0.0-dev.0",
       "license": "MIT"
     }
@@ -22838,7 +22848,8 @@
     "@fortawesome/vue-fontawesome": {
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.10.tgz",
-      "integrity": "sha512-b2+SLF31h32LSepVcXe+BQ63yvbq5qmTCy4KfFogCYm2bn68H5sDWUnX+U7MBqnM2aeEk9M7xSoqGnu+wSdY6w=="
+      "integrity": "sha512-b2+SLF31h32LSepVcXe+BQ63yvbq5qmTCy4KfFogCYm2bn68H5sDWUnX+U7MBqnM2aeEk9M7xSoqGnu+wSdY6w==",
+      "requires": {}
     },
     "@hapi/address": {
       "version": "2.1.4",
@@ -24263,7 +24274,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "2.4.0",
@@ -24750,7 +24762,8 @@
       "version": "4.5.13",
       "resolved": "https://registry.npmjs.org/@vue/cli-plugin-vuex/-/cli-plugin-vuex-4.5.13.tgz",
       "integrity": "sha512-I1S9wZC7iI0Wn8kw8Zh+A2Qkf6s1M6vTGBkx8boXjuzfwEEyEHRxadsVCecZc8Mkpydo0nykj+MyYF96TKFuVA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@vue/cli-service": {
       "version": "4.5.13",
@@ -24913,7 +24926,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@vue/preload-webpack-plugin/-/preload-webpack-plugin-1.1.2.tgz",
       "integrity": "sha512-LIZMuJk38pk9U9Ur4YzHjlIyMuxPlACdBIHH9/nGYVTsaGKOSnSuELiE8vS9wa+dJpIYspYUOqk+L1Q4pgHQHQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@vue/test-utils": {
       "version": "1.0.0-beta.31",
@@ -25284,7 +25298,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -25332,13 +25347,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -25958,7 +25975,8 @@
     "bootstrap": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
-      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw=="
+      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==",
+      "requires": {}
     },
     "bootstrap-vue": {
       "version": "2.21.2",
@@ -32319,7 +32337,8 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
       "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk=",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -35447,7 +35466,8 @@
     "portal-vue": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.7.tgz",
-      "integrity": "sha512-+yCno2oB3xA7irTt0EU5Ezw22L2J51uKAacE/6hMPMoO/mx3h4rXFkkBkT4GFsMDv/vEe8TNKC3ujJJ0PTwb6g=="
+      "integrity": "sha512-+yCno2oB3xA7irTt0EU5Ezw22L2J51uKAacE/6hMPMoO/mx3h4rXFkkBkT4GFsMDv/vEe8TNKC3ujJJ0PTwb6g==",
+      "requires": {}
     },
     "portfinder": {
       "version": "1.0.28",
@@ -39311,7 +39331,8 @@
     "vue-class-component": {
       "version": "7.2.6",
       "resolved": "https://registry.npmjs.org/vue-class-component/-/vue-class-component-7.2.6.tgz",
-      "integrity": "sha512-+eaQXVrAm/LldalI272PpDe3+i4mPis0ORiMYxF6Ae4hyuCh15W8Idet7wPUEs4N4YptgFHGys4UrgNQOMyO6w=="
+      "integrity": "sha512-+eaQXVrAm/LldalI272PpDe3+i4mPis0ORiMYxF6Ae4hyuCh15W8Idet7wPUEs4N4YptgFHGys4UrgNQOMyO6w==",
+      "requires": {}
     },
     "vue-clipboard2": {
       "version": "0.3.1",
@@ -39497,7 +39518,8 @@
     "vue-select": {
       "version": "3.12.2",
       "resolved": "https://registry.npmjs.org/vue-select/-/vue-select-3.12.2.tgz",
-      "integrity": "sha512-KWIXQ50pC+B1wpBmaUXwuHm8yevPIL8YsZin9Hi2qCdK7C0KMbztRk6adgpIJ99bqaiccrGFQIPuXsuUNeegPw=="
+      "integrity": "sha512-KWIXQ50pC+B1wpBmaUXwuHm8yevPIL8YsZin9Hi2qCdK7C0KMbztRk6adgpIJ99bqaiccrGFQIPuXsuUNeegPw==",
+      "requires": {}
     },
     "vue-slider-component": {
       "version": "3.2.14",
@@ -39552,13 +39574,15 @@
     "vuex": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
-      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw=="
+      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==",
+      "requires": {}
     },
     "vuex-module-decorators": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/vuex-module-decorators/-/vuex-module-decorators-0.16.1.tgz",
       "integrity": "sha512-Zz8HF2rMoDYf78uOBbWCq8wGFFo7YyNWc10Yj2eScKxVoRMla9HnFpiqvI3Dm0cLyOnBBklCn1AFUys62BZGAw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -40684,7 +40708,8 @@
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
       "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",


### PR DESCRIPTION
This PR makes various changes to the engine that were needed to get the FITS UI/UX going. Specifically:

- Add some existing APIs to the TypeScript exports (especially the LayerMap pieces)
- Provide a mechanism to properly set up the FitsProperties of tiled FITS files. This needs some new notification APIs to be set up. The existing HiPS FITS code didn't need this because it could respond to the download the HiPS "properties" file, but plain tiled FITS doesn't have that
- And set up non-HiPS tiled FITS to use the above mechanism with some custom FITS headers in the level-0 tile
- Add a hook to guess an appropriate zoom level when going to an Imageset. Ideally, imagesets should be wrapped in Place objects which can specify the desired view exactly, but this isn't always available
- Also update the `package-lock.json` format
- And some whitespace and formatting cleanups