### PR TITLE
FITS UI part 3: engine-vuex extensions

### DIFF
--- a/engine-vuex/src/store.ts
+++ b/engine-vuex/src/store.ts
@@ -773,6 +773,21 @@ export class WWTEngineVuexModule extends VuexModule implements WWTEngineVuexStat
     }
   }
 
+  get imagesetForLayer() {
+    return function (guidtext: string): Imageset | null {
+      if (Vue.$wwt.inst === null)
+        throw new Error('cannot get imagesetForLayer without linking to WWTInstance');
+
+      const layer = Vue.$wwt.inst.lm.get_layerList()[guidtext];
+
+      if (layer !== null && layer instanceof ImageSetLayer) {
+        return layer.get_imageSet();
+      } else {
+        return null;
+      }
+    }
+  }
+
   get activeImagesetLayerStates() {
     const states: ImageSetLayerState[] = [];
 

--- a/engine-vuex/src/wwtaware.ts
+++ b/engine-vuex/src/wwtaware.ts
@@ -191,6 +191,7 @@ import {
  * Getters:
  *
  * - [[activeImagesetLayerStates]]
+ * - [[imagesetForLayer]]
  * - [[imagesetStateForLayer]]
  *
  * Mutations:
@@ -326,6 +327,7 @@ export class WWTAwareComponent extends Vue {
       ...mapGetters([
         "activeImagesetLayerStates",
         "findRADecForScreenPoint",
+        "imagesetForLayer",
         "imagesetStateForLayer",
         "layerForHipsCatalog",
         "lookupImageset",
@@ -545,11 +547,27 @@ export class WWTAwareComponent extends Vue {
    */
   activeImagesetLayerStates!: ImageSetLayerState[];
 
+  /** Look up the WWT engine object for an active imageset layer.
+   *
+   * This getter gets the WWT `Imageset` object associated with an imageset
+   * layer. The returned object is *not* part of the Vue(x) reactivity system,
+   * so you shouldn't use it to set up UI elements, but you can obtain more
+   * detailed information about the imageset than is stored in the state
+   * management system. For UI purposes, use [[imagesetStateForLayer]].
+   *
+   * @param guidtext The GUID of the layer to query, as a string
+   * @returns The layer's underlying imageset, or null if the GUID is
+   * unrecognized
+   */
+  imagesetForLayer!: (guidtext: string) => Imageset | null;
+
   /** Look up the reactive state for an active imageset layer.
    *
    * These layers are created using the [[addImageSetLayer]] action. The state
    * returned by this function is part of the reactive Vuex store, so you can
    * wire it up to your UI and it will update as the layer settings are changed.
+   * If you need "runtime" state not captured in the reactivity system, you may
+   * need to use [[imagesetForLayer]] instead.
    *
    * @param guidtext The GUID of the layer to query, as a string
    * @returns The layer state, or null if the GUID is unrecognized

--- a/engine-vuex/src/wwtaware.ts
+++ b/engine-vuex/src/wwtaware.ts
@@ -185,10 +185,12 @@ import {
  *
  * State:
  *
+ * - [[wwtActiveLayers]]
  * - [[wwtImagesetLayers]]
  *
  * Getters:
  *
+ * - [[activeImagesetLayerStates]]
  * - [[imagesetStateForLayer]]
  *
  * Mutations:
@@ -208,6 +210,7 @@ import {
  *
  * State:
  *
+ * - [[wwtActiveLayers]]
  * - [[wwtSpreadSheetLayers]]
  *
  * Mutations:
@@ -298,6 +301,7 @@ export class WWTAwareComponent extends Vue {
 
     this.$options.computed = {
       ...mapState({
+        wwtActiveLayers: (state, _getters) => (state as WWTEngineVuexState).activeLayers,
         wwtAvailableImagesets: (state, _getters) => (state as WWTEngineVuexState).availableImagesets,
         wwtBackgroundImageset: (state, _getters) => (state as WWTEngineVuexState).backgroundImageset,
         wwtCurrentTime: (state, _getters) => (state as WWTEngineVuexState).currentTime,
@@ -320,6 +324,7 @@ export class WWTAwareComponent extends Vue {
         wwtSpreadSheetLayers: (state, _getters) => (state as WWTEngineVuexState).spreadSheetLayers,
       }),
       ...mapGetters([
+        "activeImagesetLayerStates",
         "findRADecForScreenPoint",
         "imagesetStateForLayer",
         "layerForHipsCatalog",
@@ -381,6 +386,16 @@ export class WWTAwareComponent extends Vue {
   }
 
   // Teach TypeScript about everything we wired up. State:
+
+  /** The GUIDs of all rendered layers, in their draw order.
+   *
+   * This list gives the GUIDs of the layers that are currently candidates for
+   * rendering. This list is determined by the hierarchy of "layer maps"
+   * registered with the engine and its current rendering mode. Layers in this
+   * list might not be actually rendered if their `enabled` flag is false, if
+   * they are fully transparent, and so on.
+   **/
+  wwtActiveLayers!: string[];
 
   /** Information about the imagesets that are available to be used as a background.
    *
@@ -518,6 +533,17 @@ export class WWTAwareComponent extends Vue {
   wwtShowWebGl2Warning!: boolean;
 
   // Getters
+
+  /** Get the reactive state for the active imageset layers
+   *
+   * These layers are created using the [[addImageSetLayer]] action. The state
+   * structures returned by this function is part of the reactive Vuex store, so
+   * you can wire them up to your UI and they will update correctly. The list is
+   * returned in the engine's render order.
+   *
+   * @returns The layer states
+   */
+  activeImagesetLayerStates!: ImageSetLayerState[];
 
   /** Look up the reactive state for an active imageset layer.
    *


### PR DESCRIPTION
Here we add a few more hooks to the engine-vuex module to help the frontend know what the active layers are. The code that manages the spreadsheet layers should be updated to use the same infrastructure ­— the LayerMaps hierarchy is the correct source of truth for this information.