### PR TITLE
Fix for uninteractable area around notifications

### DIFF
--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -2452,8 +2452,8 @@ body {
 }
 
 .vue-notification-group {
-  padding-right: 2.5rem;
-  padding-top: 0.75rem;
+  margin-right: 2.5rem;
+  margin-top: 0.75rem;
 }
 
 /* Generic v-tooltip CSS derived from: https://github.com/Akryum/v-tooltip#sass--less */


### PR DESCRIPTION
Easing myself into this again with a really simple PR. 

Basically there is always an area of 0.75rem height that cannot be interacted with since it is covered by vue-notification-group. When the notification is showing the area is even bigger making the control button and part of the zoom button.