### PR TITLE
Transparent black disabled by deafault

### DIFF
--- a/engine/wwtlib/FitsProperties.cs
+++ b/engine/wwtlib/FitsProperties.cs
@@ -21,7 +21,7 @@ namespace wwtlib
         public double MinVal = double.MaxValue;
         public double UpperCut = double.MinValue;
         public double LowerCut = double.MaxValue;
-        public bool TransparentBlack = true;
+        public bool TransparentBlack = false;
         public string ColorMapName = "gray";
         public ScaleTypes ScaleType = ScaleTypes.Linear;
 

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -257,6 +257,7 @@
               Load
               <a
                 href="https://docs.worldwidetelescope.org/data-guide/1/data-file-formats/collections/"
+                target="_blank"
                 >WTML</a
               >
               data collection:

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -2367,7 +2367,7 @@ body {
   position: absolute;
   top: 0.5rem;
   left: 0.5rem;
-  width: 25vw;
+  max-width: 25vw;
   border-radius: 5px;
   color: white;
   font-weight: bold;


### PR DESCRIPTION
As discussed, the transparentBlack property is now off by default, just like the current pywwt behaviour.

Also two tiny changes

1. to open a help link in a new tab 
2. fixed unnecessarily wide display-panel for larger screens.