### PR TITLE
Fix issue with committing inside a mutation

### DIFF
--- a/engine-vuex/src/store.ts
+++ b/engine-vuex/src/store.ts
@@ -355,6 +355,10 @@ export interface LoadImageCollectionParams {
   loadChildFolders?: boolean;
 }
 
+/** This function creates the list of currently active layers.
+ * Keeping this functionality outside of the store allows us to use it from
+ * inside either an action or a mutation.
+ */
 function activeLayersList(): string[] {
   if (Vue.$wwt.inst === null)
     throw new Error('cannot get activeLayersList without linking to WWTInstance');

--- a/engine-vuex/src/store.ts
+++ b/engine-vuex/src/store.ts
@@ -735,14 +735,6 @@ export class WWTEngineVuexModule extends VuexModule implements WWTEngineVuexStat
   activeLayers: string[] = [];
 
   @Mutation
-  internalUpdateActiveLayers(): void {
-    if (Vue.$wwt.inst === null)
-      throw new Error('cannot get internalUpdateActiveLayers without linking to WWTInstance');
-
-    this.activeLayers = activeLayersList();
-  }
-
-  @Mutation
   deleteLayer(id: string | Guid): void {
     if (Vue.$wwt.inst === null)
       throw new Error('cannot deleteLayer without linking to WWTInstance');
@@ -819,7 +811,7 @@ export class WWTEngineVuexModule extends VuexModule implements WWTEngineVuexStat
     const guidText = wwtLayer.id.toString();
     Vue.set(this.imagesetLayers, guidText, new ImageSetLayerState(wwtLayer));
 
-    this.context.commit('internalUpdateActiveLayers');
+    (this.context.state as WWTEngineVuexState).activeLayers = activeLayersList();
     return wwtLayer;
   }
 
@@ -943,7 +935,7 @@ export class WWTEngineVuexModule extends VuexModule implements WWTEngineVuexStat
     const guidText = wwtLayer.id.toString();
     Vue.set(this.spreadSheetLayers, guidText, new SpreadSheetLayerState(wwtLayer));
 
-    this.context.commit('internalUpdateActiveLayers');
+    (this.context.state as WWTEngineVuexState).activeLayers = activeLayersList();
     return wwtLayer;
   }
 
@@ -1025,7 +1017,7 @@ export class WWTEngineVuexModule extends VuexModule implements WWTEngineVuexStat
       Vue.set(this.spreadSheetLayers, guidText, new SpreadSheetLayerState(wwtLayer));
     }
 
-    this.context.commit('internalUpdateActiveLayers');
+    (this.context.state as WWTEngineVuexState).activeLayers = activeLayersList();
     return imgset;
   }
 


### PR DESCRIPTION
So despite what people on the second answer [here](https://stackoverflow.com/questions/40487627/can-i-call-commit-from-one-of-mutations-in-vuex-store) say, committing a mutation inside another mutation does not seem possible. This (or similar) functionality has been proposed and rejected by the Vuex team (e.g. [here](https://github.com/vuejs/vuex/issues/651) and [here](https://github.com/vuejs/vuex/issues/907)). From what I can tell, our two options are to use an action any time we want to commit multiple mutations, or pushing the duplicated functionality into an external function which gets called appropriately.

This PR takes the second approach. The function `activeLayersList`, defined external to the store, constructs and returns the `string[]` of the names of active layers. We then call this function in the following ways:
* From a mutation: Here we can assign the result of the function directly to `this.activeLayers`
* From an action: Inside an action we have two options: we can either modify the state directly (accessible as `this.context.state`), or wrap the operation in a mutation. In this PR, I've chosen the first option so as to avoid the need for a wrapper mutation.

Needing to have the functionality outside the store isn't ideal, but I think this gets us what we want with a minimum of repeated code.
