### PR TITLE
Research app UI updates

### DIFF
--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -179,8 +179,8 @@
             >
               <template #option="option">
                 <div class="item-option">
-                  <h4>{{ option.name }}</h4>
-                  <em>{{ option.description }}</em>
+                  <h4 class="ellipsize">{{ option.name }}</h4>
+                  <p class="ellipsize"><em>{{ option.description }}</em></p>
                 </div>
               </template>
               <template #selected-option="option">
@@ -205,8 +205,8 @@
             >
               <template #option="option">
                 <div class="item-option">
-                  <h4>{{ option.name }}</h4>
-                  <em>{{ option.description }}</em>
+                  <h4 class="ellipsize">{{ option.name }}</h4>
+                  <p class="ellipsize"><em>{{ option.description }}</em></p>
                 </div>
               </template>
               <template #selected-option="option">
@@ -2565,6 +2565,12 @@ body {
   }
 }
 
+.ellipsize {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* Specialized styling for popups */
 
 ul.tool-menu {
@@ -2629,11 +2635,13 @@ ul.tool-menu {
 .item-option {
   & h4 {
     margin: 0;
+    width: 100%;
   }
 
-  & em {
+  & p {
     margin: 0;
     font-size: small;
+    widtH: 100%;
   }
 }
 

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -184,7 +184,7 @@
                 </div>
               </template>
               <template #selected-option="option">
-                <div>{{ option.name }}</div>
+                <div class="ellipsize">{{ option.name }}</div>
               </template>
             </v-select>
           </div>
@@ -210,7 +210,7 @@
                 </div>
               </template>
               <template #selected-option="option">
-                <div>{{ option.name }}</div>
+                <div class="ellipsize">{{ option.name }}</div>
               </template>
               <template #no-options="{ search, searching }">
                 <template v-if="searching">
@@ -240,8 +240,8 @@
             >
               <template #option="option">
                 <div class="item-option">
-                  <h4>{{ option.name }}</h4>
-                  <em>{{ option.description }}</em>
+                  <h4 class="ellipsize">{{ option.name }}</h4>
+                  <p class="ellipsize"><em>{{ option.description }}</em></p>
                 </div>
               </template>
               <template #selected-option-container="">
@@ -2630,6 +2630,18 @@ ul.tool-menu {
   .vs__dropdown-option--highlight {
     color: red;
   }
+
+  .vs__selected-options {
+    margin: 0;
+    flex-wrap: nowrap;
+    flex-grow: 1;
+    overflow: hidden;
+  }
+
+  .vs__selected {
+    overflow: hidden;
+  }
+
 }
 
 .item-option {
@@ -2641,7 +2653,7 @@ ul.tool-menu {
   & p {
     margin: 0;
     font-size: small;
-    widtH: 100%;
+    width: 100%;
   }
 }
 

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -2654,7 +2654,7 @@ This makes the last element of the last list item in the
 display panel have the rounded bottom edge
 The alternative to this is to have Vue bind a class to the last element
 */
-#display-panel > *:last-child > *:last-child > *:last-child {
+#display-panel > *:last-child > *:last-child {
   border-bottom-left-radius: 5px;
   border-bottom-right-radius: 5px;
 }

--- a/research-app/src/CatalogItem.vue
+++ b/research-app/src/CatalogItem.vue
@@ -16,9 +16,6 @@
         >{{ catalog.name }}</label
       >
       <span id="buttons-container">
-        <a href="#" v-hide="!hasFocus" @click="handleDelete" class="icon-link"
-          ><font-awesome-icon class="icon" icon="times"
-        /></a>
         <a href="#" v-hide="!hasFocus" @click="handleToggle" class="icon-link"
           ><font-awesome-icon
             v-if="visible"
@@ -27,6 +24,9 @@
             v-if="!visible"
             class="icon"
             icon="eye-slash"
+        /></a>
+        <a href="#" v-hide="!hasFocus" @click="handleDelete" class="icon-link"
+          ><font-awesome-icon class="icon" icon="times"
         /></a>
       </span>
     </div>
@@ -345,11 +345,12 @@ export default class CatalogItem extends Vue {
 #main-container {
   width: calc(100% - 10px);
   padding: 5px;
+  display: flex;
+  justify-content: space-around;
 }
 
 #name-label {
   display: inline-block;
-  width: 75%;
   vertical-align: middle;
 
   &:hover {
@@ -358,7 +359,9 @@ export default class CatalogItem extends Vue {
 }
 
 #buttons-container {
-  width: 25%;
+  align-self: flex-end;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .circle-popover {
@@ -378,17 +381,19 @@ export default class CatalogItem extends Vue {
 .icon {
   color: white;
   margin: auto 1%;
-  float: right;
 }
 
 .icon-link {
   height: 100%;
-  background: #404040;
+  background: inherit;
+  margin-left: 5px;
+  margin-right: 5px;
 }
 
 .icon-button {
   cursor: pointer;
   display: inline-block;
+  background: inherit;
 }
 
 .prompt {
@@ -403,6 +408,7 @@ export default class CatalogItem extends Vue {
   // Get nice vertical alignment in individual rows
   display: flex;
   align-items: center;
+  width: 100%;
 }
 
 .ellipsize {
@@ -415,10 +421,11 @@ export default class CatalogItem extends Vue {
   display: inline-flex;
   flex-flow: row nowrap;
   align-items: center;
+  flex: 50%;
 }
 
 .scale-factor-input {
-  flex: 1;
+  width: 50%;
   text-align: center;
 }
 

--- a/research-app/src/CatalogItem.vue
+++ b/research-app/src/CatalogItem.vue
@@ -346,7 +346,7 @@ export default class CatalogItem extends Vue {
   width: calc(100% - 10px);
   padding: 5px;
   display: flex;
-  justify-content: space-around;
+  justify-content: space-between;
 }
 
 #name-label {
@@ -386,8 +386,8 @@ export default class CatalogItem extends Vue {
 .icon-link {
   height: 100%;
   background: inherit;
-  margin-left: 5px;
-  margin-right: 5px;
+  margin-left: 3px;
+  margin-right: 3px;
 }
 
 .icon-button {

--- a/research-app/src/SourceItem.vue
+++ b/research-app/src/SourceItem.vue
@@ -254,12 +254,6 @@ a:visited {
   color: lightcoral;
 }
 
-.ellipsize {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .detail-container {
   font-size: 9pt;
   margin: 0px 5px;

--- a/tests/page_objects/researchApp.ts
+++ b/tests/page_objects/researchApp.ts
@@ -136,7 +136,7 @@ module.exports = {
           selector: ".vs__dropdown-option > div > h4"
         },
         backgroundDropdownOptionDescription: {
-          selector: ".vs__dropdown-option > div > em"
+          selector: ".vs__dropdown-option > div > p"
         },
         catalogSelectionContainer: {
           selector: "#catalog-select-container-tool"
@@ -157,7 +157,7 @@ module.exports = {
           selector: ".vs__dropdown-option > div > h4"
         },
         catalogDropdownOptionDescription: {
-          selector: ".vs__dropdown-option > div > em"
+          selector: ".vs__dropdown-option > div > p"
         },
       },
       props: {


### PR DESCRIPTION
This PR contains a few small UI updates to the research app. I'm still working on adjusting the overall UI layout based in response to screen size, but I can see that requiring some discussion and iteration, so I'm thinking that can go in its own PR.

The changes in this PR are:

- Retain the `border-radius` of the bottom item in the display panel when it's highlighted. Currently, when the bottom item is highlighted, its bottom corners return to being rectangular. I suspect that the structure in the panel items in the panel changed at some point and the CSS hadn't been updated to match.
- Ellipsize the items in the dropdown selectors to avoid horizontal scrolling in the dropdowns, as well as the selected items (i.e. for the backgrounds and imagery layers).
- Change the container with the labels and buttons in the catalog item to use a flexbox-based layout. If we like this layout, I can change the other display panel items to use the same setup.