### PR TITLE
Research app display panel UI

### DIFF
--- a/research-app/src/CatalogItem.vue
+++ b/research-app/src/CatalogItem.vue
@@ -1,11 +1,13 @@
 <template>
-  <div id="root-container">
+  <div
+    id="root-container"
+    @mouseenter="hasFocus = true"
+    @mouseleave="hasFocus = false"
+    @focus="hasFocus = true"
+    @blur="hasFocus = false"
+  >
     <div
       id="main-container"
-      @mouseenter="hasFocus = true"
-      @mouseleave="hasFocus = false"
-      @focus="hasFocus = true"
-      @blur="hasFocus = false"
     >
       <label
         focusable="false"
@@ -13,22 +15,20 @@
         class="ellipsize"
         @click="isSelected = !isSelected"
         @keyup.enter="isSelected = !isSelected"
-        >{{ catalog.name }}</label
-      >
-      <span id="buttons-container">
-        <a href="#" v-hide="!hasFocus" @click="handleToggle" class="icon-link"
-          ><font-awesome-icon
-            v-if="visible"
-            class="icon"
-            icon="eye" /><font-awesome-icon
-            v-if="!visible"
-            class="icon"
-            icon="eye-slash"
-        /></a>
-        <a href="#" v-hide="!hasFocus" @click="handleDelete" class="icon-link"
-          ><font-awesome-icon class="icon" icon="times"
-        /></a>
-      </span>
+        >{{ catalog.name }}
+      </label>
+      <font-awesome-icon
+        v-hide="!hasFocus"
+        class="icon-button"
+        :icon="visible ? 'eye' : 'eye-slash'"
+        @click="handleToggle"
+      />
+      <font-awesome-icon
+        v-hide="!hasFocus"
+        class="icon-button"
+        icon="times"
+        @click="handleDelete"
+      />
     </div>
     <transition-expand>
       <div v-if="isSelected" class="detail-container">
@@ -78,7 +78,7 @@
           <span class="prompt">Size adjust:</span>
           <div class="flex-row">
             <font-awesome-icon
-              class="icon icon-button"
+              class="icon-button"
               size="lg"
               icon="minus-circle"
               @keyup.enter="doAdjustSize(false)"
@@ -91,7 +91,7 @@
               v-model.lazy="scaleFactorDbText"
             />
             <font-awesome-icon
-              class="icon icon-button"
+              class="icon-button"
               size="lg"
               icon="plus-circle"
               @keyup.enter="doAdjustSize(true)"
@@ -347,21 +347,17 @@ export default class CatalogItem extends Vue {
   padding: 5px;
   display: flex;
   justify-content: space-between;
+  gap: 2px;
 }
 
 #name-label {
   display: inline-block;
-  vertical-align: middle;
+  flex: 1;
+  padding-right: 10px;
 
   &:hover {
     cursor: pointer;
   }
-}
-
-#buttons-container {
-  align-self: flex-end;
-  display: flex;
-  justify-content: flex-end;
 }
 
 .circle-popover {
@@ -378,22 +374,10 @@ export default class CatalogItem extends Vue {
   padding-left: 15px;
 }
 
-.icon {
-  color: white;
-  margin: auto 1%;
-}
-
-.icon-link {
-  height: 100%;
-  background: inherit;
-  margin-left: 3px;
-  margin-right: 3px;
-}
-
 .icon-button {
   cursor: pointer;
-  display: inline-block;
-  background: inherit;
+  margin: 2px;
+  width: 1em;
 }
 
 .prompt {
@@ -409,12 +393,6 @@ export default class CatalogItem extends Vue {
   display: flex;
   align-items: center;
   width: 100%;
-}
-
-.ellipsize {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .flex-row {

--- a/research-app/src/ImagesetItem.vue
+++ b/research-app/src/ImagesetItem.vue
@@ -510,12 +510,6 @@ export default class ImagesetItem extends Vue {
   gap: 2px;
 }
 
-.ellipsize {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .scrubber {
   flex: 1;
   cursor: pointer;

--- a/research-app/src/ImagesetItem.vue
+++ b/research-app/src/ImagesetItem.vue
@@ -1,11 +1,13 @@
 <template>
-  <div id="root-container">
+  <div
+    id="root-container"
+    @mouseenter="hasFocus = true"
+    @mouseleave="hasFocus = false"
+    @focus="hasFocus = true"
+    @blur="hasFocus = false"
+  >
     <div
       id="main-container"
-      @mouseenter="hasFocus = true"
-      @mouseleave="hasFocus = false"
-      @focus="hasFocus = true"
-      @blur="hasFocus = false"
     >
       <label
         focusable="false"
@@ -13,8 +15,8 @@
         class="ellipsize"
         @click="isSelected = !isSelected"
         @keyup.enter="isSelected = !isSelected"
-        >{{ imageset.settings.name }}</label
-      >
+        >{{ imageset.settings.name }}
+      </label>
       <font-awesome-icon
         v-hide="!hasFocus"
         class="icon-button"
@@ -474,6 +476,7 @@ export default class ImagesetItem extends Vue {
 #name-label {
   display: inline-block;
   flex: 1;
+  padding-right: 10px;
 
   &:hover {
     cursor: pointer;

--- a/research-app/src/SourceItem.vue
+++ b/research-app/src/SourceItem.vue
@@ -1,42 +1,45 @@
 <template>
-  <div id="root-container">
+  <div
+    id="root-container"
+    @mouseenter="hasFocus = true"
+    @mouseleave="hasFocus = false"
+    @focus="hasFocus = true"
+    @blur="hasFocus = false"
+  >
     <div
       id="main-container"
-      @mouseenter="hasFocus = true"
-      @mouseleave="hasFocus = false"
-      @focus="hasFocus = true"
-      @blur="hasFocus = false"
     >
       <label
         v-show="!editing"
         focusable="false"
-        class="name-label ellipsize"
+        id="name-label"
+        class="ellipsize"
         @click="isSelected = !isSelected"
         @keyup.enter="isSelected = !isSelected"
-        >{{ source.name }}</label
-      >
-      <input v-show="editing" class="name-input" @blur="editing = false" />
-      <span id="buttons-container">
-        <a href="#" v-hide="!hasFocus" @click="handleDelete" class="icon-link"
-          ><font-awesome-icon class="icon" icon="times"
-        /></a>
-        <a
-          href="#"
-          v-hide="!hasFocus"
-          @click="handleMarkerClick"
-          class="icon-link"
-          ><font-awesome-icon class="icon" icon="map-marker-alt"
-        /></a>
-        <a
-          href="#"
-          v-hide="!hasFocus"
-          @click="handleEditClick"
-          class="icon-link"
-          ><font-awesome-icon
-            :class="['icon', { 'icon-active': editing }]"
-            icon="pencil-alt"
-        /></a>
-      </span>
+        >{{ source.name }}
+      </label>
+      <input
+        v-show="editing"
+        class="name-input"
+        @blur="editing = false" />
+      <font-awesome-icon
+        v-hide="!hasFocus"
+        :class="['icon-button', { 'icon-active': editing }]"
+        icon="pencil-alt"
+        @click="handleEditClick"
+      />
+      <font-awesome-icon
+        v-hide="!hasFocus"
+        class="icon-button"
+        icon="map-marker-alt"
+        @click='handleMarkerClick'
+      />
+      <font-awesome-icon
+        v-hide="!hasFocus"
+        class="icon-button"
+        icon="times"
+        @click="handleDelete"
+      />
     </div>
     <transition-expand>
       <div v-if="isSelected" class="detail-container">
@@ -225,12 +228,15 @@ export default class SourceItem extends Vue {
 #main-container {
   width: calc(100% - 10px);
   padding: 5px;
+  display: flex;
+  justify-content: space-between;
+  gap: 2px;
 }
 
-.name-label {
+#name-label {
   display: inline-block;
-  width: 62%;
-  vertical-align: middle;
+  flex: 1;
+  padding-right: 10px;
 
   &:hover {
     cursor: pointer;
@@ -240,10 +246,7 @@ export default class SourceItem extends Vue {
 .name-input {
   display: inline-block;
   background: #999999;
-}
-
-#buttons-container {
-  width: 38%;
+  flex: 1;
 }
 
 a {
@@ -260,18 +263,14 @@ a:visited {
   padding-left: 15px;
 }
 
-.icon {
-  color: white;
-  margin: auto 1%;
-  float: right;
+.icon-button {
+  cursor: pointer;
+  margin: 2px;
+  width: 1em;
 }
 
 .icon-active {
   color: darkred;
-}
-
-.icon-link {
-  height: 100%;
 }
 
 .prompt {

--- a/tests/page_objects/researchApp.ts
+++ b/tests/page_objects/researchApp.ts
@@ -73,14 +73,11 @@ module.exports = {
         catalogTitle: {
           selector: "#catalogs-container #name-label"
         },
-        catalogButtonContainer: {
-          selector: "#catalogs-container #buttons-container"
-        },
         catalogVisibilityButton: {
-          selector: "#catalogs-container #buttons-container .fa-eye, #catalogs-container #buttons-container .fa-eye-slash"
+          selector: "#catalogs-container .fa-eye"
         },
         catalogDeleteButton: {
-          selector: "#catalogs-container #buttons-container .fa-times"
+          selector: "#catalogs-container .fa-times"
         },
       },
       props: {
@@ -161,7 +158,7 @@ module.exports = {
         },
       },
       props: {
-        backgroundOptionCount: 832,
+        backgroundOptionCount: 834,
         catalogOptionCount: 49,
         firstBackgroundName: "Digitized Sky Survey (Color)",
         firstBackgroundDescription: "Copyright DSS Consortium",

--- a/tests/page_objects/researchApp.ts
+++ b/tests/page_objects/researchApp.ts
@@ -163,7 +163,8 @@ module.exports = {
         firstBackgroundName: "Digitized Sky Survey (Color)",
         firstBackgroundDescription: "Copyright DSS Consortium",
         firstCatalogName: "The DENIS database (DENIS Consortium, 2005) (denis)",
+        firstCatalogRegex: /^The DENIS database \(DENIS Consortium, 2005\) \(denis\)(\s+)?/
       },
-    }
+    },
   }
 }

--- a/tests/research_app/basic_test.ts
+++ b/tests/research_app/basic_test.ts
@@ -146,7 +146,7 @@ const tests = {
         ];
         displayPanel.expect.elements("@catalogItem").count.to.equal(1);
         utils.expectAllPresent(displayPanel, firstCatalogButtons);
-        displayPanel.expect.element(firstCatalogTitle).text.to.equal(tools.props.firstCatalogName);
+        displayPanel.expect.element(firstCatalogTitle).text.to.match(tools.props.firstCatalogRegex);
 
         // To start, the visibility and delete button should not be visible
         utils.expectAllNotVisible(displayPanel, firstCatalogButtons);

--- a/tests/research_app/basic_test.ts
+++ b/tests/research_app/basic_test.ts
@@ -140,8 +140,10 @@ const tests = {
         // Check that the catalog displays in the panel
         // with the correct name
         const firstCatalogTitle = utils.nthOfTypeSelector("@catalogTitle", 1);
-        const firstCatalogButtons: string[] = ["@catalogVisibilityButton", "@catalogDeleteButton"]
-            .map(selector => utils.nthOfTypeSelector(selector, 1));
+        const firstCatalogButtons: string[] = [
+            utils.nthOfTypeSelector("@catalogVisibilityButton", 1),
+            utils.nthOfTypeSelector("@catalogDeleteButton", 2),
+        ];
         displayPanel.expect.elements("@catalogItem").count.to.equal(1);
         utils.expectAllPresent(displayPanel, firstCatalogButtons);
         displayPanel.expect.element(firstCatalogTitle).text.to.equal(tools.props.firstCatalogName);


### PR DESCRIPTION
This PR changes the source entries in the display panel to use a flexbox-based layout to match the catalog and imageset containers. Additionally, using `ImagesetItem` as the base, I made the buttons have uniform size and spacing across all of the containers.