### PR TITLE
Allow UI manipulation and selection of general table layers

### DIFF
--- a/engine-vuex/src/index.ts
+++ b/engine-vuex/src/index.ts
@@ -7,6 +7,7 @@ import { Store } from "vuex/types";
 export { SetupForImagesetOptions } from "@wwtelescope/engine-helpers";
 
 export {
+  CatalogLayerInfo,
   CreateTableLayerParams,
   GotoRADecZoomParams,
   ImagesetInfo,

--- a/engine-vuex/src/index.ts
+++ b/engine-vuex/src/index.ts
@@ -11,7 +11,6 @@ export {
   GotoRADecZoomParams,
   ImagesetInfo,
   ImageSetLayerState,
-  isImageSetInfo,
   LoadImageCollectionParams,
   LoadTourParams,
   SpreadSheetLayerInfo,

--- a/engine-vuex/src/index.ts
+++ b/engine-vuex/src/index.ts
@@ -11,8 +11,10 @@ export {
   GotoRADecZoomParams,
   ImagesetInfo,
   ImageSetLayerState,
+  isImageSetInfo,
   LoadImageCollectionParams,
   LoadTourParams,
+  SpreadSheetLayerInfo,
   WWTEngineVuexModule,
   WWTEngineVuexState,
 } from "./store";

--- a/engine-vuex/src/store.ts
+++ b/engine-vuex/src/store.ts
@@ -117,6 +117,35 @@ export class ImagesetInfo {
   }
 }
 
+export function isImageSetInfo(o: any): o is ImagesetInfo { // eslint-disable-line @typescript-eslint/no-explicit-any
+  return typeof o.url === 'string'
+      && typeof o.name === 'string'
+      && typeof o.type === 'number'
+      && typeof o.description === 'string'
+      && typeof o.extension === 'string';
+}
+
+export class SpreadSheetLayerInfo {
+  /* The user-facing name of the layer */
+  name: string;
+
+  /* The internal GUID of the layer */
+  id: string;
+
+  /* The reference frame in which the data are defined. */
+  referenceFrame: string;
+
+  setName(name: string) {
+    this.name = name;
+  }
+
+  constructor(id: string, referenceFrame: string, name?: string) {
+    this.id = id;
+    this.referenceFrame = referenceFrame;
+    this.name = name ?? id;
+  }
+}
+
 /** Information about an active imageset layer. */
 export class ImageSetLayerState {
   /** Layer parameters exposed in WWT's generic "settings" system.
@@ -1004,6 +1033,21 @@ export class WWTEngineVuexModule extends VuexModule implements WWTEngineVuexStat
     }
   }
 
+  get spreadSheetLayerById() {
+    return function(id: string): SpreadSheetLayer | null {
+      if (Vue.$wwt.inst === null)
+        throw new Error('cannot get spreadSheetLayerById without linking to WWTInstance');
+
+      const layer = Vue.$wwt.inst.lm.get_layerList()[id];
+
+      if (layer !== null && layer instanceof SpreadSheetLayer) {
+        return layer;
+      } else {
+        return null;
+      }
+    }
+  }
+
   get spreadsheetStateForHipsCatalog() {
     return (name: string): SpreadSheetLayerSettingsInterfaceRO | null => {
       if (Vue.$wwt.inst === null)
@@ -1011,6 +1055,15 @@ export class WWTEngineVuexModule extends VuexModule implements WWTEngineVuexStat
 
       // NOTE: hack as described above -- the name is the GUID.
       return this.spreadSheetLayers[name] || null;
+    }
+  }
+
+  get spreadsheetState() {
+    return (id: string): SpreadSheetLayerSettingsInterfaceRO | null => {
+      if (Vue.$wwt.inst === null)
+        throw new Error('cannot get spreadsheetState without linking to WWTInstance');
+
+      return this.spreadSheetLayers[id] || null;
     }
   }
 

--- a/engine-vuex/src/store.ts
+++ b/engine-vuex/src/store.ts
@@ -117,14 +117,6 @@ export class ImagesetInfo {
   }
 }
 
-export function isImageSetInfo(o: any): o is ImagesetInfo { // eslint-disable-line @typescript-eslint/no-explicit-any
-  return typeof o.url === 'string'
-      && typeof o.name === 'string'
-      && typeof o.type === 'number'
-      && typeof o.description === 'string'
-      && typeof o.extension === 'string';
-}
-
 export class SpreadSheetLayerInfo {
   /* The user-facing name of the layer */
   name: string;

--- a/engine-vuex/src/wwtaware.ts
+++ b/engine-vuex/src/wwtaware.ts
@@ -38,6 +38,7 @@ import {
 } from "@wwtelescope/engine-helpers";
 
 import {
+  CatalogLayerInfo,
   CreateTableLayerParams,
   GotoRADecZoomParams,
   ImagesetInfo,
@@ -332,7 +333,9 @@ export class WWTAwareComponent extends Vue {
         "layerForHipsCatalog",
         "lookupImageset",
         "spreadSheetLayerById",
+        "spreadSheetLayer",
         "spreadsheetState",
+        "spreadsheetStateById",
         "spreadsheetStateForHipsCatalog",
       ]),
       ...this.$options.computed,
@@ -615,6 +618,18 @@ export class WWTAwareComponent extends Vue {
    */
   layerForHipsCatalog!: (name: string) => SpreadSheetLayer | null;
 
+  /** Get the actual WWT `SpreadSheetLayer` for the table layer corresponding
+   * to the given CatalogLayerInfo.
+   *
+   * Do not use this function for UI purposes -- the WWT layer object is not
+   * integrated into the reactive state system, and so if you use it as a basis
+   * for UI elements, those elements will not be updated properly if/when the
+   * layer's settings change. Use [[spreadsheetState]] instead.
+   *
+   * @param id The table layer's identifier.
+   */
+  spreadSheetLayer!: (catalog: CatalogLayerInfo) => SpreadSheetLayer | null;
+
   // Mutations
 
   /** Add an [Annotation](../../engine/classes/annotation.html) to the view. */
@@ -755,7 +770,7 @@ export class WWTAwareComponent extends Vue {
    *
    * @param id The identifier of the table layer.
    */
-  spreadsheetState!: (id: string) => SpreadSheetLayerSettingsInterfaceRO | null;
+  spreadsheetStateById!: (id: string) => SpreadSheetLayerSettingsInterfaceRO | null;
 
   /** Get reactive `SpreadSheetLayer` settings for the named HiPS catalog.
    *
@@ -767,6 +782,18 @@ export class WWTAwareComponent extends Vue {
    * @param name The `datasetName` of the HiPS catalog
    */
   spreadsheetStateForHipsCatalog!: (name: string) => SpreadSheetLayerSettingsInterfaceRO | null;
+
+  /** Get reactive `SpreadSheetLayer` settings for the table layer corresponding to 
+   * the given CatalogLayerInfo.
+   *
+   * The returned data structure is a component of the app's Vuex state. You can
+   * therefore use the settings to construct UI elements, and they will update
+   * reactively as the state evolves. The actual data structures used by WWT are
+   * separate, but the two mirror each other.
+   *
+   * @param catalog A CatalogLayerInfo object corresponding to the layer.
+   */
+    spreadsheetState!: (catalog: CatalogLayerInfo) => SpreadSheetLayerSettingsInterfaceRO | null;
 
   /** Start playback of the currently loaded tour.
    *

--- a/engine-vuex/src/wwtaware.ts
+++ b/engine-vuex/src/wwtaware.ts
@@ -331,6 +331,8 @@ export class WWTAwareComponent extends Vue {
         "imagesetStateForLayer",
         "layerForHipsCatalog",
         "lookupImageset",
+        "spreadSheetLayerById",
+        "spreadsheetState",
         "spreadsheetStateForHipsCatalog",
       ]),
       ...this.$options.computed,
@@ -591,6 +593,17 @@ export class WWTAwareComponent extends Vue {
   /** Get the right ascension and declination, in degrees, for x, y coordinates on the screen */
   findRADecForScreenPoint!: (pt: { x: number; y: number }) => { ra: number; dec: number };
 
+  /** Get the actual WWT `SpreadSheetLayer` for the table layer with the given ID.
+   *
+   * Do not use this function for UI purposes -- the WWT layer object is not
+   * integrated into the reactive state system, and so if you use it as a basis
+   * for UI elements, those elements will not be updated properly if/when the
+   * layer's settings change. Use [[spreadsheetState]] instead.
+   *
+   * @param id The table layer's identifier.
+   */
+  spreadSheetLayerById!: (id: string) => SpreadSheetLayer | null;
+
   /** Get the actual WWT `SpreadSheetLayer` for the named HiPS catalog.
    *
    * Do not use this function for UI purposes -- the WWT layer object is not
@@ -732,6 +745,17 @@ export class WWTAwareComponent extends Vue {
    * want to show.
    */
   setupForImageset!: (o: SetupForImagesetOptions) => void;
+
+    /** Get reactive `SpreadSheetLayer` settings for the table layer with the given ID.
+   *
+   * The returned data structure is a component of the app's Vuex state. You can
+   * therefore use the settings to construct UI elements, and they will update
+   * reactively as the state evolves. The actual data structures used by WWT are
+   * separate, but the two mirror each other.
+   *
+   * @param id The identifier of the table layer.
+   */
+  spreadsheetState!: (id: string) => SpreadSheetLayerSettingsInterfaceRO | null;
 
   /** Get reactive `SpreadSheetLayer` settings for the named HiPS catalog.
    *

--- a/research-app-messages/src/selections.ts
+++ b/research-app-messages/src/selections.ts
@@ -1,3 +1,57 @@
+export enum ImageSetType {
+  earth = 0,
+  planet = 1,
+  sky = 2,
+  panorama = 3,
+  solarSystem = 4,
+  sandbox = 5
+}
+
+/** This class holds basic information about an imageset.
+ *
+ * Discover imagesets through the [[WWTAwareComponent.wwtAvailableImagesets]]
+ * state variable. In standard practice there will be hundreds of available
+ * imagesets of many different kinds.
+ *
+ * Imagesets may be uniquely identified by their associated image data [[url]].
+ * (If you really need to have multiple imagesets associated with the same URL,
+ * add a `#fragment` to the end.)
+ */
+ export interface ImagesetInfo {
+  /** The URL of the image data. */
+  url: string;
+
+  /** The user-facing name of the imageset. */
+  name: string;
+
+  /** The type of the imageset: panorama, sky, ... */
+  type: ImageSetType;
+
+  /** An (application-specific) string giving some additional information about
+   * the imageset. */
+  description: string;
+
+  /** The image filename extension(s) associated with this imageset.
+   *
+   * May include multiple extensions separated by spaces. May also start with a
+   * leading period.
+   */
+  extension: string;
+}
+
+export interface SpreadSheetLayerInfo {
+  /* The user-facing name of the layer */
+  name: string;
+
+  /* The internal GUID of the layer */
+  id: string;
+
+  /* The reference frame in which the data are defined. */
+  referenceFrame: string;
+}
+
+export type LayerInfo = SpreadSheetLayerInfo | ImagesetInfo;
+
 /**
  * Information about a selected source in the engine.
  * The values for right ascension and declination are given in radians.
@@ -8,9 +62,9 @@ export interface Source {
   ra: number;
   dec: number;
   name: string;
-  catalogName: string;
+  layer: LayerInfo;
   zoomDeg?: number;
-  catalogData: {
+  layerData: {
     [field: string]: string | undefined;
   };
 }

--- a/research-app-messages/src/selections.ts
+++ b/research-app-messages/src/selections.ts
@@ -44,7 +44,7 @@ export interface SpreadSheetLayerInfo {
   referenceFrame: string;
 }
 
-export type LayerInfo = SpreadSheetLayerInfo | ImagesetInfo;
+export type CatalogLayerInfo = SpreadSheetLayerInfo | ImagesetInfo;
 
 /**
  * Information about a selected source in the engine.
@@ -56,7 +56,7 @@ export interface Source {
   ra: number;
   dec: number;
   name: string;
-  layer: LayerInfo;
+  layer: CatalogLayerInfo;
   zoomDeg?: number;
   layerData: {
     [field: string]: string | undefined;

--- a/research-app-messages/src/selections.ts
+++ b/research-app-messages/src/selections.ts
@@ -1,11 +1,5 @@
-export enum ImageSetType {
-  earth = 0,
-  planet = 1,
-  sky = 2,
-  panorama = 3,
-  solarSystem = 4,
-  sandbox = 5
-}
+export const ImageSetTypes = ["earth", "planet", "sky", "panorama", "solarSystem", "sandbox"] as const;
+export type ImageSetType = (typeof ImageSetTypes)[number];
 
 /** This class holds basic information about an imageset.
  *

--- a/research-app-messages/src/selections.ts
+++ b/research-app-messages/src/selections.ts
@@ -49,14 +49,21 @@ export type CatalogLayerInfo = SpreadSheetLayerInfo | ImagesetInfo;
 /**
  * Information about a selected source in the engine.
  * The values for right ascension and declination are given in radians.
- * `catalogName` gives the name of the associated HiPS catalog,
- * while `name` gives a string name for the source.
+ * `name` gives a string name for the source.
+ * `catalogLayer` contains information about the layer, which varies
+ * based on the layer type.
+ * For a standard spreadsheet layer, see [[SpreadSheetLayerInfo]]
+ * For a HiPS catalog, see [[ImagesetInfo]].
+ * `layerData` contains all of the associated data for the source, 
+ * which will depends on the contents of the particular catalog.
+ * `zoomDeg`, if present, defines the FOV, in degrees, that WWT will
+ * use when moving to the source.
  */
 export interface Source {
   ra: number;
   dec: number;
   name: string;
-  layer: CatalogLayerInfo;
+  catalogLayer: CatalogLayerInfo;
   zoomDeg?: number;
   layerData: {
     [field: string]: string | undefined;

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -1891,6 +1891,23 @@ export default class App extends WWTAwareComponent {
     this.addHips(catalog);
   }
 
+  prepareForMessaging(source: Source): selections.Source {
+    let layer: selections.LayerInfo;
+    if (source.layer instanceof ImagesetInfo) {
+      layer = {
+        ...source.layer,
+        type: selections.ImageSetTypes[source.layer.type]
+      };
+    } else {
+      layer = source.layer;
+    }
+
+    return {
+      ...source,
+      layer: layer,
+    };
+  }
+
   @Watch("curAvailableCatalogs")
   onAvailableCatalogsChanged(catalogs: ImagesetInfo[]) {
     // Notify clients about the new catalogs
@@ -1917,7 +1934,7 @@ export default class App extends WWTAwareComponent {
     const msg: selections.SelectionStateMessage = {
       type: "wwt_selection_state",
       sessionId: this.statusMessageSessionId,
-      mostRecentSource: source,
+      mostRecentSource: this.prepareForMessaging(source),
     };
 
     this.statusMessageDestination.postMessage(msg, this.allowedOrigin);
@@ -1935,7 +1952,7 @@ export default class App extends WWTAwareComponent {
     const msg: selections.SelectionStateMessage = {
       type: "wwt_selection_state",
       sessionId: this.statusMessageSessionId,
-      selectedSources: sources,
+      selectedSources: sources.map(source => this.prepareForMessaging(source)),
     };
 
     this.statusMessageDestination.postMessage(msg, this.allowedOrigin);

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -341,7 +341,7 @@ import {
   isPolyLineAnnotationSetting,
 } from "@wwtelescope/engine-helpers";
 
-import { WWTAwareComponent, ImagesetInfo, isImageSetInfo, SpreadSheetLayerInfo } from "@wwtelescope/engine-vuex";
+import { WWTAwareComponent, ImagesetInfo, SpreadSheetLayerInfo } from "@wwtelescope/engine-vuex";
 
 import {
   classicPywwt,
@@ -2201,7 +2201,7 @@ export default class App extends WWTAwareComponent {
     for (const layerInfo of this.visibleTableLayers()) {
 
       let layer: SpreadSheetLayer | null = null;
-      if (isImageSetInfo(layerInfo)) {
+      if (layerInfo instanceof ImagesetInfo) {
         layer = this.layerForHipsCatalog(layerInfo.name);
       } else {
         layer = this.spreadSheetLayerById(layerInfo.id);

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -1010,7 +1010,7 @@ export default class App extends WWTAwareComponent {
 
   // From the store
   catalogNameMappings!: { [catalogName: string]: [string, string] };
-  layers!: CatalogLayerInfo[];
+  appTableLayers!: CatalogLayerInfo[];
   sources!: Source[];
 
   addResearchAppTableLayer!: (layer: CatalogLayerInfo) => void;
@@ -1025,7 +1025,7 @@ export default class App extends WWTAwareComponent {
       ...mapState(wwtResearchAppNamespace, {
         catalogNameMappings: (state, _getters) =>
           (state as WWTResearchAppModule).catalogNameMappings,
-        layers: (_state, getters) => getters["tableLayers"](),
+        appTableLayers: (_state, getters) => getters["tableLayers"](),
         sources: (state, _getters) => (state as WWTResearchAppModule).sources,
       }),
       ...mapGetters(wwtResearchAppNamespace, ["visibleTableLayers"]),
@@ -1416,7 +1416,7 @@ export default class App extends WWTAwareComponent {
   }
 
   wwtOnMouseMove(event: MouseEvent) {
-    if (this.layers.length == 0) {
+    if (this.appTableLayers.length == 0) {
       return;
     }
     const pt = { x: event.offsetX, y: event.offsetY };
@@ -2089,7 +2089,7 @@ export default class App extends WWTAwareComponent {
   }
 
   get haveTableLayers() {
-    return this.layers.length > 0;
+    return this.appTableLayers.length > 0;
   }
 
   get haveSources() {

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -312,7 +312,7 @@ import { mapGetters, mapMutations, mapState } from "vuex";
 
 import { distance, fmtDegLat, fmtDegLon, fmtHours } from "@wwtelescope/astro";
 
-import { CatalogLayerInfo, Source, WWTResearchAppModule } from "./store";
+import { Source, WWTResearchAppModule } from "./store";
 import { wwtEngineNamespace, wwtResearchAppNamespace } from "./namespaces";
 
 import { ImageSetType, SolarSystemObjects } from "@wwtelescope/engine-types";
@@ -341,7 +341,7 @@ import {
   isPolyLineAnnotationSetting,
 } from "@wwtelescope/engine-helpers";
 
-import { WWTAwareComponent, ImagesetInfo, SpreadSheetLayerInfo } from "@wwtelescope/engine-vuex";
+import { WWTAwareComponent, CatalogLayerInfo, ImagesetInfo, SpreadSheetLayerInfo } from "@wwtelescope/engine-vuex";
 
 import {
   classicPywwt,
@@ -2218,13 +2218,7 @@ export default class App extends WWTAwareComponent {
 
     for (const layerInfo of this.visibleTableLayers()) {
 
-      let layer: SpreadSheetLayer | null = null;
-      if (layerInfo instanceof ImagesetInfo) {
-        layer = this.layerForHipsCatalog(layerInfo.name);
-      } else {
-        layer = this.spreadSheetLayerById(layerInfo.id);
-      }
-
+      let layer = this.spreadSheetLayer(layerInfo);
       if (layer == null) {
         continue;
       }

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -31,7 +31,7 @@
           <label>Data Tables</label>
         </div>
         <spreadsheet-item
-          v-for="layer of appTableLayers"
+          v-for="layer of spreadsheetLayers"
           v-bind:key="layer.name"
           v-bind:layer="layer"
           v-bind:defaultColor="defaultColor"
@@ -1010,7 +1010,7 @@ export default class App extends WWTAwareComponent {
 
   // From the store
   catalogNameMappings!: { [catalogName: string]: [string, string] };
-  appTableLayers!: CatalogLayerInfo[];
+  spreadsheetLayers!: CatalogLayerInfo[];
   sources!: Source[];
 
   addResearchAppTableLayer!: (layer: CatalogLayerInfo) => void;
@@ -1025,7 +1025,7 @@ export default class App extends WWTAwareComponent {
       ...mapState(wwtResearchAppNamespace, {
         catalogNameMappings: (state, _getters) =>
           (state as WWTResearchAppModule).catalogNameMappings,
-        appTableLayers: (_state, getters) => getters["tableLayers"](),
+        spreadsheetLayers: (_state, getters) => getters["tableLayers"](),
         sources: (state, _getters) => (state as WWTResearchAppModule).sources,
       }),
       ...mapGetters(wwtResearchAppNamespace, ["visibleTableLayers"]),
@@ -1416,7 +1416,7 @@ export default class App extends WWTAwareComponent {
   }
 
   wwtOnMouseMove(event: MouseEvent) {
-    if (this.appTableLayers.length == 0) {
+    if (this.spreadsheetLayers.length == 0) {
       return;
     }
     const pt = { x: event.offsetX, y: event.offsetY };
@@ -2089,7 +2089,7 @@ export default class App extends WWTAwareComponent {
   }
 
   get haveTableLayers() {
-    return this.appTableLayers.length > 0;
+    return this.spreadsheetLayers.length > 0;
   }
 
   get haveSources() {

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -31,7 +31,7 @@
           <label>Data Tables</label>
         </div>
         <spreadsheet-item
-          v-for="layer of layers"
+          v-for="layer of appTableLayers"
           v-bind:key="layer.name"
           v-bind:layer="layer"
           v-bind:defaultColor="defaultColor"

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -28,7 +28,7 @@
       </div>
       <div id="spreadsheets-container" v-if="haveTableLayers">
         <div class="display-section-header">
-          <label>Catalogs and Spreadsheets</label>
+          <label>Data Tables</label>
         </div>
         <spreadsheet-item
           v-for="layer of layers"

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -962,7 +962,7 @@ interface AngleCoordinates {
 interface RawSourceInfo {
   ra: number;
   dec: number;
-  layer: CatalogLayerInfo;
+  catalogLayer: CatalogLayerInfo;
   colNames: string[];
   values: string[];
 }
@@ -1476,9 +1476,9 @@ export default class App extends WWTAwareComponent {
     return {
       ra: sourceInfo.ra,
       dec: sourceInfo.dec,
-      layer: sourceInfo.layer,
+      catalogLayer: sourceInfo.catalogLayer,
       layerData: obj,
-      name: this.nameForSource(obj, sourceInfo.layer.name),
+      name: this.nameForSource(obj, sourceInfo.catalogLayer.name),
     };
   }
 
@@ -1893,18 +1893,19 @@ export default class App extends WWTAwareComponent {
 
   prepareForMessaging(source: Source): selections.Source {
     let layer: selections.CatalogLayerInfo;
-    if (source.layer instanceof ImagesetInfo) {
+    const sourceLayer = source.catalogLayer;
+    if (sourceLayer instanceof ImagesetInfo) {
       layer = {
-        ...source.layer,
-        type: selections.ImageSetTypes[source.layer.type]
+        ...sourceLayer,
+        type: selections.ImageSetTypes[sourceLayer.type]
       };
     } else {
-      layer = source.layer;
+      layer = sourceLayer;
     }
 
     return {
       ...source,
-      layer: layer,
+      catalogLayer: layer,
     };
   }
 
@@ -2250,7 +2251,7 @@ export default class App extends WWTAwareComponent {
             dec: dec,
             colNames: colNames,
             values: values,
-            layer: layerInfo,
+            catalogLayer: layerInfo,
           };
           minDist = dist;
         }

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -341,7 +341,7 @@ import {
   isPolyLineAnnotationSetting,
 } from "@wwtelescope/engine-helpers";
 
-import { WWTAwareComponent, ImagesetInfo, SpreadSheetCatalogLayerInfo } from "@wwtelescope/engine-vuex";
+import { WWTAwareComponent, ImagesetInfo, SpreadSheetLayerInfo } from "@wwtelescope/engine-vuex";
 
 import {
   classicPywwt,
@@ -579,7 +579,7 @@ class TableLayerMessageHandler {
       })
       .then((layer) => {
         this.layerInitialized(layer);
-        this.owner.addResearchAppTableLayer(new SpreadSheetCatalogLayerInfo(layer.id.toString(), layer.get_referenceFrame(), layer.get_name()));
+        this.owner.addResearchAppTableLayer(new SpreadSheetLayerInfo(layer.id.toString(), layer.get_referenceFrame(), layer.get_name()));
         
       });
 
@@ -2001,7 +2001,7 @@ export default class App extends WWTAwareComponent {
             if (ps !== null) pysettings.push(ps);
           }
 
-          const ssli: layers.SpreadSheetCatalogLayerInfo = {
+          const ssli: layers.SpreadSheetLayerInfo = {
             header: layer.get_header(),
             settings: pysettings,
           };
@@ -2225,8 +2225,8 @@ export default class App extends WWTAwareComponent {
       }
 
       if (layer == null) {
-          continue;
-        }
+        continue;
+      }
       const hipsStr = layer.getTableDataInView();
       const rows = hipsStr.split(rowSeparator);
       const header = rows.shift();

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -312,7 +312,7 @@ import { mapGetters, mapMutations, mapState } from "vuex";
 
 import { distance, fmtDegLat, fmtDegLon, fmtHours } from "@wwtelescope/astro";
 
-import { LayerInfo, Source, WWTResearchAppModule } from "./store";
+import { CatalogLayerInfo, Source, WWTResearchAppModule } from "./store";
 import { wwtEngineNamespace, wwtResearchAppNamespace } from "./namespaces";
 
 import { ImageSetType, SolarSystemObjects } from "@wwtelescope/engine-types";
@@ -341,7 +341,7 @@ import {
   isPolyLineAnnotationSetting,
 } from "@wwtelescope/engine-helpers";
 
-import { WWTAwareComponent, ImagesetInfo, SpreadSheetLayerInfo } from "@wwtelescope/engine-vuex";
+import { WWTAwareComponent, ImagesetInfo, SpreadSheetCatalogLayerInfo } from "@wwtelescope/engine-vuex";
 
 import {
   classicPywwt,
@@ -579,7 +579,7 @@ class TableLayerMessageHandler {
       })
       .then((layer) => {
         this.layerInitialized(layer);
-        this.owner.addResearchAppTableLayer(new SpreadSheetLayerInfo(layer.id.toString(), layer.get_referenceFrame(), layer.get_name()));
+        this.owner.addResearchAppTableLayer(new SpreadSheetCatalogLayerInfo(layer.id.toString(), layer.get_referenceFrame(), layer.get_name()));
         
       });
 
@@ -962,7 +962,7 @@ interface AngleCoordinates {
 interface RawSourceInfo {
   ra: number;
   dec: number;
-  layer: LayerInfo;
+  layer: CatalogLayerInfo;
   colNames: string[];
   values: string[];
 }
@@ -1010,13 +1010,13 @@ export default class App extends WWTAwareComponent {
 
   // From the store
   catalogNameMappings!: { [catalogName: string]: [string, string] };
-  layers!: LayerInfo[];
+  layers!: CatalogLayerInfo[];
   sources!: Source[];
 
-  addResearchAppTableLayer!: (layer: LayerInfo) => void;
+  addResearchAppTableLayer!: (layer: CatalogLayerInfo) => void;
   addSource!: (source: Source) => void;
-  removeResearchAppTableLayer!: (layer: LayerInfo) => void;
-  visibleTableLayers!: () => LayerInfo[];
+  removeResearchAppTableLayer!: (layer: CatalogLayerInfo) => void;
+  visibleTableLayers!: () => CatalogLayerInfo[];
 
   // Lifecycle management
 
@@ -1892,7 +1892,7 @@ export default class App extends WWTAwareComponent {
   }
 
   prepareForMessaging(source: Source): selections.Source {
-    let layer: selections.LayerInfo;
+    let layer: selections.CatalogLayerInfo;
     if (source.layer instanceof ImagesetInfo) {
       layer = {
         ...source.layer,
@@ -2001,7 +2001,7 @@ export default class App extends WWTAwareComponent {
             if (ps !== null) pysettings.push(ps);
           }
 
-          const ssli: layers.SpreadSheetLayerInfo = {
+          const ssli: layers.SpreadSheetCatalogLayerInfo = {
             header: layer.get_header(),
             settings: pysettings,
           };

--- a/research-app/src/SourceItem.vue
+++ b/research-app/src/SourceItem.vue
@@ -47,7 +47,7 @@
           <span class="prompt">Dec:</span><span>{{ this.decStr }}</span>
         </div>
         <div class="detail-row">
-          <span class="prompt">Layer:</span
+          <span class="prompt">Table:</span
           ><span>{{ this.source.layer.name }}</span>
         </div>
         <div class="detail-row">

--- a/research-app/src/SourceItem.vue
+++ b/research-app/src/SourceItem.vue
@@ -47,8 +47,8 @@
           <span class="prompt">Dec:</span><span>{{ this.decStr }}</span>
         </div>
         <div class="detail-row">
-          <span class="prompt">Catalog:</span
-          ><span>{{ this.source.catalogName }}</span>
+          <span class="prompt">Layer:</span
+          ><span>{{ this.source.layer.name }}</span>
         </div>
         <div class="detail-row">
           <span class="prompt">Query Coordinates:</span

--- a/research-app/src/SourceItem.vue
+++ b/research-app/src/SourceItem.vue
@@ -48,7 +48,7 @@
         </div>
         <div class="detail-row">
           <span class="prompt">Table:</span
-          ><span>{{ this.source.layer.name }}</span>
+          ><span>{{ this.source.catalogLayer.name }}</span>
         </div>
         <div class="detail-row">
           <span class="prompt">Query Coordinates:</span

--- a/research-app/src/SpreadsheetItem.vue
+++ b/research-app/src/SpreadsheetItem.vue
@@ -127,8 +127,7 @@ import { ApplyTableLayerSettingsOptions } from "@wwtelescope/engine-helpers";
 import { PlotTypes } from "@wwtelescope/engine-types";
 
 import { wwtEngineNamespace, wwtResearchAppNamespace } from "./namespaces";
-import { CatalogLayerInfo } from "./store";
-import { ImagesetInfo } from "@wwtelescope/engine-vuex";
+import { CatalogLayerInfo, ImagesetInfo } from "@wwtelescope/engine-vuex";
 
 interface UiPlotTypes {
   wwt: PlotTypes;
@@ -173,7 +172,6 @@ export default class CatalogItem extends Vue {
       }),
       ...mapGetters(wwtEngineNamespace, [
         "spreadsheetState",
-        "spreadsheetStateForHipsCatalog"
       ]),
       ...this.$options.computed,
     };
@@ -195,10 +193,7 @@ export default class CatalogItem extends Vue {
   // Tied to the store value
   visible!: boolean;
 
-  spreadsheetState!: (id: string) => SpreadSheetLayerSettingsInterfaceRO | null;
-  spreadsheetStateForHipsCatalog!: (
-    _n: string
-  ) => SpreadSheetLayerSettingsInterfaceRO | null;
+  spreadsheetState!: (layer: CatalogLayerInfo) => SpreadSheetLayerSettingsInterfaceRO | null;
 
   applyTableLayerSettings!: (_o: ApplyTableLayerSettingsOptions) => void;
   deleteLayer!: (id: string | Guid) => void;
@@ -221,8 +216,7 @@ export default class CatalogItem extends Vue {
   }
 
   layerState(): SpreadSheetLayerSettingsInterfaceRO | null {
-    const id = this.layerId();
-    return this.layer instanceof ImagesetInfo ? this.spreadsheetStateForHipsCatalog(id) : this.spreadsheetState(id);
+    return this.spreadsheetState(this.layer);
   }
 
   get color(): Color {

--- a/research-app/src/SpreadsheetItem.vue
+++ b/research-app/src/SpreadsheetItem.vue
@@ -127,7 +127,7 @@ import { ApplyTableLayerSettingsOptions } from "@wwtelescope/engine-helpers";
 import { PlotTypes } from "@wwtelescope/engine-types";
 
 import { wwtEngineNamespace, wwtResearchAppNamespace } from "./namespaces";
-import { LayerInfo } from "./store";
+import { CatalogLayerInfo } from "./store";
 import { ImagesetInfo } from "@wwtelescope/engine-vuex";
 
 interface UiPlotTypes {
@@ -156,7 +156,7 @@ interface VueColorData {
 
 @Component
 export default class CatalogItem extends Vue {
-  @Prop({ required: true }) layer!: LayerInfo;
+  @Prop({ required: true }) layer!: CatalogLayerInfo;
   @Prop({ required: false, default: Color.fromArgb(1, 255, 255, 255) })
 
   defaultColor!: Color;
@@ -203,9 +203,9 @@ export default class CatalogItem extends Vue {
   applyTableLayerSettings!: (_o: ApplyTableLayerSettingsOptions) => void;
   deleteLayer!: (id: string | Guid) => void;
   removeCatalogHipsByName!: (name: string) => void;
-  removeResearchAppTableLayer!: (layer: LayerInfo) => void;
+  removeResearchAppTableLayer!: (layer: CatalogLayerInfo) => void;
   setResearchAppTableLayerVisibility!: (args: {
-    layer: LayerInfo;
+    layer: CatalogLayerInfo;
     visible: boolean;
   }) => void;
 

--- a/research-app/src/SpreadsheetItem.vue
+++ b/research-app/src/SpreadsheetItem.vue
@@ -17,26 +17,25 @@
         >{{ layer.name }}</label
       >
       <input v-show="editing" class="name-input" @blur="editing = false" />
-      <span id="buttons-container">
-        <a
-          href="#"
-          v-if="!isLayerHips"
-          v-hide="!hasFocus"
-          @click="handleEditClick"
-          class="icon-link"
-          ><font-awesome-icon
-            :class="['icon', { 'icon-active': editing }]"
-            icon="pencil-alt"
-        /></a>
-        <a href="#" v-hide="!hasFocus" @click="handleToggle" class="icon-link"
-          ><font-awesome-icon
-            class="icon"
-            :icon="visible ? 'eye' : 'eye-slash'" />
-          </a>
-        <a href="#" v-hide="!hasFocus" @click="handleDelete" class="icon-link"
-          ><font-awesome-icon class="icon" icon="times"
-        /></a>
-      </span>
+      <font-awesome-icon
+        v-if="!isLayerHips"
+        v-hide="!hasFocus"
+        @click="handleEditClick"
+        :class="['icon-button', { 'icon-active': editing }]"
+        icon="pencil-alt"
+      />
+      <font-awesome-icon
+        v-hide="!hasFocus"
+        class="icon-button"
+        :icon="visible ? 'eye' : 'eye-slash'"
+        @click="handleToggle"
+      />
+      <font-awesome-icon
+        v-hide="!hasFocus"
+        class="icon-button"
+        icon="times"
+        @click="handleDelete"
+      />
     </div>
     <transition-expand>
       <div v-if="isSelected" class="detail-container">
@@ -421,20 +420,8 @@ export default class CatalogItem extends Vue {
   padding-left: 15px;
 }
 
-.icon {
-  color: white;
-  margin: auto 1%;
-}
-
 .icon-active {
   color: darkred;
-}
-
-.icon-link {
-  height: 100%;
-  background: inherit;
-  margin-left: 3px;
-  margin-right: 3px;
 }
 
 .icon-button {

--- a/research-app/src/SpreadsheetItem.vue
+++ b/research-app/src/SpreadsheetItem.vue
@@ -117,7 +117,6 @@
 import { mapGetters, mapMutations, mapState } from "vuex";
 import { Component, Prop, Vue, Watch } from "vue-property-decorator";
 
-import { isImageSetInfo } from "@wwtelescope/engine-vuex";
 import {
   Color,
   Guid,
@@ -129,6 +128,7 @@ import { PlotTypes } from "@wwtelescope/engine-types";
 
 import { wwtEngineNamespace, wwtResearchAppNamespace } from "./namespaces";
 import { LayerInfo } from "./store";
+import { ImagesetInfo } from "@wwtelescope/engine-vuex";
 
 interface UiPlotTypes {
   wwt: PlotTypes;
@@ -217,12 +217,12 @@ export default class CatalogItem extends Vue {
   isLayerHips = false;
 
   layerId(): string {
-    return isImageSetInfo(this.layer) ? this.layer.name : this.layer.id;
+    return this.layer instanceof ImagesetInfo ? this.layer.name : this.layer.id;
   }
 
   layerState(): SpreadSheetLayerSettingsInterfaceRO | null {
     const id = this.layerId();
-    return isImageSetInfo(this.layer) ? this.spreadsheetStateForHipsCatalog(id) : this.spreadsheetState(id);
+    return this.layer instanceof ImagesetInfo ? this.spreadsheetStateForHipsCatalog(id) : this.spreadsheetState(id);
   }
 
   get color(): Color {
@@ -305,7 +305,7 @@ export default class CatalogItem extends Vue {
 
   mounted() {
     this.color = this.defaultColor;
-    this.isLayerHips = isImageSetInfo(this.layer);
+    this.isLayerHips = this.layer instanceof ImagesetInfo;
   }
 
   private applySettings(settings: SpreadSheetLayerSetting[]) {
@@ -320,7 +320,7 @@ export default class CatalogItem extends Vue {
 
   handleDelete() {
     this.removeResearchAppTableLayer(this.layer);
-    if (isImageSetInfo(this.layer)) {
+    if (this.layer instanceof ImagesetInfo) {
       this.removeCatalogHipsByName(this.layer.name);
     } else {
       this.deleteLayer(this.layer.id);

--- a/research-app/src/SpreadsheetItem.vue
+++ b/research-app/src/SpreadsheetItem.vue
@@ -8,23 +8,31 @@
       @blur="hasFocus = false"
     >
       <label
+        v-show="!editing"
         focusable="false"
         id="name-label"
         class="ellipsize"
         @click="isSelected = !isSelected"
         @keyup.enter="isSelected = !isSelected"
-        >{{ catalog.name }}</label
+        >{{ layer.name }}</label
       >
+      <input v-show="editing" class="name-input" @blur="editing = false" />
       <span id="buttons-container">
+        <a
+          href="#"
+          v-if="!isLayerHips"
+          v-hide="!hasFocus"
+          @click="handleEditClick"
+          class="icon-link"
+          ><font-awesome-icon
+            :class="['icon', { 'icon-active': editing }]"
+            icon="pencil-alt"
+        /></a>
         <a href="#" v-hide="!hasFocus" @click="handleToggle" class="icon-link"
           ><font-awesome-icon
-            v-if="visible"
             class="icon"
-            icon="eye" /><font-awesome-icon
-            v-if="!visible"
-            class="icon"
-            icon="eye-slash"
-        /></a>
+            :icon="visible ? 'eye' : 'eye-slash'" />
+          </a>
         <a href="#" v-hide="!hasFocus" @click="handleDelete" class="icon-link"
           ><font-awesome-icon class="icon" icon="times"
         /></a>
@@ -32,14 +40,14 @@
     </div>
     <transition-expand>
       <div v-if="isSelected" class="detail-container">
-        <div class="detail-row">
+        <div class="detail-row" v-if="isLayerHips">
           <span class="prompt">URL:</span
-          ><span class="ellipsize">{{ catalog.url }}</span>
+          ><span class="ellipsize">{{ layer.url }}</span>
         </div>
 
-        <div class="detail-row" v-if="catalog.description.length > 0">
+        <div class="detail-row" v-if="isLayerHips && layer.description.length > 0">
           <span class="prompt">Description:</span
-          ><span>{{ catalog.description }}</span>
+          ><span>{{ layer.description }}</span>
         </div>
 
         <div class="detail-row">
@@ -109,9 +117,10 @@
 import { mapGetters, mapMutations, mapState } from "vuex";
 import { Component, Prop, Vue, Watch } from "vue-property-decorator";
 
-import { ImagesetInfo } from "@wwtelescope/engine-vuex";
+import { isImageSetInfo } from "@wwtelescope/engine-vuex";
 import {
   Color,
+  Guid,
   SpreadSheetLayerSetting,
   SpreadSheetLayerSettingsInterfaceRO,
 } from "@wwtelescope/engine";
@@ -119,6 +128,7 @@ import { ApplyTableLayerSettingsOptions } from "@wwtelescope/engine-helpers";
 import { PlotTypes } from "@wwtelescope/engine-types";
 
 import { wwtEngineNamespace, wwtResearchAppNamespace } from "./namespaces";
+import { LayerInfo } from "./store";
 
 interface UiPlotTypes {
   wwt: PlotTypes;
@@ -146,8 +156,9 @@ interface VueColorData {
 
 @Component
 export default class CatalogItem extends Vue {
-  @Prop({ required: true }) catalog!: ImagesetInfo;
+  @Prop({ required: true }) layer!: LayerInfo;
   @Prop({ required: false, default: Color.fromArgb(1, 255, 255, 255) })
+
   defaultColor!: Color;
 
   uiPlotTypes = uiPlotTypes;
@@ -158,9 +169,12 @@ export default class CatalogItem extends Vue {
     this.$options.computed = {
       ...mapState(wwtResearchAppNamespace, {
         visible: (_state, getters) =>
-          getters["researchAppHipsCatalogVisibility"](this.catalog),
+          getters["researchAppTableLayerVisibility"](this.layer),
       }),
-      ...mapGetters(wwtEngineNamespace, ["spreadsheetStateForHipsCatalog"]),
+      ...mapGetters(wwtEngineNamespace, [
+        "spreadsheetState",
+        "spreadsheetStateForHipsCatalog"
+      ]),
       ...this.$options.computed,
     };
 
@@ -168,11 +182,12 @@ export default class CatalogItem extends Vue {
       ...this.$options.methods,
       ...mapMutations(wwtEngineNamespace, [
         "applyTableLayerSettings",
+        "deleteLayer",
         "removeCatalogHipsByName",
       ]),
       ...mapMutations(wwtResearchAppNamespace, [
-        "removeResearchAppCatalogHips",
-        "setResearchAppCatalogHipsVisibility",
+        "removeResearchAppTableLayer",
+        "setResearchAppTableLayerVisibility",
       ]),
     };
   }
@@ -180,25 +195,38 @@ export default class CatalogItem extends Vue {
   // Tied to the store value
   visible!: boolean;
 
+  spreadsheetState!: (id: string) => SpreadSheetLayerSettingsInterfaceRO | null;
   spreadsheetStateForHipsCatalog!: (
     _n: string
   ) => SpreadSheetLayerSettingsInterfaceRO | null;
 
   applyTableLayerSettings!: (_o: ApplyTableLayerSettingsOptions) => void;
+  deleteLayer!: (id: string | Guid) => void;
   removeCatalogHipsByName!: (name: string) => void;
-  removeResearchAppCatalogHips!: (catalog: ImagesetInfo) => void;
-  setResearchAppCatalogHipsVisibility!: (args: {
-    catalog: ImagesetInfo;
+  removeResearchAppTableLayer!: (layer: LayerInfo) => void;
+  setResearchAppTableLayerVisibility!: (args: {
+    layer: LayerInfo;
     visible: boolean;
   }) => void;
 
   // Local state
 
+  editing = false;
   hasFocus = false;
   isSelected = false;
+  isLayerHips = false;
+
+  layerId(): string {
+    return isImageSetInfo(this.layer) ? this.layer.name : this.layer.id;
+  }
+
+  layerState(): SpreadSheetLayerSettingsInterfaceRO | null {
+    const id = this.layerId();
+    return isImageSetInfo(this.layer) ? this.spreadsheetStateForHipsCatalog(id) : this.spreadsheetState(id);
+  }
 
   get color(): Color {
-    const state = this.spreadsheetStateForHipsCatalog(this.catalog.name);
+    const state = this.layerState();
 
     if (state !== null) {
       return state.get_color();
@@ -215,7 +243,7 @@ export default class CatalogItem extends Vue {
   }
 
   get enabled(): boolean {
-    const state = this.spreadsheetStateForHipsCatalog(this.catalog.name);
+    const state = this.layerState();
 
     if (state !== null) {
       return state.get_enabled();
@@ -225,7 +253,7 @@ export default class CatalogItem extends Vue {
   }
 
   get plotType(): PlotTypes {
-    const state = this.spreadsheetStateForHipsCatalog(this.catalog.name);
+    const state = this.layerState();
 
     if (state !== null) {
       return state.get_plotType();
@@ -239,7 +267,7 @@ export default class CatalogItem extends Vue {
   }
 
   get scaleFactorDb(): number {
-    const state = this.spreadsheetStateForHipsCatalog(this.catalog.name);
+    const state = this.layerState();
 
     if (state !== null) {
       return 10 * Math.log10(state.get_scaleFactor());
@@ -277,26 +305,31 @@ export default class CatalogItem extends Vue {
 
   mounted() {
     this.color = this.defaultColor;
+    this.isLayerHips = isImageSetInfo(this.layer);
   }
 
   private applySettings(settings: SpreadSheetLayerSetting[]) {
-    // Building on the hack/simplification that the GUID of the catalog's
-    // spreadsheet layer is its `datasetName`, even though that is absolutely
-    // not a v4 GUID at all.
+    // For HiPS layers, this builds on the hack/simplification that the GUID of
+    // the catalog's spreadsheet layer is its `datasetName`, even though that 
+    // is absolutely not a v4 GUID at all.
     this.applyTableLayerSettings({
-      id: this.catalog.name,
+      id: this.layerId(),
       settings: settings,
     });
   }
 
   handleDelete() {
-    this.removeResearchAppCatalogHips(this.catalog);
-    this.removeCatalogHipsByName(this.catalog.name);
+    this.removeResearchAppTableLayer(this.layer);
+    if (isImageSetInfo(this.layer)) {
+      this.removeCatalogHipsByName(this.layer.name);
+    } else {
+      this.deleteLayer(this.layer.id);
+    }
   }
 
   handleToggle() {
-    this.setResearchAppCatalogHipsVisibility({
-      catalog: this.catalog,
+    this.setResearchAppTableLayerVisibility({
+      layer: this.layer,
       visible: !this.visible,
     });
   }
@@ -306,6 +339,10 @@ export default class CatalogItem extends Vue {
     this.color = Color.fromArgb(rgba["a"], rgba["r"], rgba["g"], rgba["b"]);
   }
 
+  handleEditClick() {
+    this.editing = !this.editing;
+  }
+
   @Watch("visible")
   onVisibilityChange(val: boolean) {
     this.applySettings([["enabled", val]]);
@@ -313,10 +350,22 @@ export default class CatalogItem extends Vue {
 
   @Watch("enabled")
   onEnabledChange(val: boolean) {
-    this.setResearchAppCatalogHipsVisibility({
-      catalog: this.catalog,
+    this.setResearchAppTableLayerVisibility({
+      layer: this.layer,
       visible: val,
     });
+  }
+
+  @Watch("editing")
+  editingChanged(val: boolean, _oldVal: boolean) {
+    const input: HTMLInputElement = this.$el.getElementsByClassName(
+      "name-input"
+    )[0] as HTMLInputElement;
+    if (val) {
+      input.value = this.layer.name;
+    } else {
+      this.layer.name = input.value;
+    }
   }
 
   doAdjustSize(bigger: boolean) {
@@ -383,6 +432,10 @@ export default class CatalogItem extends Vue {
   margin: auto 1%;
 }
 
+.icon-active {
+  color: darkred;
+}
+
 .icon-link {
   height: 100%;
   background: inherit;
@@ -394,6 +447,11 @@ export default class CatalogItem extends Vue {
   cursor: pointer;
   display: inline-block;
   background: inherit;
+}
+
+.name-input {
+  display: inline-block;
+  background: #999999;
 }
 
 .prompt {

--- a/research-app/src/main.ts
+++ b/research-app/src/main.ts
@@ -44,9 +44,9 @@ import 'vue-slider-component/theme/default.css';
 import { createPlugin } from "@wwtelescope/engine-vuex";
 
 import App from "./App.vue";
-import CatalogItem from "./CatalogItem.vue";
 import ImagesetItem from "./ImagesetItem.vue";
 import SourceItem from "./SourceItem.vue";
+import SpreadsheetItem from "./SpreadsheetItem.vue";
 import TransitionExpand from "./TransitionExpand.vue";
 import { WWTResearchAppModule } from "./store";
 import { wwtEngineNamespace, wwtResearchAppNamespace } from "./namespaces";
@@ -95,7 +95,7 @@ Vue.component('vue-color-chrome', Chrome);
 Vue.component('v-select', vSelect);
 Vue.component('vue-slider', VueSlider);
 
-Vue.component('catalog-item', CatalogItem);
+Vue.component('spreadsheet-item', SpreadsheetItem);
 Vue.component('imageset-item', ImagesetItem);
 Vue.component('source-item', SourceItem);
 Vue.component('transition-expand', TransitionExpand);

--- a/research-app/src/store.ts
+++ b/research-app/src/store.ts
@@ -9,7 +9,7 @@ export interface Source {
   ra: number;
   dec: number;
   name: string;
-  layer: CatalogLayerInfo;
+  catalogLayer: CatalogLayerInfo;
   zoomDeg?: number;
   layerData: {
     [field: string]: string | undefined;
@@ -62,7 +62,7 @@ function infoKey(info: CatalogLayerInfo) {
 }
 
 function sourcesEqual(s1: Source, s2: Source) {
-  return (s1.ra === s2.ra) && (s1.dec === s2.dec) && (infoKey(s1.layer) === infoKey(s2.layer));
+  return (s1.ra === s2.ra) && (s1.dec === s2.dec) && (infoKey(s1.catalogLayer) === infoKey(s2.catalogLayer));
 }
 
 function getFilteredLayers(statusMap: { [id: string]: TableLayerStatus | undefined },

--- a/research-app/src/store.ts
+++ b/research-app/src/store.ts
@@ -2,22 +2,26 @@
 // Licensed under the MIT License
 
 import { Module, Mutation, VuexModule } from 'vuex-module-decorators';
-import { ImagesetInfo } from '@wwtelescope/engine-vuex';
+import { ImagesetInfo, SpreadSheetLayerInfo, isImageSetInfo } from '@wwtelescope/engine-vuex';
 import Vue from 'vue';
 
 export interface Source {
   ra: number;
   dec: number;
   name: string;
-  catalogName: string;
+  layer: LayerInfo;
   zoomDeg?: number;
-  catalogData: {
+  layerData: {
     [field: string]: string | undefined;
   };
 }
 
-export interface HipsCatalogStatus {
+export type LayerInfo = SpreadSheetLayerInfo | ImagesetInfo;
+
+export interface TableLayerStatus {
   visible: boolean;
+  type: 'hips' | 'table';
+  layer: LayerInfo;
 }
 
 type EquivalenceTest<T> = (t1: T, t2: T) => boolean;
@@ -52,7 +56,23 @@ function removeFromArray<T>(array: T[], item: T, equivalent: EquivalenceTest<T> 
 }
 
 function sourcesEqual(s1: Source, s2: Source) {
-  return (s1.ra === s2.ra) && (s1.dec === s2.dec) && (s1.catalogName === s2.catalogName);
+  return (s1.ra === s2.ra) && (s1.dec === s2.dec) && (infoKey(s1.layer) === infoKey(s2.layer));
+}
+
+function infoKey(info: LayerInfo) {
+  return isImageSetInfo(info) ? info.name : info.id;
+}
+
+function getFilteredLayers(statusMap: { [id: string]: TableLayerStatus | undefined },
+                           filter: (status: TableLayerStatus) => boolean): LayerInfo[] {
+  const statuses = Object.values(statusMap);
+  const filtered: LayerInfo[] = [];
+  for (const status of statuses) {
+    if (status !== undefined && filter(status)) {
+      filtered.push(status.layer);
+    }
+  }
+  return filtered;
 }
 
 @Module({
@@ -60,8 +80,8 @@ function sourcesEqual(s1: Source, s2: Source) {
   stateFactory: true,
 })
 export class WWTResearchAppModule extends VuexModule {
-  hipsCatalogs: ImagesetInfo[] = [];
-  hipsCatalogVisibilities: boolean[] = [];
+  
+  _tableLayers: { [id: string]: TableLayerStatus | undefined } = {};
   sources: Source[] = [];
 
   catalogNameMappings: { [catalogName: string]: [string, string] } = {
@@ -74,38 +94,52 @@ export class WWTResearchAppModule extends VuexModule {
     "The Pan-STARRS release 1 (PS1) Survey - DR1 (Chambers+, 2016) (ps1)": ["f_objID", "PAN-Starrs ID"],
   }
 
-  get researchAppHipsCatalogVisibility() {
-    return (catalog: ImagesetInfo) => {
-      const index = getIndex(this.hipsCatalogs, catalog);
-      return (index >= 0) ? this.hipsCatalogVisibilities[index] : false;
-    }
+  get hipsCatalogs() {
+    return () => getFilteredLayers(this._tableLayers, status => status.type == 'hips');
   }
 
   get visibleHipsCatalogs() {
-    return () => this.hipsCatalogs.filter((_catalog, index) => this.hipsCatalogVisibilities[index]);
+    return () => getFilteredLayers(this._tableLayers, status => status.type == 'hips' && status.visible);
   }
 
-  @Mutation
-  addResearchAppCatalogHips(catalog: ImagesetInfo) {
-    const added = addToArrayWithoutDuplication(this.hipsCatalogs, catalog);
-    if (added) {
-      this.hipsCatalogVisibilities.push(true);
+  get tableLayers() {
+    return () => getFilteredLayers(this._tableLayers, _status => true);
+  }
+
+  get visibleTableLayers() {
+    return () => getFilteredLayers(this._tableLayers, status => status.visible);
+  }
+
+  get researchAppTableLayerVisibility() {
+    return (info: LayerInfo) => {
+      const status = this._tableLayers[infoKey(info)];
+      if (status == undefined) {
+        return false;
+      }
+      return status.visible;
     }
   }
 
   @Mutation
-  removeResearchAppCatalogHips(catalog: ImagesetInfo) {
-    const index = removeFromArray(this.hipsCatalogs, catalog);
-    if (index >= 0) {
-      this.hipsCatalogVisibilities.splice(index, 1);
-    }
+  addResearchAppTableLayer(info: LayerInfo) {
+    const status: TableLayerStatus = {
+      type: isImageSetInfo(info) ? 'hips' : 'table',
+      visible: true,
+      layer: info,
+    };
+    Vue.set(this._tableLayers, infoKey(info), status);
   }
 
   @Mutation
-  setResearchAppCatalogHipsVisibility(args: { catalog: ImagesetInfo; visible: boolean }) {
-    const index = getIndex(this.hipsCatalogs, args.catalog);
-    if (index >= 0) {
-      Vue.set(this.hipsCatalogVisibilities, index, args.visible);
+  removeResearchAppTableLayer(layer: LayerInfo) {
+    Vue.delete(this._tableLayers, infoKey(layer));
+  }
+
+  @Mutation
+  setResearchAppTableLayerVisibility(args: { layer: LayerInfo; visible: boolean }) {
+    const status = this._tableLayers[infoKey(args.layer)];
+    if (status !== undefined) {
+      Vue.set(status, 'visible', args.visible);
     }
   }
 

--- a/research-app/src/store.ts
+++ b/research-app/src/store.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License
 
 import { Module, Mutation, VuexModule } from 'vuex-module-decorators';
-import { ImagesetInfo, SpreadSheetLayerInfo, isImageSetInfo } from '@wwtelescope/engine-vuex';
+import { ImagesetInfo, SpreadSheetLayerInfo } from '@wwtelescope/engine-vuex';
 import Vue from 'vue';
 
 export interface Source {
@@ -56,7 +56,7 @@ function removeFromArray<T>(array: T[], item: T, equivalent: EquivalenceTest<T> 
 }
 
 function infoKey(info: LayerInfo) {
-  return isImageSetInfo(info) ? info.name : info.id;
+  return info instanceof ImagesetInfo ? info.name : info.id;
 }
 
 function sourcesEqual(s1: Source, s2: Source) {
@@ -123,7 +123,7 @@ export class WWTResearchAppModule extends VuexModule {
   @Mutation
   addResearchAppTableLayer(info: LayerInfo) {
     const status: TableLayerStatus = {
-      type: isImageSetInfo(info) ? 'hips' : 'table',
+      type: info instanceof ImagesetInfo ? 'hips' : 'table',
       visible: true,
       layer: info,
     };

--- a/research-app/src/store.ts
+++ b/research-app/src/store.ts
@@ -55,12 +55,12 @@ function removeFromArray<T>(array: T[], item: T, equivalent: EquivalenceTest<T> 
   return index;
 }
 
-function sourcesEqual(s1: Source, s2: Source) {
-  return (s1.ra === s2.ra) && (s1.dec === s2.dec) && (infoKey(s1.layer) === infoKey(s2.layer));
-}
-
 function infoKey(info: LayerInfo) {
   return isImageSetInfo(info) ? info.name : info.id;
+}
+
+function sourcesEqual(s1: Source, s2: Source) {
+  return (s1.ra === s2.ra) && (s1.dec === s2.dec) && (infoKey(s1.layer) === infoKey(s2.layer));
 }
 
 function getFilteredLayers(statusMap: { [id: string]: TableLayerStatus | undefined },

--- a/tests/page_objects/researchApp.ts
+++ b/tests/page_objects/researchApp.ts
@@ -74,7 +74,7 @@ module.exports = {
           selector: "#spreadsheets-container #name-label"
         },
         catalogVisibilityButton: {
-          selector: "#spreadsheets-container .fa-eye,"
+          selector: "#spreadsheets-container .fa-eye"
         },
         catalogDeleteButton: {
           selector: "#spreadsheets-container .fa-times"

--- a/tests/page_objects/researchApp.ts
+++ b/tests/page_objects/researchApp.ts
@@ -73,14 +73,11 @@ module.exports = {
         catalogTitle: {
           selector: "#spreadsheets-container #name-label"
         },
-        catalogButtonContainer: {
-          selector: "#spreadsheets-container #buttons-container"
-        },
         catalogVisibilityButton: {
-          selector: "#spreadsheets-container #buttons-container .fa-eye, #spreadsheets-container #buttons-container .fa-eye-slash"
+          selector: "#spreadsheets-container .fa-eye,"
         },
         catalogDeleteButton: {
-          selector: "#spreadsheets-container #buttons-container .fa-times"
+          selector: "#spreadsheets-container .fa-times"
         },
       },
       props: {

--- a/tests/page_objects/researchApp.ts
+++ b/tests/page_objects/researchApp.ts
@@ -52,7 +52,7 @@ module.exports = {
           selector: "#  "
         },
         catalogsHeader: {
-          selector: "#catalogs-container .display-section-header"
+          selector: "#spreadsheets-container .display-section-header"
         },
         sourcesContainer: {
           selector: "#sources-container"
@@ -65,22 +65,22 @@ module.exports = {
         // i.e., the source components have a similar structure
         // with some of the same IDs
         catalogItem: {
-          selector: "#catalogs-container #root-container"
+          selector: "#spreadsheets-container #root-container"
         },
         catalogMainContainer: {
-          selector: "#catalogs-container #main-container"
+          selector: "#spreadsheets-container #main-container"
         },
         catalogTitle: {
-          selector: "#catalogs-container #name-label"
+          selector: "#spreadsheets-container #name-label"
         },
         catalogButtonContainer: {
-          selector: "#catalogs-container #buttons-container"
+          selector: "#spreadsheets-container #buttons-container"
         },
         catalogVisibilityButton: {
-          selector: "#catalogs-container #buttons-container .fa-eye, #catalogs-container #buttons-container .fa-eye-slash"
+          selector: "#spreadsheets-container #buttons-container .fa-eye, #spreadsheets-container #buttons-container .fa-eye-slash"
         },
         catalogDeleteButton: {
-          selector: "#catalogs-container #buttons-container .fa-times"
+          selector: "#spreadsheets-container #buttons-container .fa-times"
         },
       },
       props: {
@@ -161,7 +161,7 @@ module.exports = {
         },
       },
       props: {
-        backgroundOptionCount: 832,
+        backgroundOptionCount: 834,
         catalogOptionCount: 49,
         firstBackgroundName: "Digitized Sky Survey (Color)",
         firstBackgroundDescription: "Copyright DSS Consortium",


### PR DESCRIPTION
This PR adds initial support for manipulating user-added table layers via the UI, and selecting sources present in these layers. The main idea is as follows:

- I added a `SpreadSheetLayerInfo` class, analogous to `ImagesetInfo` that we were using for the HiPS catalogs, which contains the relevant information for the display panel and research app store about a spreadsheet layer.
- `CatalogItem` has been renamed to `SpreadsheetItem` (and its `catalog` prop renamed to `layer`). The `layer` prop now has type `LayerInfo = ImagesetInfo | SpreadSheetLayerInfo`. Since these layer types, and the corresponding info classes, are pretty similar, a few `v-if` statements and some delegation in the delete method are enough to handle pretty much all of the differences. Since the engine-generated names are very non-user-friendly, I added the ability to edit the layer name of a general table layer, copying the setup from `SourceItem`.
- The research app store has been modified to use a key-based data structure for layers, with the key being the ID for a table layer, and the name for a HiPS catalog (the same keying system used by the engine). The data structure values now hold three pieces of information: the type of the layer (`hips` or `table`), whether or not the layer is visible, and the `LayerInfo` itself. 
- Since sources can now come from places other than HiPS catalogs, I replaced the `catalogName` in a `Source` with a `layer` field containing the `LayerInfo` of the layer from which the source came. Keeping a reference to the `LayerInfo` object in the `Source` will be useful for reactive stuff - for example, as things are now, if the user changes the name of a table layer, the panel item for all of the sources from that layer automatically update as well. This necessitated changing the `Source` interface, and adding some other interfaces, in `research-app-messages`.
- Finally, I added a couple of methods to the `engine-vuex` store to get the layer state for non-HiPS layers, which are largely just clones of the HiPS version.

I suspect there might be some iteration on this, but I think this general setup should make handling both types of layers not too painful.