### PR TITLE
Research app UI element sizing and positioning in response to screen size

### DIFF
--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -10,276 +10,278 @@
 
     <!-- keydown.stops here and below prevent any keynav presses from reaching
       the toplevel UI handlers -->
-    <div id="display-panel" v-if="!hideAllChrome" @keydown.stop>
-      <transition name="catalog-transition">
-        <div id="overlays">
-          <p>{{ coordText }}</p>
-        </div>
-      </transition>
-      <div id="imagery-container" v-if="haveImagery">
-        <div class="display-section-header">
-          <label>Imagery</label>
-        </div>
-        <imageset-item
-          v-for="imageset of activeImagesetLayerStates"
-          v-bind:key="imageset.settings.name"
-          v-bind:imageset="imageset"
-        />
-      </div>
-      <div id="catalogs-container" v-if="haveCatalogs">
-        <div class="display-section-header">
-          <label>Catalogs</label>
-        </div>
-        <catalog-item
-          v-for="catalog of hipsCatalogs"
-          v-bind:key="catalog.name"
-          v-bind:catalog="catalog"
-          v-bind:defaultColor="defaultColor"
-        />
-      </div>
-      <div id="sources-container" v-if="haveSources">
-        <div class="display-section-header">
-          <label>Sources</label>
-        </div>
-        <source-item
-          v-for="source of sources"
-          v-bind:key="source.name"
-          v-bind:source="source"
-        />
-      </div>
-    </div>
-
-    <ul id="controls" v-if="!hideAllChrome" @keydown.stop>
-      <li v-show="showToolMenu">
-        <v-popover placement="left" trigger="manual" :open="showPopover">
-          <font-awesome-icon
-            class="tooltip-target tooltip-icon"
-            icon="sliders-h"
-            size="lg"
-            tabindex="0"
-            @keyup.enter="showPopover = !showPopover"
-            @click="showPopover = !showPopover"
-          ></font-awesome-icon>
-          <template slot="popover" tabindex="-1" show="showPopover">
-            <ul class="tooltip-content tool-menu" tabindex="-1">
-              <li v-show="showBackgroundChooser">
-                <a
-                  href="#"
-                  v-close-popover
-                  @click="
-                    selectTool('choose-background');
-                    showPopover = false;
-                  "
-                  tabindex="0"
-                  ><font-awesome-icon icon="mountain" /> Choose background</a
-                >
-              </li>
-              <li v-show="showAddImageryTool">
-                <a
-                  href="#"
-                  v-close-popover
-                  @click="
-                    selectTool('add-imagery-layer');
-                    showPopover = false;
-                  "
-                  tabindex="0"
-                  ><font-awesome-icon icon="image" /> Add imagery as layer</a
-                >
-              </li>
-              <li v-show="showCatalogTool">
-                <a
-                  href="#"
-                  v-close-popover
-                  @click="
-                    selectTool('choose-catalog');
-                    showPopover = false;
-                  "
-                  tabindex="0"
-                  ><font-awesome-icon icon="map-marked-alt" /> Add HiPS
-                  catalogs</a
-                >
-              </li>
-              <li v-show="showCollectionLoader">
-                <a
-                  href="#"
-                  v-close-popover
-                  @click="
-                    selectTool('load-collection');
-                    showPopover = false;
-                  "
-                  tabindex="0"
-                  ><font-awesome-icon icon="photo-video" /> Load WTML
-                  collection</a
-                >
-              </li>
-            </ul>
-          </template>
-        </v-popover>
-      </li>
-      <li v-show="!wwtIsTourPlaying">
-        <font-awesome-icon
-          icon="search-plus"
-          size="lg"
-          class="tooltip-icon"
-          @keyup.enter="doZoom(true)"
-          @click="doZoom(true)"
-          tabindex="0"
-        ></font-awesome-icon>
-      </li>
-      <li v-show="!wwtIsTourPlaying">
-        <font-awesome-icon
-          icon="search-minus"
-          size="lg"
-          class="tooltip-icon"
-          @keyup.enter="doZoom(false)"
-          @click="doZoom(false)"
-          tabindex="0"
-        ></font-awesome-icon>
-      </li>
-      <li v-show="fullscreenAvailable">
-        <font-awesome-icon
-          v-bind:icon="fullscreenModeActive ? 'compress' : 'expand'"
-          size="lg"
-          class="nudgeright1 tooltip-icon"
-          @keyup.enter="toggleFullscreen()"
-          @click="toggleFullscreen()"
-          tabindex="0"
-        ></font-awesome-icon>
-      </li>
-    </ul>
-
-    <div id="tools" v-if="!hideAllChrome" @keydown.stop>
-      <div class="tool-container">
-        <template v-if="currentTool == 'crossfade'">
-          <span>Foreground opacity:</span>
-          <input
-            class="opacity-range"
-            type="range"
-            v-model="foregroundOpacity"
+    <div id="ui-elements">
+      <div id="display-panel" v-if="!hideAllChrome" @keydown.stop>
+        <transition name="catalog-transition">
+          <div id="overlays">
+            <p>{{ coordText }}</p>
+          </div>
+        </transition>
+        <div id="imagery-container" v-if="haveImagery">
+          <div class="display-section-header">
+            <label>Imagery</label>
+          </div>
+          <imageset-item
+            v-for="imageset of activeImagesetLayerStates"
+            v-bind:key="imageset.settings.name"
+            v-bind:imageset="imageset"
           />
-        </template>
-
-        <template v-else-if="currentTool == 'choose-background'">
-          <div id="bg-select-container" class="item-select-container">
-            <span id="bg-select-title" class="item-select-title"
-              >Background imagery:</span
-            >
-            <v-select
-              v-model="curBackgroundImagesetName"
-              id="bg-select"
-              class="item-selector"
-              :searchable="true"
-              :clearable="false"
-              :options="curAvailableImagesets"
-              :filter="filterImagesets"
-              :close-on-select="true"
-              :reduce="(bg) => bg.name"
-              label="name"
-              placeholder="Background"
-            >
-              <template #option="option">
-                <div class="item-option">
-                  <h4 class="ellipsize">{{ option.name }}</h4>
-                  <p class="ellipsize"><em>{{ option.description }}</em></p>
-                </div>
-              </template>
-              <template #selected-option="option">
-                <div class="ellipsize">{{ option.name }}</div>
-              </template>
-            </v-select>
+        </div>
+        <div id="catalogs-container" v-if="haveCatalogs">
+          <div class="display-section-header">
+            <label>Catalogs</label>
           </div>
-        </template>
-
-        <template v-else-if="currentTool == 'add-imagery-layer'">
-          <div class="item-select-container">
-            <span class="item-select-title">Add imagery layer:</span>
-            <v-select
-              v-model="imageryToAdd"
-              class="item-selector"
-              :searchable="true"
-              :clearable="false"
-              :options="curAvailableImageryData"
-              :filter="filterImagesets"
-              label="name"
-              placeholder="Dataset"
-            >
-              <template #option="option">
-                <div class="item-option">
-                  <h4 class="ellipsize">{{ option.name }}</h4>
-                  <p class="ellipsize"><em>{{ option.description }}</em></p>
-                </div>
-              </template>
-              <template #selected-option="option">
-                <div class="ellipsize">{{ option.name }}</div>
-              </template>
-              <template #no-options="{ search, searching }">
-                <template v-if="searching">
-                  No datasets matching <em>{{ search }}</em
-                  >.
-                </template>
-                <em v-else>No datasets available. Load a WTML collection?</em>
-              </template>
-            </v-select>
+          <catalog-item
+            v-for="catalog of hipsCatalogs"
+            v-bind:key="catalog.name"
+            v-bind:catalog="catalog"
+            v-bind:defaultColor="defaultColor"
+          />
+        </div>
+        <div id="sources-container" v-if="haveSources">
+          <div class="display-section-header">
+            <label>Sources</label>
           </div>
-        </template>
+          <source-item
+            v-for="source of sources"
+            v-bind:key="source.name"
+            v-bind:source="source"
+          />
+        </div>
+      </div>
 
-        <template v-else-if="showCatalogChooser">
-          <div id="catalog-select-container-tool" class="item-select-container">
-            <span class="item-select-title">Add catalog:</span>
-            <v-select
-              v-model="catalogToAdd"
-              id="catalog-select-tool"
-              class="item-selector"
-              :searchable="true"
-              :clearable="false"
-              :options="curAvailableCatalogs"
-              :filter="filterCatalogs"
-              @change="(cat) => addHipsByName(cat.name)"
-              label="name"
-              placeholder="Catalog"
-            >
-              <template #option="option">
-                <div class="item-option">
-                  <h4 class="ellipsize">{{ option.name }}</h4>
-                  <p class="ellipsize"><em>{{ option.description }}</em></p>
-                </div>
-              </template>
-              <template #selected-option-container="">
-                <div></div>
-              </template>
-            </v-select>
-          </div>
-        </template>
+      <ul id="controls" v-if="!hideAllChrome" @keydown.stop>
+        <li v-show="showToolMenu">
+          <v-popover placement="left" trigger="manual" :open="showPopover">
+            <font-awesome-icon
+              class="tooltip-target tooltip-icon"
+              icon="sliders-h"
+              size="lg"
+              tabindex="0"
+              @keyup.enter="showPopover = !showPopover"
+              @click="showPopover = !showPopover"
+            ></font-awesome-icon>
+            <template slot="popover" tabindex="-1" show="showPopover">
+              <ul class="tooltip-content tool-menu" tabindex="-1">
+                <li v-show="showBackgroundChooser">
+                  <a
+                    href="#"
+                    v-close-popover
+                    @click="
+                      selectTool('choose-background');
+                      showPopover = false;
+                    "
+                    tabindex="0"
+                    ><font-awesome-icon icon="mountain" /> Choose background</a
+                  >
+                </li>
+                <li v-show="showAddImageryTool">
+                  <a
+                    href="#"
+                    v-close-popover
+                    @click="
+                      selectTool('add-imagery-layer');
+                      showPopover = false;
+                    "
+                    tabindex="0"
+                    ><font-awesome-icon icon="image" /> Add imagery as layer</a
+                  >
+                </li>
+                <li v-show="showCatalogTool">
+                  <a
+                    href="#"
+                    v-close-popover
+                    @click="
+                      selectTool('choose-catalog');
+                      showPopover = false;
+                    "
+                    tabindex="0"
+                    ><font-awesome-icon icon="map-marked-alt" /> Add HiPS
+                    catalogs</a
+                  >
+                </li>
+                <li v-show="showCollectionLoader">
+                  <a
+                    href="#"
+                    v-close-popover
+                    @click="
+                      selectTool('load-collection');
+                      showPopover = false;
+                    "
+                    tabindex="0"
+                    ><font-awesome-icon icon="photo-video" /> Load WTML
+                    collection</a
+                  >
+                </li>
+              </ul>
+            </template>
+          </v-popover>
+        </li>
+        <li v-show="!wwtIsTourPlaying">
+          <font-awesome-icon
+            icon="search-plus"
+            size="lg"
+            class="tooltip-icon"
+            @keyup.enter="doZoom(true)"
+            @click="doZoom(true)"
+            tabindex="0"
+          ></font-awesome-icon>
+        </li>
+        <li v-show="!wwtIsTourPlaying">
+          <font-awesome-icon
+            icon="search-minus"
+            size="lg"
+            class="tooltip-icon"
+            @keyup.enter="doZoom(false)"
+            @click="doZoom(false)"
+            tabindex="0"
+          ></font-awesome-icon>
+        </li>
+        <li v-show="fullscreenAvailable">
+          <font-awesome-icon
+            v-bind:icon="fullscreenModeActive ? 'compress' : 'expand'"
+            size="lg"
+            class="nudgeright1 tooltip-icon"
+            @keyup.enter="toggleFullscreen()"
+            @click="toggleFullscreen()"
+            tabindex="0"
+          ></font-awesome-icon>
+        </li>
+      </ul>
 
-        <template v-else-if="currentTool == 'load-collection'">
-          <div class="load-collection-container">
-            <div class="load-collection-label">
-              Load
-              <a
-                href="https://docs.worldwidetelescope.org/data-guide/1/data-file-formats/collections/"
-                target="_blank"
-                >WTML</a
+      <div id="tools" v-if="!hideAllChrome" @keydown.stop>
+        <div class="tool-container">
+          <template v-if="currentTool == 'crossfade'">
+            <span>Foreground opacity:</span>
+            <input
+              class="opacity-range"
+              type="range"
+              v-model="foregroundOpacity"
+            />
+          </template>
+
+          <template v-else-if="currentTool == 'choose-background'">
+            <div id="bg-select-container" class="item-select-container">
+              <span id="bg-select-title" class="item-select-title"
+                >Background imagery:</span
               >
-              data collection:
+              <v-select
+                v-model="curBackgroundImagesetName"
+                id="bg-select"
+                class="item-selector"
+                :searchable="true"
+                :clearable="false"
+                :options="curAvailableImagesets"
+                :filter="filterImagesets"
+                :close-on-select="true"
+                :reduce="(bg) => bg.name"
+                label="name"
+                placeholder="Background"
+              >
+                <template #option="option">
+                  <div class="item-option">
+                    <h4 class="ellipsize">{{ option.name }}</h4>
+                    <p class="ellipsize"><em>{{ option.description }}</em></p>
+                  </div>
+                </template>
+                <template #selected-option="option">
+                  <div class="ellipsize">{{ option.name }}</div>
+                </template>
+              </v-select>
             </div>
-            <div class="load-collection-row">
-              <label>URL:</label>
-              <input
-                type="url"
-                v-model="wtmlCollectionUrl"
-                @keyup.enter="submitWtmlCollectionUrl"
-              />
-              <font-awesome-icon
-                icon="arrow-circle-right"
-                size="lg"
-                class="load-collection-icon"
-                @keyup.enter="submitWtmlCollectionUrl"
-                @click="submitWtmlCollectionUrl"
-                tabindex="0"
-              ></font-awesome-icon>
+          </template>
+
+          <template v-else-if="currentTool == 'add-imagery-layer'">
+            <div class="item-select-container">
+              <span class="item-select-title">Add imagery layer:</span>
+              <v-select
+                v-model="imageryToAdd"
+                class="item-selector"
+                :searchable="true"
+                :clearable="false"
+                :options="curAvailableImageryData"
+                :filter="filterImagesets"
+                label="name"
+                placeholder="Dataset"
+              >
+                <template #option="option">
+                  <div class="item-option">
+                    <h4 class="ellipsize">{{ option.name }}</h4>
+                    <p class="ellipsize"><em>{{ option.description }}</em></p>
+                  </div>
+                </template>
+                <template #selected-option="option">
+                  <div class="ellipsize">{{ option.name }}</div>
+                </template>
+                <template #no-options="{ search, searching }">
+                  <template v-if="searching">
+                    No datasets matching <em>{{ search }}</em
+                    >.
+                  </template>
+                  <em v-else>No datasets available. Load a WTML collection?</em>
+                </template>
+              </v-select>
             </div>
-          </div>
-        </template>
+          </template>
+
+          <template v-else-if="showCatalogChooser">
+            <div id="catalog-select-container-tool" class="item-select-container">
+              <span class="item-select-title">Add catalog:</span>
+              <v-select
+                v-model="catalogToAdd"
+                id="catalog-select-tool"
+                class="item-selector"
+                :searchable="true"
+                :clearable="false"
+                :options="curAvailableCatalogs"
+                :filter="filterCatalogs"
+                @change="(cat) => addHipsByName(cat.name)"
+                label="name"
+                placeholder="Catalog"
+              >
+                <template #option="option">
+                  <div class="item-option">
+                    <h4 class="ellipsize">{{ option.name }}</h4>
+                    <p class="ellipsize"><em>{{ option.description }}</em></p>
+                  </div>
+                </template>
+                <template #selected-option-container="">
+                  <div></div>
+                </template>
+              </v-select>
+            </div>
+          </template>
+
+          <template v-else-if="currentTool == 'load-collection'">
+            <div class="load-collection-container">
+              <div class="load-collection-label">
+                Load
+                <a
+                  href="https://docs.worldwidetelescope.org/data-guide/1/data-file-formats/collections/"
+                  target="_blank"
+                  >WTML</a
+                >
+                data collection:
+              </div>
+              <div class="load-collection-row">
+                <label>URL:</label>
+                <input
+                  type="url"
+                  v-model="wtmlCollectionUrl"
+                  @keyup.enter="submitWtmlCollectionUrl"
+                />
+                <font-awesome-icon
+                  icon="arrow-circle-right"
+                  size="lg"
+                  class="load-collection-icon"
+                  @keyup.enter="submitWtmlCollectionUrl"
+                  @click="submitWtmlCollectionUrl"
+                  tabindex="0"
+                ></font-awesome-icon>
+              </div>
+            </div>
+          </template>
+        </div>
       </div>
     </div>
 
@@ -2302,11 +2304,19 @@ body {
   margin: 5px;
 }
 
-#controls {
+#ui-elements {
   position: absolute;
-  z-index: 10;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
   top: 0.5rem;
-  right: 0.5rem;
+  left: 0.5rem;
+  width: calc(100% - 1rem);
+}
+
+#controls {
+  order: 3;
+  z-index: 10;
   color: #fff;
 
   list-style-type: none;
@@ -2338,14 +2348,13 @@ body {
 }
 
 #tools {
-  position: absolute;
-  top: 0.5rem;
-  left: 50%;
+  order: 2;
   color: #fff;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
 
   .tool-container {
-    position: relative;
-    left: -50%;
     z-index: 10;
   }
 
@@ -2364,9 +2373,8 @@ body {
 }
 
 #display-panel {
-  position: absolute;
-  top: 0.5rem;
-  left: 0.5rem;
+  order: 1;
+  min-width: 175px;
   max-width: 25vw;
   border-radius: 5px;
   color: white;
@@ -2602,6 +2610,7 @@ ul.tool-menu {
 
 .item-selector {
   width: 25vw;
+  min-width: 200px;
   vertical-align: middle;
   padding: 5px;
   white-space: nowrap;
@@ -2611,6 +2620,8 @@ ul.tool-menu {
 
 .item-select-container {
   display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 
 .item-select-title {
@@ -2660,6 +2671,26 @@ ul.tool-menu {
 
 .pointer {
   cursor: pointer;
+}
+
+@media all and (max-width: 400px) {
+  #ui-elements {
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  #controls {
+    order: 2;
+  }
+
+  #tools {
+    order: 3;
+    flex-grow: 1;
+  }
+
+  .item-select-container {
+    flex-direction: column;
+  }
 }
 
 /**

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -153,7 +153,7 @@
         </ul>
       </div>
 
-      <div class="element-box" id="tools-box">
+      <div class="element-box" id="tools-box" v-if="!hideAllChrome">
         <div id="tools" v-if="!hideAllChrome" @keydown.stop>
           <div class="tool-container">
             <template v-if="currentTool == 'crossfade'">
@@ -2724,7 +2724,7 @@ ul.tool-menu {
 
   #tools-box {
     order: 3;
-    flex-grow: 1;
+    flex-grow: 0;
   }
 
   .item-select-container {
@@ -2734,6 +2734,10 @@ ul.tool-menu {
   .item-selector {
     width: 75vw;
     min-width: 75vw;
+  }
+
+  .element-box:last-child {
+    margin-right: auto;
   }
 }
 

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -2463,13 +2463,14 @@ body {
 }
 
 .load-collection-container {
-  width: 35vw;
+  width: 100%;
 
   .load-collection-label {
     width: 100%;
     font-size: 120%;
     font-weight: bold;
     margin-bottom: 0.5rem;
+    text-align: center;
   }
 
   .load-collection-row {
@@ -2478,13 +2479,15 @@ body {
     gap: 0.3rem;
     width: 100%;
     margin-top: 0.2rem;
+    justify-content: center;
 
     label {
       margin-right: 0.5rem;
     }
 
     input {
-      flex: 1;
+      width: 80%;
+      min-width: 100px;
     }
   }
 

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -2312,6 +2312,7 @@ body {
   top: 0.5rem;
   left: 0.5rem;
   width: calc(100% - 1rem);
+  gap: 5px;
 }
 
 #controls {
@@ -2350,9 +2351,6 @@ body {
 #tools {
   order: 2;
   color: #fff;
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
 
   .tool-container {
     z-index: 10;
@@ -2374,7 +2372,7 @@ body {
 
 #display-panel {
   order: 1;
-  min-width: 175px;
+  min-width: 200px;
   max-width: 25vw;
   border-radius: 5px;
   color: white;
@@ -2610,7 +2608,7 @@ ul.tool-menu {
 
 .item-selector {
   width: 25vw;
-  min-width: 200px;
+  min-width: 175px;
   vertical-align: middle;
   padding: 5px;
   white-space: nowrap;
@@ -2622,6 +2620,7 @@ ul.tool-menu {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
+  flex-direction: row;
 }
 
 .item-select-title {
@@ -2673,10 +2672,10 @@ ul.tool-menu {
   cursor: pointer;
 }
 
-@media all and (max-width: 400px) {
+@media all and (max-width: 425px) {
   #ui-elements {
     flex-wrap: wrap;
-    align-items: center;
+    gap: 15px 1px;
   }
 
   #controls {
@@ -2689,7 +2688,18 @@ ul.tool-menu {
   }
 
   .item-select-container {
-    flex-direction: column;
+    align-items: center;
+  }
+
+  .item-selector {
+    width: 75vw;
+    min-width: 75vw;
+  }
+}
+
+@media all and (max-width: 250px) {
+  #display-panel {
+    min-width: calc(100% - 30px);
   }
 }
 

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -11,276 +11,282 @@
     <!-- keydown.stops here and below prevent any keynav presses from reaching
       the toplevel UI handlers -->
     <div id="ui-elements">
-      <div id="display-panel" v-if="!hideAllChrome" @keydown.stop>
-        <transition name="catalog-transition">
-          <div id="overlays">
-            <p>{{ coordText }}</p>
+      <div class="element-box" id="display-panel-box">
+        <div id="display-panel" v-if="!hideAllChrome" @keydown.stop>
+          <transition name="catalog-transition">
+            <div id="overlays">
+              <p>{{ coordText }}</p>
+            </div>
+          </transition>
+          <div id="imagery-container" v-if="haveImagery">
+            <div class="display-section-header">
+              <label>Imagery</label>
+            </div>
+            <imageset-item
+              v-for="imageset of activeImagesetLayerStates"
+              v-bind:key="imageset.settings.name"
+              v-bind:imageset="imageset"
+            />
           </div>
-        </transition>
-        <div id="imagery-container" v-if="haveImagery">
-          <div class="display-section-header">
-            <label>Imagery</label>
+          <div id="catalogs-container" v-if="haveCatalogs">
+            <div class="display-section-header">
+              <label>Catalogs</label>
+            </div>
+            <catalog-item
+              v-for="catalog of hipsCatalogs"
+              v-bind:key="catalog.name"
+              v-bind:catalog="catalog"
+              v-bind:defaultColor="defaultColor"
+            />
           </div>
-          <imageset-item
-            v-for="imageset of activeImagesetLayerStates"
-            v-bind:key="imageset.settings.name"
-            v-bind:imageset="imageset"
-          />
-        </div>
-        <div id="catalogs-container" v-if="haveCatalogs">
-          <div class="display-section-header">
-            <label>Catalogs</label>
+          <div id="sources-container" v-if="haveSources">
+            <div class="display-section-header">
+              <label>Sources</label>
+            </div>
+            <source-item
+              v-for="source of sources"
+              v-bind:key="source.name"
+              v-bind:source="source"
+            />
           </div>
-          <catalog-item
-            v-for="catalog of hipsCatalogs"
-            v-bind:key="catalog.name"
-            v-bind:catalog="catalog"
-            v-bind:defaultColor="defaultColor"
-          />
-        </div>
-        <div id="sources-container" v-if="haveSources">
-          <div class="display-section-header">
-            <label>Sources</label>
-          </div>
-          <source-item
-            v-for="source of sources"
-            v-bind:key="source.name"
-            v-bind:source="source"
-          />
         </div>
       </div>
 
-      <ul id="controls" v-if="!hideAllChrome" @keydown.stop>
-        <li v-show="showToolMenu">
-          <v-popover placement="left" trigger="manual" :open="showPopover">
+      <div class="element-box" id="controls-box">
+        <ul id="controls" v-if="!hideAllChrome" @keydown.stop>
+          <li v-show="showToolMenu">
+            <v-popover placement="left" trigger="manual" :open="showPopover">
+              <font-awesome-icon
+                class="tooltip-target tooltip-icon"
+                icon="sliders-h"
+                size="lg"
+                tabindex="0"
+                @keyup.enter="showPopover = !showPopover"
+                @click="showPopover = !showPopover"
+              ></font-awesome-icon>
+              <template slot="popover" tabindex="-1" show="showPopover">
+                <ul class="tooltip-content tool-menu" tabindex="-1">
+                  <li v-show="showBackgroundChooser">
+                    <a
+                      href="#"
+                      v-close-popover
+                      @click="
+                        selectTool('choose-background');
+                        showPopover = false;
+                      "
+                      tabindex="0"
+                      ><font-awesome-icon icon="mountain" /> Choose background</a
+                    >
+                  </li>
+                  <li v-show="showAddImageryTool">
+                    <a
+                      href="#"
+                      v-close-popover
+                      @click="
+                        selectTool('add-imagery-layer');
+                        showPopover = false;
+                      "
+                      tabindex="0"
+                      ><font-awesome-icon icon="image" /> Add imagery as layer</a
+                    >
+                  </li>
+                  <li v-show="showCatalogTool">
+                    <a
+                      href="#"
+                      v-close-popover
+                      @click="
+                        selectTool('choose-catalog');
+                        showPopover = false;
+                      "
+                      tabindex="0"
+                      ><font-awesome-icon icon="map-marked-alt" /> Add HiPS
+                      catalogs</a
+                    >
+                  </li>
+                  <li v-show="showCollectionLoader">
+                    <a
+                      href="#"
+                      v-close-popover
+                      @click="
+                        selectTool('load-collection');
+                        showPopover = false;
+                      "
+                      tabindex="0"
+                      ><font-awesome-icon icon="photo-video" /> Load WTML
+                      collection</a
+                    >
+                  </li>
+                </ul>
+              </template>
+            </v-popover>
+          </li>
+          <li v-show="!wwtIsTourPlaying">
             <font-awesome-icon
-              class="tooltip-target tooltip-icon"
-              icon="sliders-h"
+              icon="search-plus"
               size="lg"
+              class="tooltip-icon"
+              @keyup.enter="doZoom(true)"
+              @click="doZoom(true)"
               tabindex="0"
-              @keyup.enter="showPopover = !showPopover"
-              @click="showPopover = !showPopover"
             ></font-awesome-icon>
-            <template slot="popover" tabindex="-1" show="showPopover">
-              <ul class="tooltip-content tool-menu" tabindex="-1">
-                <li v-show="showBackgroundChooser">
-                  <a
-                    href="#"
-                    v-close-popover
-                    @click="
-                      selectTool('choose-background');
-                      showPopover = false;
-                    "
-                    tabindex="0"
-                    ><font-awesome-icon icon="mountain" /> Choose background</a
-                  >
-                </li>
-                <li v-show="showAddImageryTool">
-                  <a
-                    href="#"
-                    v-close-popover
-                    @click="
-                      selectTool('add-imagery-layer');
-                      showPopover = false;
-                    "
-                    tabindex="0"
-                    ><font-awesome-icon icon="image" /> Add imagery as layer</a
-                  >
-                </li>
-                <li v-show="showCatalogTool">
-                  <a
-                    href="#"
-                    v-close-popover
-                    @click="
-                      selectTool('choose-catalog');
-                      showPopover = false;
-                    "
-                    tabindex="0"
-                    ><font-awesome-icon icon="map-marked-alt" /> Add HiPS
-                    catalogs</a
-                  >
-                </li>
-                <li v-show="showCollectionLoader">
-                  <a
-                    href="#"
-                    v-close-popover
-                    @click="
-                      selectTool('load-collection');
-                      showPopover = false;
-                    "
-                    tabindex="0"
-                    ><font-awesome-icon icon="photo-video" /> Load WTML
-                    collection</a
-                  >
-                </li>
-              </ul>
+          </li>
+          <li v-show="!wwtIsTourPlaying">
+            <font-awesome-icon
+              icon="search-minus"
+              size="lg"
+              class="tooltip-icon"
+              @keyup.enter="doZoom(false)"
+              @click="doZoom(false)"
+              tabindex="0"
+            ></font-awesome-icon>
+          </li>
+          <li v-show="fullscreenAvailable">
+            <font-awesome-icon
+              v-bind:icon="fullscreenModeActive ? 'compress' : 'expand'"
+              size="lg"
+              class="nudgeright1 tooltip-icon"
+              @keyup.enter="toggleFullscreen()"
+              @click="toggleFullscreen()"
+              tabindex="0"
+            ></font-awesome-icon>
+          </li>
+        </ul>
+      </div>
+
+      <div class="element-box" id="tools-box">
+        <div id="tools" v-if="!hideAllChrome" @keydown.stop>
+          <div class="tool-container">
+            <template v-if="currentTool == 'crossfade'">
+              <span>Foreground opacity:</span>
+              <input
+                class="opacity-range"
+                type="range"
+                v-model="foregroundOpacity"
+              />
             </template>
-          </v-popover>
-        </li>
-        <li v-show="!wwtIsTourPlaying">
-          <font-awesome-icon
-            icon="search-plus"
-            size="lg"
-            class="tooltip-icon"
-            @keyup.enter="doZoom(true)"
-            @click="doZoom(true)"
-            tabindex="0"
-          ></font-awesome-icon>
-        </li>
-        <li v-show="!wwtIsTourPlaying">
-          <font-awesome-icon
-            icon="search-minus"
-            size="lg"
-            class="tooltip-icon"
-            @keyup.enter="doZoom(false)"
-            @click="doZoom(false)"
-            tabindex="0"
-          ></font-awesome-icon>
-        </li>
-        <li v-show="fullscreenAvailable">
-          <font-awesome-icon
-            v-bind:icon="fullscreenModeActive ? 'compress' : 'expand'"
-            size="lg"
-            class="nudgeright1 tooltip-icon"
-            @keyup.enter="toggleFullscreen()"
-            @click="toggleFullscreen()"
-            tabindex="0"
-          ></font-awesome-icon>
-        </li>
-      </ul>
 
-      <div id="tools" v-if="!hideAllChrome" @keydown.stop>
-        <div class="tool-container">
-          <template v-if="currentTool == 'crossfade'">
-            <span>Foreground opacity:</span>
-            <input
-              class="opacity-range"
-              type="range"
-              v-model="foregroundOpacity"
-            />
-          </template>
-
-          <template v-else-if="currentTool == 'choose-background'">
-            <div id="bg-select-container" class="item-select-container">
-              <span id="bg-select-title" class="item-select-title"
-                >Background imagery:</span
-              >
-              <v-select
-                v-model="curBackgroundImagesetName"
-                id="bg-select"
-                class="item-selector"
-                :searchable="true"
-                :clearable="false"
-                :options="curAvailableImagesets"
-                :filter="filterImagesets"
-                :close-on-select="true"
-                :reduce="(bg) => bg.name"
-                label="name"
-                placeholder="Background"
-              >
-                <template #option="option">
-                  <div class="item-option">
-                    <h4 class="ellipsize">{{ option.name }}</h4>
-                    <p class="ellipsize"><em>{{ option.description }}</em></p>
-                  </div>
-                </template>
-                <template #selected-option="option">
-                  <div class="ellipsize">{{ option.name }}</div>
-                </template>
-              </v-select>
-            </div>
-          </template>
-
-          <template v-else-if="currentTool == 'add-imagery-layer'">
-            <div class="item-select-container">
-              <span class="item-select-title">Add imagery layer:</span>
-              <v-select
-                v-model="imageryToAdd"
-                class="item-selector"
-                :searchable="true"
-                :clearable="false"
-                :options="curAvailableImageryData"
-                :filter="filterImagesets"
-                label="name"
-                placeholder="Dataset"
-              >
-                <template #option="option">
-                  <div class="item-option">
-                    <h4 class="ellipsize">{{ option.name }}</h4>
-                    <p class="ellipsize"><em>{{ option.description }}</em></p>
-                  </div>
-                </template>
-                <template #selected-option="option">
-                  <div class="ellipsize">{{ option.name }}</div>
-                </template>
-                <template #no-options="{ search, searching }">
-                  <template v-if="searching">
-                    No datasets matching <em>{{ search }}</em
-                    >.
-                  </template>
-                  <em v-else>No datasets available. Load a WTML collection?</em>
-                </template>
-              </v-select>
-            </div>
-          </template>
-
-          <template v-else-if="showCatalogChooser">
-            <div id="catalog-select-container-tool" class="item-select-container">
-              <span class="item-select-title">Add catalog:</span>
-              <v-select
-                v-model="catalogToAdd"
-                id="catalog-select-tool"
-                class="item-selector"
-                :searchable="true"
-                :clearable="false"
-                :options="curAvailableCatalogs"
-                :filter="filterCatalogs"
-                @change="(cat) => addHipsByName(cat.name)"
-                label="name"
-                placeholder="Catalog"
-              >
-                <template #option="option">
-                  <div class="item-option">
-                    <h4 class="ellipsize">{{ option.name }}</h4>
-                    <p class="ellipsize"><em>{{ option.description }}</em></p>
-                  </div>
-                </template>
-                <template #selected-option-container="">
-                  <div></div>
-                </template>
-              </v-select>
-            </div>
-          </template>
-
-          <template v-else-if="currentTool == 'load-collection'">
-            <div class="load-collection-container">
-              <div class="load-collection-label">
-                Load
-                <a
-                  href="https://docs.worldwidetelescope.org/data-guide/1/data-file-formats/collections/"
-                  target="_blank"
-                  >WTML</a
+            <template v-else-if="currentTool == 'choose-background'">
+              <div id="bg-select-container" class="item-select-container">
+                <span id="bg-select-title" class="item-select-title"
+                  >Background imagery:</span
                 >
-                data collection:
+                <v-select
+                  v-model="curBackgroundImagesetName"
+                  id="bg-select"
+                  class="item-selector"
+                  :searchable="true"
+                  :clearable="false"
+                  :options="curAvailableImagesets"
+                  :filter="filterImagesets"
+                  :close-on-select="true"
+                  :reduce="(bg) => bg.name"
+                  label="name"
+                  placeholder="Background"
+                >
+                  <template #option="option">
+                    <div class="item-option">
+                      <h4 class="ellipsize">{{ option.name }}</h4>
+                      <p class="ellipsize"><em>{{ option.description }}</em></p>
+                    </div>
+                  </template>
+                  <template #selected-option="option">
+                    <div class="ellipsize">{{ option.name }}</div>
+                  </template>
+                </v-select>
               </div>
-              <div class="load-collection-row">
-                <label>URL:</label>
-                <input
-                  type="url"
-                  v-model="wtmlCollectionUrl"
-                  @keyup.enter="submitWtmlCollectionUrl"
-                />
-                <font-awesome-icon
-                  icon="arrow-circle-right"
-                  size="lg"
-                  class="load-collection-icon"
-                  @keyup.enter="submitWtmlCollectionUrl"
-                  @click="submitWtmlCollectionUrl"
-                  tabindex="0"
-                ></font-awesome-icon>
+            </template>
+
+            <template v-else-if="currentTool == 'add-imagery-layer'">
+              <div class="item-select-container">
+                <span class="item-select-title">Add imagery layer:</span>
+                <v-select
+                  v-model="imageryToAdd"
+                  class="item-selector"
+                  :searchable="true"
+                  :clearable="false"
+                  :options="curAvailableImageryData"
+                  :filter="filterImagesets"
+                  label="name"
+                  placeholder="Dataset"
+                >
+                  <template #option="option">
+                    <div class="item-option">
+                      <h4 class="ellipsize">{{ option.name }}</h4>
+                      <p class="ellipsize"><em>{{ option.description }}</em></p>
+                    </div>
+                  </template>
+                  <template #selected-option="option">
+                    <div class="ellipsize">{{ option.name }}</div>
+                  </template>
+                  <template #no-options="{ search, searching }">
+                    <template v-if="searching">
+                      No datasets matching <em>{{ search }}</em
+                      >.
+                    </template>
+                    <em v-else>No datasets available. Load a WTML collection?</em>
+                  </template>
+                </v-select>
               </div>
-            </div>
-          </template>
+            </template>
+
+            <template v-else-if="showCatalogChooser">
+              <div id="catalog-select-container-tool" class="item-select-container">
+                <span class="item-select-title">Add catalog:</span>
+                <v-select
+                  v-model="catalogToAdd"
+                  id="catalog-select-tool"
+                  class="item-selector"
+                  :searchable="true"
+                  :clearable="false"
+                  :options="curAvailableCatalogs"
+                  :filter="filterCatalogs"
+                  @change="(cat) => addHipsByName(cat.name)"
+                  label="name"
+                  placeholder="Catalog"
+                >
+                  <template #option="option">
+                    <div class="item-option">
+                      <h4 class="ellipsize">{{ option.name }}</h4>
+                      <p class="ellipsize"><em>{{ option.description }}</em></p>
+                    </div>
+                  </template>
+                  <template #selected-option-container="">
+                    <div></div>
+                  </template>
+                </v-select>
+              </div>
+            </template>
+
+            <template v-else-if="currentTool == 'load-collection'">
+              <div class="load-collection-container">
+                <div class="load-collection-label">
+                  Load
+                  <a
+                    href="https://docs.worldwidetelescope.org/data-guide/1/data-file-formats/collections/"
+                    target="_blank"
+                    >WTML</a
+                  >
+                  data collection:
+                </div>
+                <div class="load-collection-row">
+                  <label>URL:</label>
+                  <input
+                    type="url"
+                    v-model="wtmlCollectionUrl"
+                    @keyup.enter="submitWtmlCollectionUrl"
+                  />
+                  <font-awesome-icon
+                    icon="arrow-circle-right"
+                    size="lg"
+                    class="load-collection-icon"
+                    @keyup.enter="submitWtmlCollectionUrl"
+                    @click="submitWtmlCollectionUrl"
+                    tabindex="0"
+                  ></font-awesome-icon>
+                </div>
+              </div>
+            </template>
+          </div>
         </div>
       </div>
     </div>
@@ -2261,6 +2267,12 @@ export default class App extends WWTAwareComponent {
 </script>
 
 <style lang="less">
+
+/** Note: the CSS is designed to keep the tools element (which contains the various dropdown selectors) 
+  * centered at all times. This is done by using nested flexbox containers, based on the first answer
+  * from https://stackoverflow.com/questions/32378953/keep-the-middle-item-centered-when-side-items-have-different-widths
+*/
+
 html {
   height: 100%;
   margin: 0;
@@ -2307,16 +2319,40 @@ body {
 #ui-elements {
   position: absolute;
   display: flex;
-  justify-content: space-between;
   align-items: flex-start;
   top: 0.5rem;
   left: 0.5rem;
   width: calc(100% - 1rem);
-  gap: 5px;
+}
+
+.element-box {
+  display: flex;
+}
+
+.element-box:first-child {
+  margin-right: auto;
+}
+.element-box:last-child {
+  margin-left: auto; 
+}
+
+#display-panel-box {
+  flex: 2;
+  order: 1;
+}
+
+#tools-box {
+  flex: 3;
+  order: 2;
+}
+
+#controls-box {
+  flex: 2;
+  order: 3;
+  justify-content: flex-end;
 }
 
 #controls {
-  order: 3;
   z-index: 10;
   color: #fff;
 
@@ -2351,6 +2387,10 @@ body {
 #tools {
   order: 2;
   color: #fff;
+  left: -calc(12.5vw - 15px);
+  width: 100%;
+  display: flex;
+  justify-content: center;
 
   .tool-container {
     z-index: 10;
@@ -2678,11 +2718,11 @@ ul.tool-menu {
     gap: 15px 1px;
   }
 
-  #controls {
+  #controls-box {
     order: 2;
   }
 
-  #tools {
+  #tools-box {
     order: 3;
     flex-grow: 1;
   }
@@ -2699,7 +2739,12 @@ ul.tool-menu {
 
 @media all and (max-width: 250px) {
   #display-panel {
-    min-width: calc(100% - 30px);
+    width: 100%;
+    min-width: 100%;
+  }
+
+  #controls-box {
+    flex: 0;
   }
 }
 


### PR DESCRIPTION
This PR modifies the research app UI to be more responsive to changes in screen size. This is done via flexbox layouts (sometimes nested). The main things that this layout looks to achieve are the following:

- Keep the selection tools centered on the screen while preventing any overlap with the display panel. The top-level flexbox containers that wrap the display panel, tools, and controls have `flex` values of 2, 3,  and 2, respectively, which means that the share of horizontal space allocated to the `display-panel-box` is 2/7, or about 28%. The display panel has a `max-width` of `25vw`.
  * Using 1,2,1 gives the display panel no extra space inside of its container (unless the browser is spanning multiple monitors), which I thought looked worse when shrinking the screen size. Using 4, 7, 4 (which gives a share of 4/15, or about 27%, to the display panel container), didn't look noticeably different than 2, 3, 2.
- Keep a minimum width (of `200px`) for the display panel, to preserve usability, until the screen width becomes very small.
- When the screen becomes narrow (less than `425px`), the selection tools wrap onto the next line, below the display panel and the controls, and are centered horizontally.
- For very narrow screens (narrower than `250px`), the display panel will shrink to accommodate the controls. I didn't want to have the controls wrap to the next line - since they're relatively tall and narrow, it doesn't look very good.

For the very narrow (sub-`250px`) screens some of the display panel items can get cut off. Once we get the large-scale behavior finalized I might go take another look at some of them, but I think there's also just a limit to what can be done with such a narrow screen.