### PR TITLE
research-app: Fix blocking of pointer events by UI elements container

### DIFF
--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -2366,6 +2366,7 @@ body {
 #tools-box {
   flex: 3;
   order: 2;
+  justify-content: center;
 }
 
 #controls-box {
@@ -2411,8 +2412,6 @@ body {
   pointer-events: auto;
   order: 2;
   color: #fff;
-  left: -calc(12.5vw - 15px);
-  width: 100%;
   display: flex;
   justify-content: center;
 


### PR DESCRIPTION
This PR fixes the fact that the `#ui-elements` container for the UI elements at the top of research app blocks pointer events - most noticeably, one can't pan if the mouse is in this area.

The fix is simple - assign `pointer-events: none` to `#ui-elements`, and `pointer-events: auto` to each of `#display-panel`, `#tools`, and `#controls`. This has the effect that pointer events are ignored by the empty space of the `#ui-elements` container.