### PR TITLE
research-app: Tweak imageset panel items

### DIFF
--- a/research-app/src/ImagesetItem.vue
+++ b/research-app/src/ImagesetItem.vue
@@ -77,9 +77,9 @@
             </option>
           </select>
         </div>
-
+      
         <div class="detail-row">
-          <span class="prompt">Low cutoff:</span>
+          <span class="prompt cutoff">Low cutoff:</span>
           <input
             type="text"
             class="detail-input"
@@ -95,7 +95,7 @@
         </div>
 
         <div class="detail-row">
-          <span class="prompt">High cutoff:</span>
+          <span class="prompt cutoff">High cutoff:</span>
           <input
             type="text"
             class="detail-input"
@@ -483,6 +483,11 @@ export default class ImagesetItem extends Vue {
   }
 }
 
+select {
+  width: 70%;
+  max-width: fit-content;
+}
+
 .detail-container {
   font-size: 9pt;
   margin: 0px 5px;
@@ -508,6 +513,13 @@ export default class ImagesetItem extends Vue {
   display: flex;
   align-items: center;
   gap: 2px;
+  justify-content: flex-start;
+}
+
+.detail-input {
+  flex: 1;
+  min-width: 10px;
+  text-align: center;
 }
 
 .scrubber {
@@ -515,8 +527,9 @@ export default class ImagesetItem extends Vue {
   cursor: pointer;
 }
 
-.detail-input {
-  flex: 1;
-  text-align: center;
+.cutoff {
+  width: 84px;
+  padding-right: 0px;
 }
+
 </style>


### PR DESCRIPTION
This PR makes the UI elements of an imageset item in the display panel shrink appropriately to fit the display panel size (currently they can be hidden when the display panel shrinks).

The "Colormap" and "Stretch" `select`s now shrink to fit within the item container, as do the `input`s for the low and high cutoffs. I allowed the cutoff inputs to grow with the display panel, since they display a large number of decimal places. I also set the prompt labels for the two cutoff fields to have a fixed width (`84px`). Without this, on every screen that I tried, the "Low cutoff" and "High cutoff" labels were _almost_ the same width, and the small difference made the two rows look sloppy. We could line up all of the inputs/selects if we wanted, but it would waste some space, particularly on the "Stretch" row.