### PR TITLE
Prepared HealpixTile for planetary HiPS

### DIFF
--- a/engine/wwtlib/HealpixTile.cs
+++ b/engine/wwtlib/HealpixTile.cs
@@ -251,8 +251,15 @@ namespace wwtlib
 
         public override bool IsTileBigEnough(RenderContext renderContext)
         {
-            double arcPixels = (3600 / (Math.Pow(2, Level) * 4));
-            return (renderContext.FovScale < arcPixels);
+            if(dataset.DataSetType == ImageSetType.Planet)
+            {
+                double arcPixels = (180 / (Math.Pow(2, Level) * 4));
+                return (renderContext.FovScale < arcPixels);
+            } else
+            {
+                double arcPixels = (3600 / (Math.Pow(2, Level) * 4));
+                return (renderContext.FovScale < arcPixels);
+            }
         }
 
         private Vector3d[] Boundaries(int x, int y, int step)


### PR DESCRIPTION
Simple fix to handle planetary HiPS. Really cool with the latest Planets & Moons category from https://github.com/WorldWideTelescope/wwt-hips-list-importer/commit/1b227fec7f644ad99c2da092451c37dde76866cd

There is definitely a more accurate way of calculating whether the tile is big enough. For example, calculating the number of screen pixels currently covered by either of the tile sides while also taking into account that the number of pixels per tile can vary in different HiPS. But this very simple heuristic actually seems to work quite well.