### PR TITLE
research-app: Fix issue with query scripting

### DIFF
--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -1398,10 +1398,9 @@ export default class App extends WWTAwareComponent {
 
   getQueryScript(location: Location): string | null {
     if (!location) {
-      return;
+      return null;
     }
     const query = new URLSearchParams(location.search);
-
     return query.get('script');
   }
 

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -1512,7 +1512,7 @@ export default class App extends WWTAwareComponent {
             messagesOfType.splice(messagesOfType.indexOf(m), 1);
           });
           if (messagesOfType.length === 0) {
-            this.messageHandlers.delete(msgType);
+            this.messageHandlers.delete(completedType);
             finishedMessageTypes.push(msgType);
             nextTypesPresent.filter(prerequisitesMet).forEach(addMessagesOfType);
           }

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -1195,13 +1195,21 @@ export default class App extends WWTAwareComponent {
     }
 
     this.waitForReady().then(() => {
+
+      const script = this.getQueryScript(window.location);
+      if (script !== null) {
+        this.statusMessageDestination = window;
+      }
+
       // This returns a promise but I don't think that we need to wait for that
       // to resolve before going ahead and starting to listen for messages.
       this.loadImageCollection({ url: this.hipsUrl, loadChildFolders: true })
         .then(() => {
-          // Get and handle the query parameters
+          // Handle the query script
           // We (potentially) need the catalogs to have finished loading for this
-          this.handleQueryParameters(window.location);
+          if (script !== null) {
+            this.handleQueryScript(script);
+          }
         });
 
       // Don't start listening for messages until the engine is ready to go.
@@ -1388,20 +1396,18 @@ export default class App extends WWTAwareComponent {
     }
   }
 
-  handleQueryParameters(location: Location): void {
+  getQueryScript(location: Location): string | null {
     if (!location) {
       return;
     }
     const query = new URLSearchParams(location.search);
 
-    const msgs = query.get('script');
-    if (!msgs) {
-      return;
-    }
+    return query.get('script');
+  }
 
-    //const decoded = decompress(msgs) as string;
-    const decoded = msgs;
-    const messageStrings = decoded.split(",");
+  handleQueryScript(script: string): void {
+
+    const messageStrings = script.split(",");
     const messages: Message[] = messageStrings.map(str => this.decodeObjectBase64(str))
                                     .filter((obj): obj is Message => "event" in obj || "type" in obj);
 


### PR DESCRIPTION
I think this PR should do the trick as far as fixing up `statusMessageDestination` issue that was popping up in the release version of the app. Basically, the idea is to do something similar to what we do with `allowedOrigin`: if there is a query script present, we set `statusMessageDestination` early as the current window. In this case, it's in the `then` block after `waitForReady` rather than in `main.ts`. To facilitate this, I split out the part of the code that grabs the query script.

Also, this PR fixes another bug in the query message handling that was causing the wrong message handler to be removed when a message type that needs a reply was completed. (This is on what is now line 1514). Now, after the query script initialization is complete, the message handler table is left in the same state as it would be with no query script.