### PR TITLE
Filled annotation circle performance improvement

### DIFF
--- a/engine/wwtlib/Annotation.cs
+++ b/engine/wwtlib/Annotation.cs
@@ -15,6 +15,7 @@ namespace wwtlib
 
         protected static PointList PointList = null;
         protected static LineList LineList = null;
+        protected static TriangleFanList TriangleFanPointList = null;
         protected static TriangleList TriangleList = null;
 
         public static bool BatchDirty = true;
@@ -24,6 +25,7 @@ namespace wwtlib
             {
                 PointList = new PointList(renderContext);
                 LineList = new LineList();
+                TriangleFanPointList = new TriangleFanList();
                 TriangleList = new TriangleList();
                 LineList.DepthBuffered = false;
                 TriangleList.DepthBuffered = false;
@@ -46,6 +48,12 @@ namespace wwtlib
             if (LineList != null)
             {
                 LineList.DrawLines(renderContext, 1);
+            }
+
+
+            if (TriangleFanPointList != null)
+            {
+                TriangleFanPointList.Draw(renderContext, 1);
             }
 
             if (TriangleList != null)
@@ -155,7 +163,7 @@ namespace wwtlib
 
         bool fill = false;
 
-        
+
         public bool Fill
         {
             get { return fill; }
@@ -294,16 +302,12 @@ namespace wwtlib
                         {
                             LineList.AddLine(vertexList[i], vertexList[i + 1], lineColor, new Dates(0, 1));
                         }
-                        LineList.AddLine(vertexList[vertexList.Count - 1], vertexList[0], lineColor, new Dates(0, 1));
                     }
                     if (fill)
                     {
-                        List<int> indexes = Tessellator.TesselateSimplePoly(vertexList);
-
-                        for (int i = 0; i < indexes.Count; i += 3)
-                        {
-                            TriangleList.AddSubdividedTriangles(vertexList[indexes[i]], vertexList[indexes[i + 1]], vertexList[indexes[i + 2]], fillColor, new Dates(0, 1), 2);
-                        }
+                        Vector3d pos = Vector3d.Create(center.X, center.Y, center.Z);
+                        vertexList.Insert(0, pos);
+                        TriangleFanPointList.AddShape(vertexList, fillColor, new Dates(0, 1));
                     }
                     AnnotationDirty = false;
                 }


### PR DESCRIPTION
This reduces the memory usage of filled circles by >98%. While this can be improved further, this is the 20% of the effort giving 80% of the value. 

The performance is still not optimal when showing thousands of filled circles, but now it is at least functional. 

With the previous implementation the inside of the circle was filled with 1136 triangles. Each of these triangles have 3 points. Each of the points have a position (x, y, z), a normal (x, y z), a start date and end date, a color (rgba). So, in total, filling a circle required 1136 * 3 * (3 + 3 + 1 + 1 + 4) = 40 896 numbers. So no wonder there were some issues :smile:

The new implementation reduces the number of points to 74 and removes the normal -> 74 * (3 + 1 + 1 + 4) = 666 numbers per filled circle. 

With some changes, we could reduce it to 228 numbers, since we only really need one set of the dates and color. But this would require breaking some current engine conventions to implement. 

In theory, I think it should be possible to draw a quad (two triangles), and use the fragment shader to only fill within a radius from the quad center, which would draw a circle. This, together with the above improvement would draw the same shape with 4 * 3 + 1 + 1 + 4 = 18 numbers. So there is another ~98% memory reduction available should we need it.

The utopian solution (using only 9 numbers) of creating the circle in the fragment shader with a single position as input due to limitation in point size (ALIASED_POINT_SIZE, which is also different for different systems). This limitation causes the circle to not grow when zooming past a certain point.
