### PR TITLE
Webfile localhost error

### DIFF
--- a/engine/wwtlib/HealpixTile.cs
+++ b/engine/wwtlib/HealpixTile.cs
@@ -681,11 +681,11 @@ namespace wwtlib
                         });
                     } else
                     {
-                        FitsImageJs image = FitsImageJs.CreateTiledFits(dataset, URL, delegate (WcsImage wcsImage)
+                        fitsImage = FitsImageJs.CreateTiledFits(dataset, URL, delegate (WcsImage wcsImage)
                         {
                             texReady = true;
                             Downloading = false;
-                            errored = false;
+                            errored = fitsImage.errored;
                             ReadyToRender = texReady && (DemReady || !demTile);
                             RequestPending = false;
                             TileCache.RemoveFromQueue(this.Key, true);

--- a/engine/wwtlib/TangentTile.cs
+++ b/engine/wwtlib/TangentTile.cs
@@ -115,7 +115,7 @@ namespace wwtlib
 
                             texReady = true;
                             Downloading = false;
-                            errored = false;
+                            errored = fitsImage.errored;
                             ReadyToRender = texReady && (DemReady || !demTile);
                             RequestPending = false;
                             TileCache.RemoveFromQueue(this.Key, true);

--- a/engine/wwtlib/WebFile.cs
+++ b/engine/wwtlib/WebFile.cs
@@ -124,9 +124,14 @@ namespace wwtlib
 
                                 string new_url = URLHelpers.singleton.activateProxy(_url);
 
-                                if (new_url != null) { // null => don't bother: we know that the proxy won't help
+                                if (new_url != null) // null => don't bother: we know that the proxy won't help
+                                {
                                     _url = new_url;
                                     CORS();
+                                } else
+                                {
+                                    _message = xhr.StatusText;
+                                    State = StateType.Error;
                                 }
                             }
                         }


### PR DESCRIPTION
The WebFile State for localhost urls, or requests tagged with WWTFlagship or NeverProxy were never updated if the request failed. So the users of WebFile were never notified that a problem occurred. This was especially noticeable when loading HiPS from localhost, which often requests tiles that don't exist.

I also attached a small update to correct the error state of FitsImageJs (used by browsers not supporting WebGL2) in case of errors. 