### PR TITLE
Fix SpreadSheetLayer longitude values

### DIFF
--- a/engine/wwtlib/Coordinates.cs
+++ b/engine/wwtlib/Coordinates.cs
@@ -108,7 +108,7 @@ namespace wwtlib
                     meridean = -meridean;
                 }
             }
-            return Coordinates.GeoTo3dDoubleRad(lat, 90 + lng + meridean, radius);
+            return Coordinates.GeoTo3dRad(lat, 90 + lng + meridean, radius);
         }
 
         //static public Coordinates EquitorialToHorizon4(Coordinates equitorial, Coordinates location, Date utc)

--- a/engine/wwtlib/Coordinates.cs
+++ b/engine/wwtlib/Coordinates.cs
@@ -65,7 +65,7 @@ namespace wwtlib
             x -= falseEasting;
             y -= falseNorthing;
 
-           
+
 
             if (x != 0 || y != 0)
             {
@@ -280,7 +280,7 @@ namespace wwtlib
 
             return Vector2d.Create(hrAngle,dec);
         }
-      
+
         //static void AltAzToRaDec2(double alt, double az, out double hrAngle, out double dec, double lat)
         //{
         //    if (alt == 0)
@@ -290,7 +290,7 @@ namespace wwtlib
         //    if (az == 0)
         //    {
         //        az = .00000000001;
-        //    } 
+        //    }
         //    double sin_dec;
         //    double cos_lat = Math.Cos(lat);
 
@@ -400,7 +400,7 @@ namespace wwtlib
             return mst;
         }
 
-        
+
 
         public double RA
         {
@@ -431,7 +431,7 @@ namespace wwtlib
         {
             get
             {
-                
+
                 return declination / RC;
             }
             set
@@ -457,7 +457,7 @@ namespace wwtlib
 
             }
             //todo This was broken check callers to see what effect it had.
-            set 
+            set
             {
                 ascention = ((value*RC)+(Math.PI*2)%(Math.PI*2));
             }
@@ -523,14 +523,14 @@ namespace wwtlib
             else
             {
                 ascention = 0;
-            } 
-               
-            
+            }
+
+
             return new Coordinates(ascention, declination);
 
         }
 
-        
+
         static public Coordinates CartesianToSpherical2(Vector3d vector)
         {
 		    double rho = Math.Sqrt(vector.X * vector.X + vector.Y * vector.Y + vector.Z * vector.Z);
@@ -575,7 +575,7 @@ namespace wwtlib
         {
             return target < 0 ? -1 : 1;
         }
-     
+
         static public string FormatDMSSign(double angle, bool sign)
         {
 
@@ -736,7 +736,7 @@ namespace wwtlib
         //            }
 
         //            val = sign * (hours + minutes / 60 + seconds / 3600);
-        //        } 
+        //        }
         //        else
         //        {
         //            val = Convert.ToDouble(data);
@@ -750,7 +750,7 @@ namespace wwtlib
         //    {
         //        return false;
         //    }
-  
+
         //}
 
         //static public bool Validate(string data)
@@ -821,10 +821,10 @@ namespace wwtlib
 
         static public double ParseDec(string data)
         {
-          
+
             double dec = Parse(data);
             return Math.Max(Math.Min(dec, 90.00), -90);
-          
+
         }
 
         //static public bool ValidateDec(string data)
@@ -873,7 +873,7 @@ namespace wwtlib
 
         //            double val = sign * (hours + minutes / 60 + seconds / 3600);
         //            return (val >= -90 && val <= 90);
-        //        } 
+        //        }
         //        else
         //        {
         //            double val = Convert.ToDouble(data);
@@ -885,7 +885,7 @@ namespace wwtlib
         //    {
         //        return false;
         //    }
-        //} 
+        //}
 
         static public double Parse(string data)
         {
@@ -955,8 +955,8 @@ namespace wwtlib
             {
                 return 0;
             }
-        }   
-        
+        }
+
         //public static bool operator == (Coordinates one, Coordinates two)
         //{
         //    if (!(one is Coordinates))
@@ -1088,7 +1088,7 @@ namespace wwtlib
                                                + DMSToDegrees(0, 0, 1999.25) * Ucubed
                                                - DMSToDegrees(0, 0, 51.38) * U4
                                                - DMSToDegrees(0, 0, 249.67) * U5
-                                               - DMSToDegrees(0, 0, 39.05) * U6 
+                                               - DMSToDegrees(0, 0, 39.05) * U6
                                                + DMSToDegrees(0, 0, 7.12) * U7
                                                + DMSToDegrees(0, 0, 27.87) * U8
                                                + DMSToDegrees(0, 0, 5.79) * U9

--- a/engine/wwtlib/Coordinates.cs
+++ b/engine/wwtlib/Coordinates.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-
 
 namespace wwtlib
 {
@@ -10,39 +8,36 @@ namespace wwtlib
         protected const double RC = (3.1415927 / 180.0);
         protected const double RCRA = (3.1415927 / 12.0);
         protected const float radius = 1;
+
         static public Vector3d GeoTo3d(double lat, double lng)
         {
             return Vector3d.Create((Math.Cos(lng * RC) * Math.Cos(lat * RC) * radius), (Math.Sin(lat * RC) * radius), (Math.Sin(lng * RC) * Math.Cos(lat * RC) * radius));
-
         }
 
         static public Vector3d GeoTo3dDouble(double lat, double lng)
         {
             return Vector3d.Create(Math.Cos(lng * RC) * Math.Cos(lat * RC) * radius, Math.Sin(lat * RC) * radius, Math.Sin(lng * RC) * Math.Cos(lat * RC) * radius);
-
         }
+
         static public Vector3d GeoTo3dDoubleRad(double lat, double lng, double radius)
         {
             lng -= 180;
             return Vector3d.Create(Math.Cos(lng * RC) * Math.Cos(lat * RC) * radius, Math.Sin(lat * RC) * radius, Math.Sin(lng * RC) * Math.Cos(lat * RC) * radius);
-
         }
+
         static public Vector3d GeoTo3dRad(double lat, double lng, double radius)
         {
             return Vector3d.Create(((Math.Cos(lng * RC)) * (Math.Cos(lat * RC)) * radius), ((Math.Sin(lat * RC) * radius)), ((Math.Sin(lng * RC)) * (Math.Cos(lat * RC)) * radius));
-
         }
 
         static public Vector3d RADecTo3d(double ra, double dec)
         {
             return Vector3d.Create((Math.Cos(ra * RCRA) * Math.Cos(dec * RC) * radius), (Math.Sin(dec * RC) * radius), (Math.Sin(ra * RCRA) * Math.Cos(dec * RC) * radius));
-
         }
 
         static public Vector3d RADecTo3dAu(double ra, double dec, double au)
         {
             return Vector3d.Create((Math.Cos(ra * RCRA) * Math.Cos(dec * RC) * au), (Math.Sin(dec * RC) * au), (Math.Sin(ra * RCRA) * Math.Cos(dec * RC) * au));
-
         }
 
         static public Vector3d RADecTo3dMat(double ra, double dec, Matrix3d mat)
@@ -54,9 +49,10 @@ namespace wwtlib
         {
             point.Dec = -point.Dec;
             return Vector3d.Create((Math.Cos(point.RA * RCRA) * Math.Cos(point.Dec * RC) * radius), (Math.Sin(point.Dec * RC) * radius), (Math.Sin(point.RA * RCRA) * Math.Cos(point.Dec * RC) * radius));
-
         }
+
         const double EarthRadius = 6371000;
+
         static public Vector3d SterographicTo3d(double x, double y, double radius, double standardLat, double meridean, double falseEasting, double falseNorthing, double scale, bool north )
         {
             double lat=90;
@@ -64,8 +60,6 @@ namespace wwtlib
 
             x -= falseEasting;
             y -= falseNorthing;
-
-
 
             if (x != 0 || y != 0)
             {

--- a/engine/wwtlib/Coordinates.cs
+++ b/engine/wwtlib/Coordinates.cs
@@ -9,6 +9,12 @@ namespace wwtlib
         protected const double RCRA = (3.1415927 / 12.0);
         protected const float radius = 1;
 
+        // NB: these functions are redundant in the webclient because we don't
+        // have the single-precision `Vector3` type that's distinguished from
+        // `Vector3d`. To minimize the code delta from Windows, we keep both
+        // names for simplicity. But the `...Rad` functions are added because
+        // ScriptSharp can't deal with overloads.
+
         static public Vector3d GeoTo3d(double lat, double lng)
         {
             return Vector3d.Create(Math.Cos(lng * RC) * Math.Cos(lat * RC) * radius, Math.Sin(lat * RC) * radius, Math.Sin(lng * RC) * Math.Cos(lat * RC) * radius);
@@ -19,11 +25,10 @@ namespace wwtlib
             return Vector3d.Create(Math.Cos(lng * RC) * Math.Cos(lat * RC) * radius, Math.Sin(lat * RC) * radius, Math.Sin(lng * RC) * Math.Cos(lat * RC) * radius);
         }
 
-        static public Vector3d GeoTo3dDoubleRad(double lat, double lng, double radius)
-        {
-            lng -= 180;
-            return Vector3d.Create(Math.Cos(lng * RC) * Math.Cos(lat * RC) * radius, Math.Sin(lat * RC) * radius, Math.Sin(lng * RC) * Math.Cos(lat * RC) * radius);
-        }
+        //static public Vector3d GeoTo3dDoubleRad(double lat, double lng, double radius)
+        //{
+        //    return Vector3d.Create(Math.Cos(lng * RC) * Math.Cos(lat * RC) * radius, Math.Sin(lat * RC) * radius, Math.Sin(lng * RC) * Math.Cos(lat * RC) * radius);
+        //}
 
         static public Vector3d GeoTo3dRad(double lat, double lng, double radius)
         {

--- a/engine/wwtlib/Coordinates.cs
+++ b/engine/wwtlib/Coordinates.cs
@@ -11,7 +11,7 @@ namespace wwtlib
 
         static public Vector3d GeoTo3d(double lat, double lng)
         {
-            return Vector3d.Create((Math.Cos(lng * RC) * Math.Cos(lat * RC) * radius), (Math.Sin(lat * RC) * radius), (Math.Sin(lng * RC) * Math.Cos(lat * RC) * radius));
+            return Vector3d.Create(Math.Cos(lng * RC) * Math.Cos(lat * RC) * radius, Math.Sin(lat * RC) * radius, Math.Sin(lng * RC) * Math.Cos(lat * RC) * radius);
         }
 
         static public Vector3d GeoTo3dDouble(double lat, double lng)
@@ -27,17 +27,17 @@ namespace wwtlib
 
         static public Vector3d GeoTo3dRad(double lat, double lng, double radius)
         {
-            return Vector3d.Create(((Math.Cos(lng * RC)) * (Math.Cos(lat * RC)) * radius), ((Math.Sin(lat * RC) * radius)), ((Math.Sin(lng * RC)) * (Math.Cos(lat * RC)) * radius));
+            return Vector3d.Create(Math.Cos(lng * RC) * Math.Cos(lat * RC) * radius, Math.Sin(lat * RC) * radius, Math.Sin(lng * RC) * Math.Cos(lat * RC) * radius);
         }
 
         static public Vector3d RADecTo3d(double ra, double dec)
         {
-            return Vector3d.Create((Math.Cos(ra * RCRA) * Math.Cos(dec * RC) * radius), (Math.Sin(dec * RC) * radius), (Math.Sin(ra * RCRA) * Math.Cos(dec * RC) * radius));
+            return Vector3d.Create(Math.Cos(ra * RCRA) * Math.Cos(dec * RC) * radius, Math.Sin(dec * RC) * radius, Math.Sin(ra * RCRA) * Math.Cos(dec * RC) * radius);
         }
 
         static public Vector3d RADecTo3dAu(double ra, double dec, double au)
         {
-            return Vector3d.Create((Math.Cos(ra * RCRA) * Math.Cos(dec * RC) * au), (Math.Sin(dec * RC) * au), (Math.Sin(ra * RCRA) * Math.Cos(dec * RC) * au));
+            return Vector3d.Create(Math.Cos(ra * RCRA) * Math.Cos(dec * RC) * au, Math.Sin(dec * RC) * au, Math.Sin(ra * RCRA) * Math.Cos(dec * RC) * au);
         }
 
         static public Vector3d RADecTo3dMat(double ra, double dec, Matrix3d mat)

--- a/engine/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/engine/wwtlib/Layers/SpreadSheetLayer.cs
@@ -811,7 +811,7 @@ namespace wwtlib
                                 }
                                 if (bufferIsFlat)
                                 {
-                                    Xcoord += 180;
+                                 //   Xcoord += 180;
                                 }
 
                             }

--- a/engine/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/engine/wwtlib/Layers/SpreadSheetLayer.cs
@@ -823,7 +823,7 @@ namespace wwtlib
                             //    alt += offset / meanRadius;
                             // }
 
-                            Vector3d pos = Coordinates.GeoTo3dDoubleRad(Ycoord, Xcoord, alt);
+                            Vector3d pos = Coordinates.GeoTo3dRad(Ycoord, Xcoord, alt);
 
                             if (astronomical && !bufferIsFlat)
                             {

--- a/engine/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/engine/wwtlib/Layers/SpreadSheetLayer.cs
@@ -1208,8 +1208,8 @@ namespace wwtlib
             //todo space? using RA/DEC
             for (int i = 0; i < (geo.PointList.Count); i++)
             {
-                vertexList.Add(Coordinates.GeoTo3dDoubleRad(geo.PointList[i].Lat, geo.PointList[i].Lng, 1 + (geo.PointList[i].Alt / meanRadius)));
-                vertexListGround.Add(Coordinates.GeoTo3dDoubleRad(geo.PointList[i].Lat, geo.PointList[i].Lng, 1));
+                vertexList.Add(Coordinates.GeoTo3dRad(geo.PointList[i].Lat, geo.PointList[i].Lng, 1 + (geo.PointList[i].Alt / meanRadius)));
+                vertexListGround.Add(Coordinates.GeoTo3dRad(geo.PointList[i].Lat, geo.PointList[i].Lng, 1));
             }
 
 
@@ -1267,7 +1267,7 @@ namespace wwtlib
 
             for (int i = 0; i < (geo.PointList.Count); i++)
             {
-                vertexList.Add(Coordinates.GeoTo3dDoubleRad(geo.PointList[i].Lat, geo.PointList[i].Lng, 1 + (geo.PointList[i].Alt / meanRadius)));
+                vertexList.Add(Coordinates.GeoTo3dRad(geo.PointList[i].Lat, geo.PointList[i].Lng, 1 + (geo.PointList[i].Alt / meanRadius)));
             }
 
 


### PR DESCRIPTION
This PR is aimed at fixing the cause of #34. I think the culprit is [SpreadSheetLayer.GeoTo3dDoubleRad](https://github.com/WorldWideTelescope/wwt-webgl-engine/blob/master/engine/wwtlib/Layers/SpreadSheetLayer.cs#L826), which adjusts the longitude of the point by 180 degress before performing the transformation.

This function is currently called in five places:
[SpreadSheetLayer.cs, line 826](https://github.com/WorldWideTelescope/wwt-webgl-engine/blob/master/engine/wwtlib/Layers/SpreadSheetLayer.cs#L826)
[SpreadSheetLayer.cs, line 1211](https://github.com/WorldWideTelescope/wwt-webgl-engine/blob/master/engine/wwtlib/Layers/SpreadSheetLayer.cs#L1211)
[SpreadSheetLayer.cs, line 1212](https://github.com/WorldWideTelescope/wwt-webgl-engine/blob/master/engine/wwtlib/Layers/SpreadSheetLayer.cs#L1212)
[SpreadSheetLayer.cs, line 1270](https://github.com/WorldWideTelescope/wwt-webgl-engine/blob/master/engine/wwtlib/Layers/SpreadSheetLayer.cs#L1270)
[Coordinates.cs, line 111](https://github.com/WorldWideTelescope/wwt-webgl-engine/blob/master/engine/wwtlib/Coordinates.cs#L111)

In all five of these cases, the Windows client calls `SpreadSheetLayer.GeoTo3dDouble` - specifically, the one with the three-argument signature, which performs the same operation, minus the longitudinal adjustment. The corresponding Windows client calls are [here](https://github.com/Carifio24/wwt-windows-client/blob/master/WWTExplorer3d/SpreadSheetLayer.cs#L1332), [here](https://github.com/Carifio24/wwt-windows-client/blob/master/WWTExplorer3d/SpreadSheetLayer.cs#L1790), [here](https://github.com/Carifio24/wwt-windows-client/blob/master/WWTExplorer3d/SpreadSheetLayer.cs#L1791), [here](https://github.com/Carifio24/wwt-windows-client/blob/master/WWTExplorer3d/SpreadSheetLayer.cs#L1848), and [here](https://github.com/Carifio24/wwt-windows-client/blob/master/WWTCore/WWTCore/Coordinates.cs#L130).

The web engine function `GeoTo3dRad` (defined [here](https://github.com/WorldWideTelescope/wwt-webgl-engine/blob/master/engine/wwtlib/Coordinates.cs#L32)) corresponds to `GeoTo3dDouble` in the Windows client. The names are a bit wonky here - maybe an attempt to avoid overloads for ScriptSharp?). So, for this PR, I've changed all of the calls to `GeoTo3dDoubleRad` to `GeoTo3dRad`.