### PR TITLE
Flip longitude of non-astronomical spreadsheet layers by 180 degrees

### DIFF
--- a/engine/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/engine/wwtlib/Layers/SpreadSheetLayer.cs
@@ -815,6 +815,10 @@ namespace wwtlib
                                 }
 
                             }
+                            else
+                            {
+                                Xcoord += 180;
+                            }
 
                             // TODO:
                             // double offset = EGM96Geoid.Height(Ycoord, Xcoord);


### PR DESCRIPTION
This PR looks to resolve #177 by flipping the longitudes of non-astronomical spreadsheet layers by 180 degrees. See the comments in that issue for a breakdown of the `astronomical` and `bufferIsFlat` parameters. This change should affect Earth/planetary layers (and, in theory, panoramas as well).

