### PR TITLE
Allow toggling whether sources from a given layer are selectable

### DIFF
--- a/research-app-messages/src/selections.ts
+++ b/research-app-messages/src/selections.ts
@@ -112,3 +112,37 @@ export function isAddSourceMessage(o: any): o is AddSourceMessage {  // eslint-d
   return o.type === 'add_source' &&
       typeof o.source === 'object';
 }
+
+export interface ModifySelectabilityMessage {
+
+  /** The tag identifying this message type */
+  type: "modify_selectability";
+
+  /** The identifier of the layer to modify. */
+  id: string;
+
+  /** Whether to make the layer selectable. */
+  selectable: boolean;
+}
+
+/** A type-guard function for [[ModifySelectabilityMessage]]. */
+export function isModifySelectabilityMessage(o: any): o is ModifySelectabilityMessage {  // eslint-disable-line @typescript-eslint/no-explicit-any
+  return o.type === 'modify_selectability' &&
+    typeof o.id === 'string' &&
+    typeof o.selectable === 'boolean';
+}
+
+export interface ModifyAllSelectabilityMessage {
+
+  /** The tag identifying this message type. */
+  type: "modify_all_selectability";
+
+  /** Whether to make all layers selectable. */
+  selectable: boolean;
+}
+
+/** A type-guard function for [[ModifyAllSelectabilityMessage]]. */
+export function isModifyAllSelectabilityMessage(o: any): o is ModifyAllSelectabilityMessage {  // eslint-disable-line @typescript-eslint/no-explicit-any
+  return o.type === 'modify_all_selectability' &&
+    typeof o.selectable === 'boolean';
+}

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -645,6 +645,7 @@ class TableLayerMessageHandler {
   private queuedUpdate: classicPywwt.UpdateTableLayerMessage | null = null;
   private queuedSettings: classicPywwt.PywwtSpreadSheetLayerSetting[] = [];
   private queuedRemoval: classicPywwt.RemoveTableLayerMessage | null = null;
+  private queuedSelectability: selections.ModifySelectabilityMessage | null = null;
 
   constructor(owner: App) {
     this.owner = owner;
@@ -708,6 +709,11 @@ class TableLayerMessageHandler {
     if (this.queuedRemoval !== null) {
       this.handleRemoveMessage(this.queuedRemoval);
       this.queuedRemoval = null;
+    }
+
+    if (this.queuedSelectability !== null) {
+      this.handleSelectabilityMessage(this.queuedSelectability);
+      this.queuedSelectability = null;
     }
   }
 
@@ -833,6 +839,24 @@ class TableLayerMessageHandler {
         this.owner.deleteLayer(this.internalId);
         this.internalId = null;
         this.created = false;
+      }
+    }
+  }
+
+  handleSelectabilityMessage(msg: selections.ModifySelectabilityMessage) {
+    if (this.internalId === null) {
+      // Layer not yet created or fully initialized. Queue up message for processing
+      // once it's ready.
+      if (this.queuedSelectability === null) {
+        this.queuedSelectability = msg;
+      }
+    } else {
+      const layer = this.owner.spreadsheetLayers.find(x => x.name === msg.id);
+      if (layer !== undefined) {
+        this.owner.setResearchAppTableLayerSelectability({
+          layer: layer,
+          selectable: msg.selectable
+        });
       }
     }
   }
@@ -1151,10 +1175,15 @@ export default class App extends WWTAwareComponent {
 
   addResearchAppTableLayer!: (layer: CatalogLayerInfo) => void;
   addSource!: (source: Source) => void;
+  setResearchAppTableLayerSelectability!: (args: {
+    layer: CatalogLayerInfo;
+    selectable: boolean;
+  }) => void;
   hipsCatalogs!: () => CatalogLayerInfo[];
   removeResearchAppTableLayer!: (layer: CatalogLayerInfo) => void;
   appTableLayers!: () => CatalogLayerInfo[];
   visibleTableLayers!: () => CatalogLayerInfo[];
+  selectableTableLayers!: () => CatalogLayerInfo[];
 
   // Lifecycle management
 
@@ -1168,7 +1197,8 @@ export default class App extends WWTAwareComponent {
       }),
       ...mapGetters(wwtResearchAppNamespace, [
         "hipsCatalogs",
-        "visibleTableLayers"
+        "selectableTableLayers",
+        "visibleTableLayers",
       ]),
       ...mapGetters(wwtResearchAppNamespace, {
         appTableLayers: "tableLayers",
@@ -1182,6 +1212,7 @@ export default class App extends WWTAwareComponent {
         "addResearchAppTableLayer",
         "addSource",
         "removeResearchAppTableLayer",
+        "setResearchAppTableLayerSelectability"
       ]),
     };
   }
@@ -1817,6 +1848,8 @@ export default class App extends WWTAwareComponent {
     this.messageHandlers.set("resume_tour", this.handleResumeTour);
 
     this.messageHandlers.set("add_source", this.handleAddSource);
+    this.messageHandlers.set("modify_selectability", this.handleModifySelectability);
+    this.messageHandlers.set("modify_all_selectability", this.handleModifyAllSelectability);
 
     // Ignore incoming view_state messages. When testing the app, you might want
     // to launch it as (e.g.)
@@ -2640,6 +2673,29 @@ export default class App extends WWTAwareComponent {
     return true;
   }
 
+  handleModifySelectability(msg: selections.ModifySelectabilityMessage): boolean {
+    if (!selections.isModifySelectabilityMessage(msg)) return false;
+
+    const handler = this.tableLayers.get(msg.id);
+    if (handler !== undefined) {
+      handler.handleSelectabilityMessage(msg);
+    }
+    return true;
+  }
+
+  handleModifyAllSelectability(msg: selections.ModifyAllSelectabilityMessage): boolean {
+    if (!selections.isModifyAllSelectabilityMessage(msg)) return false;
+
+    this.spreadsheetLayers.forEach(
+      layer =>
+        this.setResearchAppTableLayerSelectability({
+          layer: layer,
+          selectable: msg.selectable
+        })
+      );
+    return true;
+  }
+
   // "Tools" menu
 
   currentTool: ToolType = null;
@@ -2813,7 +2869,7 @@ export default class App extends WWTAwareComponent {
     const rowSeparator = "\r\n";
     const colSeparator = "\t";
 
-    for (const layerInfo of this.visibleTableLayers()) {
+    for (const layerInfo of this.selectableTableLayers()) {
 
       const layer = this.spreadSheetLayer(layerInfo);
       if (layer == null) {

--- a/research-app/src/store.ts
+++ b/research-app/src/store.ts
@@ -24,6 +24,7 @@ export interface TableLayerStatus {
   visible: boolean;
   type: 'hips' | 'table';
   layer: CatalogLayerInfo;
+  selectable: boolean
 }
 
 type EquivalenceTest<T> = (t1: T, t2: T) => boolean;
@@ -112,6 +113,10 @@ export class WWTResearchAppModule extends VuexModule {
     return () => getFilteredLayers(this._tableLayers, status => status.visible);
   }
 
+  get selectableTableLayers() {
+    return () => getFilteredLayers(this._tableLayers, status => status.visible && status.selectable);
+  }
+
   get researchAppTableLayerVisibility() {
     return (info: CatalogLayerInfo) => {
       const status = this._tableLayers[infoKey(info)];
@@ -122,12 +127,23 @@ export class WWTResearchAppModule extends VuexModule {
     }
   }
 
+  get researchAppTableLayerSelectability() {
+    return (info: CatalogLayerInfo) => {
+      const status = this._tableLayers[infoKey(info)];
+      if (status == undefined) {
+        return false;
+      }
+      return status.selectable;
+    }
+  }
+
   @Mutation
   addResearchAppTableLayer(info: CatalogLayerInfo) {
     const status: TableLayerStatus = {
       type: info instanceof ImagesetInfo ? 'hips' : 'table',
       visible: true,
       layer: info,
+      selectable: true
     };
     Vue.set(this._tableLayers, infoKey(info), status);
   }
@@ -142,6 +158,14 @@ export class WWTResearchAppModule extends VuexModule {
     const status = this._tableLayers[infoKey(args.layer)];
     if (status !== undefined) {
       Vue.set(status, 'visible', args.visible);
+    }
+  }
+
+  @Mutation
+  setResearchAppTableLayerSelectability(args: { layer: CatalogLayerInfo; selectable: boolean }) {
+    const status = this._tableLayers[infoKey(args.layer)];
+    if (status !== undefined) {
+      Vue.set(status, 'selectable', args.selectable);
     }
   }
 


### PR DESCRIPTION
This PR adds the ability to toggle whether or not the sources in a given table layer are selectable. This toggling can be done either in the UI or programmatically via a message. My motivation for this was from investigating the `glue-wwt` speed issue when using the newest version of `pywwt`. I believe that issue pops up when there are a lot of points visible due to the nearest-source calculation slowing things down. Removing layer selectability should increase performance - in particular, if no layers are selectable, `closestInView` doesn't need to do any work. From testing on my machine, this did indeed seem to be the case. Aside from glue, though, I think any client embedding the research app benefits from this if they don't want source selection - performance should be increased and they won't see unnecessary cursor changes as the mouse moves off of/onto sources.

To accomplish this, an additional `selectable` field is added to the `TableLayerStatus` items in the research app's store. The closest-source algorithm in the research app then only looks for sources in layers that are both visible and selectable. Two messages are added - one to set the selectability of a particular layer, and another convenience message type to allow modifying the selectability of all layers at once. The single-layer message is handled by the `TableLayerMessageHandler` class in the research app. Since a user won't know the internal name of layer they create, we need to identify the layer by the name they gave it, which these handlers are already set up to do.

In the UI, this is accomplished by adding an extra icon in `SpreadsheetItem` which toggles selectability. I couldn't find a good FontAwesome icon that I felt made the intent obvious, so I "made" one by stacking the mouse pointer icon with the slash. Suggestions of something different to use here are welcome.
