### PR TITLE
Use layer ID in query script catalog messages

### DIFF
--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -1624,7 +1624,7 @@ export default class App extends WWTAwareComponent {
 
         catalogSettingsMessages.push({
           event: "table_layer_set_multi",
-          id: catalog.name,
+          id: id,
           settings: pywwtLayerSettings.map(s => s[0]),
           values: pywwtLayerSettings.map(s => s[1]),
         });


### PR DESCRIPTION
I thought I had covered all of our bases when making the HiPS catalog name --> id conversion, but this PR fixes an issue that slipped through the cracks. Essentially, in `stateAsUrl`, the messages that restore settings on HiPS catalogs in the URL export are currently still using the dataset name, rather than the layer ID, for identifying the layer. This doesn't work since we gave the `tableId` earlier in the method as the layer ID, and so the settings don't get applied. This PR changes the `id` field of the settings message to use the layer ID rather than the dataset name.