### PR TITLE
Allow creating VoTableLayer from XML

### DIFF
--- a/engine/wwtlib/Layers/Layer.cs
+++ b/engine/wwtlib/Layers/Layer.cs
@@ -560,6 +560,9 @@ namespace wwtlib
                 case "OrbitLayer":
                     newLayer = new OrbitLayer();
                     break;
+                case "VoTableLayer":
+                    newLayer = new VoTableLayer();
+                    break;
                 default:
                     return null;
             }


### PR DESCRIPTION
Currently the engine won't create a `VoTableLayer` from XML (e.g. from a tour), because `"VoTableLayer"` is missing as an option in the switch statement here. This PR fixes this issue by adding the appropriate case.

This partially resolves #182. It doesn't fix the colormap issue, which is a separate problem and will potentially require a bit of thought. As far as I can tell, `SpreadSheetLayer` also doesn't support the full set of colormap options (such as the one used in the tour referenced in the issue), so maybe updating those together can be done a later PR.