### PR TITLE
Pin Vue to 2.6.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "jsdom": "^16.5.0",
         "pako": "^1.0.11",
         "uuid": "^8.3.2",
+        "vue": "~2.6.11",
         "vue-color": "^2.8.1",
         "vue-select": "^3.11.2"
       },
@@ -60,7 +61,7 @@
         "uglify-js": "^3.9.1",
         "vue-class-component": "^7.2.3",
         "vue-property-decorator": "^8.4.1",
-        "vue-template-compiler": "^2.6.11",
+        "vue-template-compiler": "~2.6.11",
         "vuex-module-decorators": "^0.16.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@types/debounce": "^1.2.0",
         "@types/jsdom": "^16.2.13",
         "@types/vue-color": "^2.4.3",
-        "@types/vue-select": "^3.11.1",
+        "@types/vue-select": "3.16.0",
         "@wwtelescope/astro": "file:astro",
         "@wwtelescope/embed": "file:embed",
         "@wwtelescope/embed-common": "file:embed-common",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/debounce": "^1.2.0",
     "@types/jsdom": "^16.2.13",
     "@types/vue-color": "^2.4.3",
-    "@types/vue-select": "^3.11.1",
+    "@types/vue-select": "3.16.0",
     "@wwtelescope/astro": "file:astro",
     "@wwtelescope/embed": "file:embed",
     "@wwtelescope/embed-common": "file:embed-common",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "jsdom": "^16.5.0",
     "pako": "^1.0.11",
     "uuid": "^8.3.2",
+    "vue": "~2.6.11",
     "vue-color": "^2.8.1",
     "vue-select": "^3.11.2"
   },
@@ -66,7 +67,7 @@
     "uglify-js": "^3.9.1",
     "vue-class-component": "^7.2.3",
     "vue-property-decorator": "^8.4.1",
-    "vue-template-compiler": "^2.6.11",
+    "vue-template-compiler": "~2.6.11",
     "vuex-module-decorators": "^0.16.1"
   }
 }

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -34,7 +34,7 @@ export async function parseXMLFromUrl(url: string): Promise<Document> {
     return axios.get(url)
         .then(response => response.data)
         .then(text => {
-            return new JSDOM(text).window.document;
+            return new JSDOM(text, { contentType: "text/xml" }).window.document;
         })
         .catch(err => {
             console.log(err);


### PR DESCRIPTION
While building with the current `package.json`, one gets the following error with one of Vue's type declaration files:

```
> @wwtelescope/research-app-messages@0.0.0-dev.0 build /home/jon/dev/WWT/test/research-app-messages
> tsc

lerna ERR! npm run build exited 2 in '@wwtelescope/astro'
lerna ERR! npm run build stdout:

> @wwtelescope/astro@0.0.0-dev.0 build /home/jon/dev/WWT/test/astro
> tsc

../node_modules/vue/types/jsx.d.ts(39,7): error TS1110: Type expected.
../node_modules/vue/types/jsx.d.ts(39,20): error TS1005: ';' expected.
../node_modules/vue/types/jsx.d.ts(39,21): error TS1128: Declaration or statement expected.
../node_modules/vue/types/jsx.d.ts(40,1): error TS1128: Declaration or statement expected.

lerna ERR! npm run build stderr:
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! @wwtelescope/astro@0.0.0-dev.0 build: `tsc`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the @wwtelescope/astro@0.0.0-dev.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/jon/.npm/_logs/2022-07-15T21_07_38_621Z-debug.log

lerna ERR! npm run build exited 2 in '@wwtelescope/astro'
lerna WARN complete Waiting for 2 child processes to exit. CTRL-C to exit immediately.
```

Running the lint script gives essentially the same error. This might be related to Vue 2.7, which was released 16 days ago. Pinning `vue` and `vue-template-compiler` to `~2.6.11` fixes this issue, so I propose we do that for now. This PR adds those pins.