### PR TITLE
WebGL context loss / restored

### DIFF
--- a/engine-vuex/src/Component.vue
+++ b/engine-vuex/src/Component.vue
@@ -65,6 +65,27 @@ export default class WWTComponent extends Vue {
       this.internalUpdate();
     };
 
+    const wwtcmpt0 = document.getElementById("wwtcmpt0");
+    if (wwtcmpt0 != null){
+      const wwtCanvas = wwtcmpt0.children[0];
+      if (wwtCanvas != null) {
+        wwtCanvas.addEventListener('webglcontextlost', (event) => {
+          const e = event as WebGLContextEvent;
+          console.log("Vue: WebGL context lost: " + e.statusMessage);
+          if (this.renderLoopId !== undefined) {
+            window.cancelAnimationFrame(this.renderLoopId);
+          }
+          e.preventDefault();
+        }, false);
+        wwtCanvas.addEventListener('webglcontextrestored', (event) => {
+          const e = event as WebGLContextEvent;
+          console.log("Vue: WebGL context restored: " + e.statusMessage);
+          render();
+        }, false);
+      }
+
+    }
+
     // Wait for the WWT engine to signal readiness, then wait another tick, then
     // start the rendering loop. This way, if a user wants to do some
     // initialization that has to wait for the ready signal, we won't flash any

--- a/engine/wwtlib/Graphics/Shaders.cs
+++ b/engine/wwtlib/Graphics/Shaders.cs
@@ -5,6 +5,28 @@ using System.Html;
 
 namespace wwtlib
 {
+    public class ShaderResetter
+    {
+        public static void ResetAllShaders()
+        {
+            SimpleLineShader.initialized = false;
+            SimpleLineShader2D.initialized = false;
+            OrbitLineShader.initialized = false;
+            LineShaderNormalDates.initialized = false;
+            TimeSeriesPointSpriteShader.initialized = false;
+            KeplerPointSpriteShader.initialized = false;
+            EllipseShader.initialized = false;
+            ModelShader.initialized = false;
+            ModelShaderTan.initialized = false;
+            TileShader.initialized = false;
+            FitsShader.initialized = false;
+            ImageShader.initialized = false;
+            ImageShader2.initialized = false;
+            SpriteShader.initialized = false;
+            ShapeSpriteShader.initialized = false;
+            TextShader.initialized = false;
+        }
+    }
 
     public class SimpleLineShader
     {
@@ -87,6 +109,10 @@ namespace wwtlib
             GL gl = renderContext.gl;
             if (gl != null)
             {
+                if (gl.isContextLost())
+                {
+                    return; // Lost context is further handled by the "webglcontextlost" event
+                }
                 if (!initialized)
                 {
                     Init(renderContext);
@@ -198,6 +224,10 @@ namespace wwtlib
             GL gl = renderContext.gl;
             if (gl != null)
             {
+                if (gl.isContextLost())
+                {
+                    return; // Lost context is further handled by the "webglcontextlost" event
+                }
                 if (!initialized)
                 {
                     Init(renderContext);
@@ -321,6 +351,10 @@ namespace wwtlib
             GL gl = renderContext.gl;
             if (gl != null)
             {
+                if (gl.isContextLost())
+                {
+                    return; // Lost context is further handled by the "webglcontextlost" event
+                }
                 if (!initialized)
                 {
                     Init(renderContext);
@@ -475,6 +509,10 @@ namespace wwtlib
             GL gl = renderContext.gl;
             if (gl != null)
             {
+                if (gl.isContextLost())
+                {
+                    return; // Lost context is further handled by the "webglcontextlost" event
+                }
                 if (!initialized)
                 {
                     Init(renderContext);
@@ -672,6 +710,10 @@ namespace wwtlib
             GL gl = renderContext.gl;
             if (gl != null)
             {
+                if (gl.isContextLost())
+                {
+                    return; // Lost context is further handled by the "webglcontextlost" event
+                }
                 if (!initialized)
                 {
                     Init(renderContext);
@@ -915,6 +957,10 @@ namespace wwtlib
             GL gl = renderContext.gl;
             if (gl != null)
             {
+                if (gl.isContextLost())
+                {
+                    return; // Lost context is further handled by the "webglcontextlost" event
+                }
                 if (!initialized)
                 {
                     Init(renderContext);
@@ -2479,6 +2525,10 @@ namespace wwtlib
             GL gl = renderContext.gl;
             if (gl != null)
             {
+                if (gl.isContextLost())
+                {
+                    return; // Lost context is further handled by the "webglcontextlost" event
+                }
                 if (!initialized)
                 {
                     Init(renderContext);
@@ -2605,6 +2655,10 @@ namespace wwtlib
             GL gl = renderContext.gl;
             if (gl != null)
             {
+                if (gl.isContextLost())
+                {
+                    return; // Lost context is further handled by the "webglcontextlost" event
+                }
                 if (!initialized)
                 {
                     Init(renderContext);
@@ -2736,6 +2790,10 @@ namespace wwtlib
             GL gl = renderContext.gl;
             if (gl != null)
             {
+                if (gl.isContextLost())
+                {
+                    return; // Lost context is further handled by the "webglcontextlost" event
+                }
                 if (!initialized)
                 {
                     Init(renderContext);

--- a/engine/wwtlib/RenderContext.cs
+++ b/engine/wwtlib/RenderContext.cs
@@ -306,6 +306,43 @@ namespace wwtlib
         }
 
 
+        public void ResetTiles()
+        {
+            ToastTile.ResetStaticVariables();
+            ResetImageset(BackgroundImageset);
+            ResetImageset(ForegroundImageset);
+
+            foreach (Layer layer in LayerManager.AllMaps["Sky"].Layers)
+            {
+                if (layer is ImageSetLayer)
+                {
+                    ResetImageset(((ImageSetLayer)layer).ImageSet);
+                }
+            }
+        }
+
+        private void ResetImageset(Imageset imageset)
+        {
+            if (imageset == null)
+            {
+                return;
+            }
+            int maxX = GetTilesXForLevel(imageset, imageset.BaseLevel);
+            int maxY = GetTilesYForLevel(imageset, imageset.BaseLevel);
+
+            for (int x = 0; x < maxX; x++)
+            {
+                for (int y = 0; y < maxY; y++)
+                {
+                    Tile tile = TileCache.GetTile(imageset.BaseLevel, x, y, imageset, null);
+                    if (tile != null)
+                    {
+                        tile.Reset(this);
+                    }
+                }
+            }
+        }
+
         private List<Imageset> activeCatalogHipsImagesets = new List<Imageset>();
 
         public List<Imageset> CatalogHipsImagesets

--- a/engine/wwtlib/Tile.cs
+++ b/engine/wwtlib/Tile.cs
@@ -1231,6 +1231,14 @@ namespace wwtlib
                 renderChildPart[i] = BlendState.Create(false, 500);
             }
         }
+
+        public virtual void Reset(RenderContext renderContext)
+        {
+            GeometryCreated = false;
+            //TODO only call makeTexture if texture is ready to be created
+            MakeTexture();
+            //TODO propagate to children
+        }
     }
 
 }

--- a/engine/wwtlib/ToastTile.cs
+++ b/engine/wwtlib/ToastTile.cs
@@ -490,8 +490,6 @@ namespace wwtlib
             base.CreateGeometry(renderContext);
             if (!subDivided)
             {
-             
-
 
                 if (vertexList == null)
                 {
@@ -891,6 +889,42 @@ namespace wwtlib
 
             DemReady = true;
             return true;
+        }
+
+        public static void ResetStaticVariables()
+        {
+            ClearIndexBuffer(slashIndexBuffer);
+            ClearIndexBuffer(backSlashIndexBuffer);
+            ClearIndexBuffer(rootIndexBuffer);
+        }
+        public override void Reset(RenderContext renderContext)
+        {
+            GeometryCreated = false;
+            subDivided = false;
+            //TODO vertexList is still the same, but a new buffer needs to be created...
+            //Extract creation of new buffer instead of nulling vertexList!
+            vertexList = null; 
+
+            //TODO deal with async requests
+            if (texReady) // TODO deal with FITS 
+            {
+                MakeTexture();
+            }
+
+            foreach (Tile child in children){
+                if (child != null)
+                {
+                    child.Reset(renderContext);
+                }
+            }
+        }
+
+        private static void ClearIndexBuffer(WebGLBuffer[] buffer)
+        {
+            for (int i = 0; i < buffer.Length; i++)
+            {
+                buffer[i] = null;
+            }
         }
     }
 

--- a/engine/wwtlib/WebGL.cs
+++ b/engine/wwtlib/WebGL.cs
@@ -706,6 +706,15 @@ namespace System.Html
         public void set(WebGLIntArray array, int offset) { }
     }
 
+    [ScriptIgnoreNamespace]
+    [ScriptImport]
+    public class WebGLContextEvent
+    {
+        [ScriptField]
+        public string StatusMessage { get { return null; } }
+        public void PreventDefault() { return; }
+    }
+
 
     [ScriptIgnoreNamespace]
     [ScriptImport]


### PR DESCRIPTION
The prototype implementation gracefully handles loss of WebGL context, as well as properly restores all WebGL variables for Toast Tiles. Something along these lines is what is needed for the rest of the application to properly recover from a context loss.

- [ ] Loss of context can happen at any time, so the shader's `if (gl.isContextLost())` check is not enough. Use try/catch instead.
- [ ] Fix all committed TODO's.
- [ ] Handle context loss & restored for the rest of the application.

Fully implementing this would let WWT gracefully recover from loss of WebGL context, and not require a page reload like the one discussed here: https://github.com/WorldWideTelescope/wwt-webgl-engine/issues/199.

This PR does not address any potential issues which may cause a loss of context in the first place.