### PR TITLE
Expose FolderUp class

### DIFF
--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -750,6 +750,21 @@ export class Folder implements Thumbnail {
   childLoadCallback(callback: Action): void;
 }
 
+export class FolderUp implements Thumbnail {
+  get_name(): string;
+  get_thumbnail(): Thumbnail;
+  set_thumbnail(thumbnail: Thumbnail): Thumbnail;
+  get_thumbnailUrl(): string;
+  set_thumbnailUrl(url: string): string;
+  get_isImage(): boolean;
+  get_isTour(): boolean;
+  get_isFolder(): boolean;
+  get_isCloudCommunityItem(): boolean;
+  get_readOnly(): boolean;
+  get_children(): Thumbnail[] | null;
+  parent: Folder;
+}
+
 /** An simple Version 4 GUID.
  *
  * Note that in WWT, GUID contents are not validated in any way upon creation.

--- a/engine/wwtlib/FolderUp.cs
+++ b/engine/wwtlib/FolderUp.cs
@@ -6,7 +6,7 @@ using System.Html;
 
 namespace wwtlib
 {
-    class FolderUp : IThumbnail
+    public class FolderUp : IThumbnail
     {
         public FolderUp()
         {


### PR DESCRIPTION
This PR exposes the `FolderUp` class from the engine by making the source C# class be `public`. A TypeScript declaration for this class is also added in the engine's `index.d.ts` file.

The main use case for this at the moment is for doing folder browsing at the Vue level. Although we haven't really used it yet, the `FolderView` component that we've been using for the custom interactives (see e.g. [here](https://github.com/Carifio24/wwt-webgl-engine/blob/embed-jwst-collection/embed/src/FolderView.vue)) has the capability to work exactly like the folder browser in the web client, which requires using `FolderUp` to navigate upwards in the folder hierarchy.