### PR TITLE
Fire AddImageSetLayer callback for re-added imageset

### DIFF
--- a/engine/wwtlib/FitsProperties.cs
+++ b/engine/wwtlib/FitsProperties.cs
@@ -46,6 +46,7 @@ namespace wwtlib
         // suffices. The tiling framework already uses WcsLoaded so for that
         // case we need to add this extra hook.
         public Action<FitsImage> OnMainImageLoaded = null;
+        public bool MainImageLoadedEventHasFired = false;
 
         public FitsProperties()
         {
@@ -56,7 +57,8 @@ namespace wwtlib
         // data have loaded and these FitsProperties can be trusted.
         internal void FireMainImageLoaded(FitsImage image)
         {
-            if (OnMainImageLoaded != null) {
+            if (OnMainImageLoaded != null && !MainImageLoadedEventHasFired) {
+                MainImageLoadedEventHasFired = true;
                 OnMainImageLoaded(image);
             }
         }

--- a/engine/wwtlib/Layers/LayerManager.cs
+++ b/engine/wwtlib/Layers/LayerManager.cs
@@ -411,7 +411,7 @@ namespace wwtlib
             // The tile rendering codepaths require that "Extension" is exactly
             // .fits -- multiple extensions are not currently supported.
 
-            bool isNonhipsTiledFits =
+            bool isNonHipsTiledFits =
                 imageset.Extension == ".fits" &&
                 layer.GetFitsImage() == null &&
                 imageset.Projection != ProjectionType.Healpix;
@@ -437,7 +437,7 @@ namespace wwtlib
             // the callback argument gets fired at the right time for such
             // datasets.
 
-            if (isNonhipsTiledFits) {
+            if (isNonHipsTiledFits) {
                 imageset.FitsProperties.OnMainImageLoaded = delegate (FitsImage image) {
                     image.ApplyDisplaySettings();
                     if (callback != null) {
@@ -450,7 +450,7 @@ namespace wwtlib
 
             // For everything not yet handled, just trigger the callback now, if
             // needed.
-            if (callback != null && !isNonhipsTiledFits) {
+            if (callback != null && (!isNonHipsTiledFits || imageset.FitsProperties.MainImageLoadedEventHasFired)) {
                 callback(layer);
             }
 


### PR DESCRIPTION
Trigger callback even if the main image already has been loaded by the engine For example, when a previously added imageset is added.