### PR TITLE
research-app: Remove non-HiPS spreadsheet layers from UI on removal message

### DIFF
--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -835,6 +835,10 @@ class TableLayerMessageHandler {
         }
       } else {
         this.owner.deleteLayer(this.internalId);
+        if (this.layer !== null) {
+          const info = new SpreadSheetLayerInfo(this.layer.id.toString(), this.layer.get_referenceFrame(), this.layer.get_name());
+          this.owner.removeResearchAppTableLayer(info);
+        }
         this.internalId = null;
         this.created = false;
       }


### PR DESCRIPTION
While using pywwt, I noticed that calling a table layer's `remove()` doesn't remove the layer from the research app UI. This is because the pywwt layer removal happens through a message, and currently the research app message handler only removes a spreadsheet layer from the research app store if it's a HiPS. This PR adds the missing logic.

Note that `this.layer` shouldn't be null if `this.internalId` isn't null (which is the block we're in here), so that check is really a TypeScript thing.