### PR TITLE
Fix bug in time span parsing

### DIFF
--- a/engine/wwtlib/Util.cs
+++ b/engine/wwtlib/Util.cs
@@ -105,8 +105,8 @@ namespace wwtlib
 
             if (parts.Length == 3)
             {
-                val += int.Parse(parts[0]) * 36000000;
-                val += int.Parse(parts[1]) * 600000;
+                val += int.Parse(parts[0]) * 3600000;
+                val += int.Parse(parts[1]) * 60000;
                 val += (int)(double.Parse(parts[2]) * 1000);
             }
             return val;


### PR DESCRIPTION
This PR resolves #54. The tour duration bug described in that issue is due to extra factors of 10 in two constants in the engine's `Util::ParseTimeSpan` static method. This function converts an HH:MM:SS.S time duration to milliseconds. However, the conversion factors for minutes and hours are both 10 times larger than they should be - e.g. there are 60000 milliseconds in one minute, not 600000. The same issue occurs with hours.