### PR TITLE
Enable drag operations over WWT

### DIFF
--- a/research-app-messages/src/index.ts
+++ b/research-app-messages/src/index.ts
@@ -184,3 +184,72 @@ export function isPingPongMessage(o: any): o is PingPongMessage {  // eslint-dis
     typeof o.threadId === "string" &&
     (o.sessionId === undefined || typeof o.sessionId === "string");
 }
+
+
+/** A message sent by the app to enable drag operations over the app. The
+ * message is triggered when the pointer moves over the app with any button
+ * pressed.
+ * */
+export interface PointerMoveMessage {
+  /** The tag identifying this message type. */
+  type: "wwt_pointer_move";
+
+  /** The clientX property of the originating pointer move event. */
+  clientX: number;
+  
+  /** The clientY property of the originating pointer move event. */
+  clientY: number;
+
+  /** An app/client session identifier.
+   *
+   * If a single client is communicating with multiple apps, it needs to be able
+   * to tell which app is the source of any update messages. This session
+   * identifier allows clients to do so. The default value is "default". But if
+   * a client sends a [[PingPongMessage]] with a customized ``sessionId`` field,
+   * that value will start appearing in these view state update messages.
+   */
+  sessionId?: string;
+}
+
+/** Type guard function for [[PointerMoveMessage]]. */
+export function isPointerMoveMessage(o: any): o is PointerMoveMessage {  // eslint-disable-line @typescript-eslint/no-explicit-any
+  return typeof o.type === "string" &&
+    o.type == "wwt_pointer_move" &&
+    typeof o.clientX === "number" &&
+    typeof o.clientY === "number" &&
+    (o.sessionId === undefined || typeof o.sessionId === "string");
+}
+
+
+/** A message sent by the app to enable drag operations over the app. The
+ * message is triggered when the pointerup event is triggered within the app.
+ * */
+ export interface PointerUpMessage {
+  /** The tag identifying this message type. */
+  type: "wwt_pointer_up";
+
+  /** The clientX property of the originating pointer up event. */
+  clientX: number;
+  
+  /** The clientY property of the originating pointer up event. */
+  clientY: number;
+
+  /** An app/client session identifier.
+   *
+   * If a single client is communicating with multiple apps, it needs to be able
+   * to tell which app is the source of any update messages. This session
+   * identifier allows clients to do so. The default value is "default". But if
+   * a client sends a [[PingPongMessage]] with a customized ``sessionId`` field,
+   * that value will start appearing in these view state update messages.
+   */
+  sessionId?: string;
+}
+
+/** Type guard function for [[PointerUpMessage]]. */
+export function isPointerUpMessage(o: any): o is PointerUpMessage {  // eslint-disable-line @typescript-eslint/no-explicit-any
+  return typeof o.type === "string" &&
+    o.type == "wwt_pointer_up" &&
+    typeof o.clientX === "number" &&
+    typeof o.clientY === "number" &&
+    (o.sessionId === undefined || typeof o.sessionId === "string");
+}


### PR DESCRIPTION
This one has been bugging me for a long time, so I decided to finally look into the issue. 

The main problem I have encountered is in jupyter where wwt-jupyterlab I cannot move any windows on top of the WWT app. All mouse events happening on top of WWT never reach jupyter in this case, because WWT is inside an iframe. Since the mouse events cannot go through an iframe for security reasons, we can create a relay with `postMessage`.

This PR let's clients, like wwt-jupyterlab (and other people using the research app in an iframe), know when the drag operation events are occurring inside WWT. Then the client will have to throw a mousemove or mouseup event to get the desired result. Like this: https://github.com/WorldWideTelescope/wwt-jupyterlab/pull/13

Added code:
- Now posting pointermove/up events occurring inside the app. This allows interested parties (namely wwt-jupyterlab) to relay the events to clients outside the wwt iframe.