### PR TITLE
Add functionality to find screen point for given coordinates

### DIFF
--- a/engine-vuex/src/store.ts
+++ b/engine-vuex/src/store.ts
@@ -506,6 +506,14 @@ export class WWTEngineVuexModule extends VuexModule implements WWTEngineVuexStat
     }
   }
 
+  get findScreenPointForRADec() {
+    return function (pt: { ra: number; dec: number }): { x: number; y: number } {
+      if (Vue.$wwt.inst === null)
+        throw new Error('cannot findScreenPointForRADec without linking to WWTInstance');
+      return Vue.$wwt.inst.ctl.getScreenPointForCoordinates(pt.ra / 15, pt.dec);
+    }
+  }
+
   @Mutation
   internalLinkToInstance(wwt: WWTInstance): void {
     Vue.$wwt.link(wwt);

--- a/engine-vuex/src/wwtaware.ts
+++ b/engine-vuex/src/wwtaware.ts
@@ -329,6 +329,7 @@ export class WWTAwareComponent extends Vue {
       ...mapGetters([
         "activeImagesetLayerStates",
         "findRADecForScreenPoint",
+        "findScreenPointForRADec",
         "imagesetForLayer",
         "imagesetStateForLayer",
         "layerForHipsCatalog",
@@ -600,6 +601,9 @@ export class WWTAwareComponent extends Vue {
 
   /** Get the right ascension and declination, in degrees, for x, y coordinates on the screen */
   findRADecForScreenPoint!: (pt: { x: number; y: number }) => { ra: number; dec: number };
+
+  /** Given an RA and Dec position, return the x, y coordinates of the screen point */
+  findScreenPointForRADec!: (pt:  { ra: number; dec: number }) => { x: number; y: number };
 
   /** Get the actual WWT `SpreadSheetLayer` for the table layer with the given ID.
    *

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -2616,6 +2616,9 @@ export class WWTControl {
   /** Given x and y coordinates on the screen, returns the RA and Dec */
   getCoordinatesForScreenPoint(x: number, y: number): { x: number; y: number };
 
+  /** Given RA and Dec, return the screen point */
+  getScreenPointForCoordinates(ra: number, dec: number): { x: number; y: number };
+
   /** Start loading the tour stored at the specified URL.
    *
    * When loading is complete, a `tourReady` event will be issued, which you can

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -2616,7 +2616,7 @@ export class WWTControl {
   /** Given x and y coordinates on the screen, returns the RA and Dec */
   getCoordinatesForScreenPoint(x: number, y: number): { x: number; y: number };
 
-  /** Given RA and Dec, return the screen point */
+  /** Given RA and Dec, return the x and y coordinates of the corresponding screen point */
   getScreenPointForCoordinates(ra: number, dec: number): { x: number; y: number };
 
   /** Start loading the tour stored at the specified URL.

--- a/engine/wwtlib/Coordinates.cs
+++ b/engine/wwtlib/Coordinates.cs
@@ -550,6 +550,16 @@ namespace wwtlib
 
         }
 
+        static public Vector3d SphericalSkyToCartesian(Vector2d vector)
+        {
+            double ra = vector.X * (Math.PI / 12);
+            double dec = vector.Y * (Math.PI / 180);
+            double x = Math.Cos(ra) * Math.Cos(dec);
+            double y = -Math.Sin(dec);
+            double z = Math.Sin(ra) * Math.Cos(dec);
+            return Vector3d.Create(x, y, z);
+        }
+
         static public Vector2d CartesianToLatLng(Vector3d vector)
         {
             double rho = Math.Sqrt(vector.X * vector.X + vector.Y * vector.Y + vector.Z * vector.Z);

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -1718,6 +1718,28 @@ namespace wwtlib
             return vPickRayDir;
         }
 
+        public Vector2d TransformWorldPointToPickSpace(Vector3d worldPoint, double backBufferWidth, double backBufferHeight)
+        {
+            Matrix3d m = Matrix3d.MultiplyMatrix(RenderContext.View, RenderContext.World);
+            m.Invert();
+            m.Transpose();
+            Vector2d p = new Vector2d();
+            double vz = worldPoint.X * m.M13 + worldPoint.Y * m.M23 + worldPoint.Z * m.M33;
+            double vx = (worldPoint.X * m.M11 + worldPoint.Y * m.M21 + worldPoint.Z * m.M31) / vz;
+            double vy = (worldPoint.X * m.M12 + worldPoint.Y * m.M22 + worldPoint.Z * m.M32) / vz;
+            p.X = Math.Round((1 + RenderContext.Projection.M11 * vx) * (backBufferWidth / 2));
+            p.Y = Math.Round((1 + RenderContext.Projection.M22 * vy) * (backBufferHeight / 2));
+            return p;
+        }
+
+        public Vector2d GetScreenPointForCoordinates(double ra, double dec)
+        {
+            Vector2d pt = Vector2d.Create(ra, dec);
+            Vector3d cartesian = Coordinates.SphericalSkyToCartesian(pt);
+            Vector2d result = TransformWorldPointToPickSpace(cartesian, RenderContext.Width, RenderContext.Height);
+            return result;
+        }
+
         // Initialization
 
         public static ScriptInterface scriptInterface;

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -1722,11 +1722,11 @@ namespace wwtlib
         {
             Matrix3d m = Matrix3d.MultiplyMatrix(RenderContext.View, RenderContext.World);
             m.Invert();
-            m.Transpose();
+
             Vector2d p = new Vector2d();
-            double vz = worldPoint.X * m.M13 + worldPoint.Y * m.M23 + worldPoint.Z * m.M33;
-            double vx = (worldPoint.X * m.M11 + worldPoint.Y * m.M21 + worldPoint.Z * m.M31) / vz;
-            double vy = (worldPoint.X * m.M12 + worldPoint.Y * m.M22 + worldPoint.Z * m.M32) / vz;
+            double vz = worldPoint.X * m.M31 + worldPoint.Y * m.M32 + worldPoint.Z * m.M33;
+            double vx = (worldPoint.X * m.M11 + worldPoint.Y * m.M12 + worldPoint.Z * m.M13) / vz;
+            double vy = (worldPoint.X * m.M21 + worldPoint.Y * m.M22 + worldPoint.Z * m.M23) / vz;
             p.X = Math.Round((1 + RenderContext.Projection.M11 * vx) * (backBufferWidth / 2));
             p.Y = Math.Round((1 + RenderContext.Projection.M22 * vy) * (backBufferHeight / 2));
             return p;


### PR DESCRIPTION
This PR adds functionality to the engine to find the x and y coordinates of the screen point corresponding to a given RA and Dec. The plumbing to expose this to TypeScript is also added.

Basically, this adds three new functions to the engine itself: `TransformWorldPointToPickSpace`, `SphericalSkyToCartesian`, and `GetScreenPointForCoordinates`. These three functions are intended as essentially inverse functions to `TransformPickPointToWorldSpace`, `CartesianToSphericalSky`, and `GetCoordinatesForScreenPoint`, respectively.

I can see a few intended use cases. I have some ideas on how to use this to improve the point selection in the research app, and this could also be used for building dynamic scale bars or anything else distance/size-based.