### PR TITLE
FITS position adjustments

### DIFF
--- a/engine/wwtlib/Imageset.cs
+++ b/engine/wwtlib/Imageset.cs
@@ -841,7 +841,7 @@ namespace wwtlib
                 }
                 if (Levels > 0)
                 {
-                    return CenterX - OffsetX;
+                    return CenterX;
                 }
                 else
                 {
@@ -860,7 +860,7 @@ namespace wwtlib
                 }
                 if (Levels > 0)
                 {
-                    return CenterY + OffsetY;
+                    return CenterY;
                 }
                 else
                 {

--- a/engine/wwtlib/Imageset.cs
+++ b/engine/wwtlib/Imageset.cs
@@ -832,42 +832,83 @@ namespace wwtlib
             }
         }
 
+        // Calculate either the X or Y coordinate of the estimated image center.
+        //
+        // This estimate has some important limitations. First, because images
+        // might contain transparent regions, the "center" of the image that a
+        // user will perceive might have nothing to do with the center of the
+        // image bitmap. For instance, imagine that the bitmap is 100x100 but
+        // that everything is transparent except for 10x10 pixels in the
+        // top-left corner. We don't know anything about the "barycenter" of the
+        // image here, so we can't account for that.
+        //
+        // Second, for untiled SkyImage imagesets, to properly compute the
+        // bitmap center we need its dimensions, which simply aren't available
+        // here. All we can do is guess a "reasonable" image size.
+        //
+        // For these reasons, this method should be avoided when possible. The
+        // preferred way to "know" the location of an image's center is to wrap
+        // the image in a Place object, which can just specify the exact
+        // coordinates and zoom level too.
+        //
+        // Even disregarding the above, it's non-trivial to locate the image
+        // center because of the OffsetX/Y parameters and potential rotation of
+        // the image's coordinate system relative to the sky.
+        private double CalcViewCenterCoordinate(bool isX)
+        {
+            double rot = Coordinates.DegreesToRadians(rotation);
+            double crot = Math.Cos(rot);
+            double srot = Math.Sin(rot);
+
+            double dx = 0, dy = 0;
+
+            if (Levels > 0) {
+                dx = -offsetX;
+                dy = offsetY;
+            } else {
+                // This is the part where we need the image's dimensions to
+                // be able to compute the center coordinate correctly. Since
+                // we don't have that information, we just guess :-(
+                double effWidth = 800;
+                double effHeight = 800;
+
+                dx = (offsetX - effWidth / 2) * baseTileDegrees;
+                dy = (effHeight / 2 - offsetY) * baseTileDegrees;
+            }
+
+            if (bottomsUp) {
+                dx = -dx;
+            }
+
+            if (isX) {
+                return centerX + dx * crot + dy * srot;
+            } else {
+                return centerY - dx * srot + dy * crot;
+            }
+        }
+
         public double ViewCenterX
         {
             get {
-                if (WcsImage != null)
-                {
-                    return ((WcsImage)WcsImage).ViewCenterX;
-                }
-                if (Levels > 0)
-                {
-                    return CenterX;
-                }
-                else
-                {
-                    return CenterX + OffsetX / 256 * BaseTileDegrees;
+                if (WcsImage != null) {
+                    return ((WcsImage) WcsImage).ViewCenterX;
+                } else {
+                    return CalcViewCenterCoordinate(true);
                 }
             }
         }
 
         public double ViewCenterY
         {
-            get
-            {
-                if (WcsImage != null)
-                {
-                    return ((WcsImage)WcsImage).ViewCenterY;
-                }
-                if (Levels > 0)
-                {
-                    return CenterY;
-                }
-                else
-                {
-                    return CenterY + OffsetY / 256 * BaseTileDegrees;
+            get {
+                if (WcsImage != null) {
+                    return ((WcsImage) WcsImage).ViewCenterY;
+                } else {
+                    return CalcViewCenterCoordinate(false);
                 }
             }
         }
+
         public static Imageset Create(string name, string url, ImageSetType dataSetType, BandPass bandPass, ProjectionType projection, int imageSetID, int baseLevel, int levels, int tileSize, double baseTileDegrees, string extension, bool bottomsUp, string quadTreeMap, double centerX, double centerY, double rotation, bool sparse, string thumbnailUrl, bool defaultSet, bool elevationModel, int wf, double offsetX, double offsetY, string credits, string creditsUrl, string demUrlIn, string alturl, double meanRadius, string referenceFrame)
         {
             Imageset temp = new Imageset();

--- a/engine/wwtlib/TangentTile.cs
+++ b/engine/wwtlib/TangentTile.cs
@@ -22,10 +22,18 @@ namespace wwtlib
             }
             double tileDegrees = this.dataset.BaseTileDegrees / (Math.Pow(2, this.Level));
 
-            double latMin = (((double)this.dataset.BaseTileDegrees / 2 - (((double)this.tileY) * tileDegrees)) + dataset.OffsetY);
-            double latMax = (((double)this.dataset.BaseTileDegrees / 2 - (((double)(this.tileY + 1)) * tileDegrees)) + dataset.OffsetY);
-            double lngMin = ((((double)this.tileX * tileDegrees) - this.dataset.BaseTileDegrees / dataset.WidthFactor) + dataset.OffsetX);
-            double lngMax = (((((double)(this.tileX + 1)) * tileDegrees) - (double)this.dataset.BaseTileDegrees / dataset.WidthFactor) + dataset.OffsetX);
+
+            // The position needs to be adjusted by half a pixel to make sure that
+            // the center of the pixel is displayed at the target position,
+            // instead of a corner of that pixel. Each tile is 256 pixels and we
+            // want to adjust the entire dataset with one half pixel of the pixel
+            // size of the original image, i.e. the BaseLevel + Levels
+            double halfPixelCorrection = this.dataset.BaseTileDegrees / Math.Pow(2, this.dataset.BaseLevel + this.dataset.Levels) / 256 / 2;
+
+            double latMin = (((double)this.dataset.BaseTileDegrees / 2 - (((double)this.tileY) * tileDegrees)) + dataset.OffsetY) - halfPixelCorrection;
+            double latMax = (((double)this.dataset.BaseTileDegrees / 2 - (((double)(this.tileY + 1)) * tileDegrees)) + dataset.OffsetY) - halfPixelCorrection;
+            double lngMin = ((((double)this.tileX * tileDegrees) - this.dataset.BaseTileDegrees / dataset.WidthFactor) + dataset.OffsetX) + halfPixelCorrection;
+            double lngMax = (((((double)(this.tileX + 1)) * tileDegrees) - (double)this.dataset.BaseTileDegrees / dataset.WidthFactor) + dataset.OffsetX) + halfPixelCorrection;
 
             double latCenter = (latMin + latMax) / 2.0;
             double lngCenter = (lngMin + lngMax) / 2.0;
@@ -84,11 +92,17 @@ namespace wwtlib
         {
             double tileDegrees = (double)this.dataset.BaseTileDegrees / ((double)Math.Pow(2, this.Level));
 
+            // The position needs to be adjusted by half a pixel to make sure that
+            // the center of the pixel is displayed at the target position,
+            // instead of a corner of that pixel. Each tile is 256 pixels and we
+            // want to adjust the entire dataset with one half pixel of the pixel
+            // size of the original image, i.e. the BaseLevel + Levels
+            double halfPixelCorrection = this.dataset.BaseTileDegrees / Math.Pow(2, this.dataset.BaseLevel + this.dataset.Levels) / 256 / 2;
 
-            double latMin = ((double)this.dataset.BaseTileDegrees / 2 + (((double)(this.tileY + 1)) * tileDegrees)) + dataset.OffsetY;
-            double latMax = ((double)this.dataset.BaseTileDegrees / 2 + (((double)this.tileY) * tileDegrees)) + dataset.OffsetY;
-            double lngMin = (((double)this.tileX * tileDegrees) - this.dataset.BaseTileDegrees / dataset.WidthFactor) + dataset.OffsetX;
-            double lngMax = ((((double)(this.tileX + 1)) * tileDegrees) - this.dataset.BaseTileDegrees / dataset.WidthFactor) + dataset.OffsetX;
+            double latMin = ((double)this.dataset.BaseTileDegrees / 2 + (((double)(this.tileY + 1)) * tileDegrees)) + dataset.OffsetY + halfPixelCorrection;
+            double latMax = ((double)this.dataset.BaseTileDegrees / 2 + (((double)this.tileY) * tileDegrees)) + dataset.OffsetY + halfPixelCorrection;
+            double lngMin = (((double)this.tileX * tileDegrees) - this.dataset.BaseTileDegrees / dataset.WidthFactor) + dataset.OffsetX + halfPixelCorrection;
+            double lngMax = ((((double)(this.tileX + 1)) * tileDegrees) - this.dataset.BaseTileDegrees / dataset.WidthFactor) + dataset.OffsetX + halfPixelCorrection;
 
             double latCenter = (latMin + latMax) / 2.0;
             double lngCenter = (lngMin + lngMax) / 2.0;
@@ -228,10 +242,17 @@ namespace wwtlib
         {
             double tileDegrees = this.dataset.BaseTileDegrees / (Math.Pow(2, this.Level));
             LatLngEdges edges = new LatLngEdges();
-            edges.latMin = (((double)this.dataset.BaseTileDegrees / 2.0 - (((double)this.tileY) * tileDegrees)) + this.dataset.OffsetY);
-            edges.latMax = (((double)this.dataset.BaseTileDegrees / 2.0 - (((double)(this.tileY + 1)) * tileDegrees)) + this.dataset.OffsetY);
-            edges.lngMin = ((((double)this.tileX * tileDegrees) - (double)this.dataset.BaseTileDegrees / dataset.WidthFactor) + this.dataset.OffsetX);
-            edges.lngMax = (((((double)(this.tileX + 1)) * tileDegrees) - (double)this.dataset.BaseTileDegrees / dataset.WidthFactor) + this.dataset.OffsetX);
+
+            // The position needs to be adjusted by half a pixel to make sure that
+            // the center of the pixel is displayed at the target position,
+            // instead of a corner of that pixel. Each tile is 256 pixels and we
+            // want to adjust the entire dataset with one half pixel of the pixel
+            // size of the original image, i.e. the BaseLevel + Levels
+            double halfPixelCorrection = this.dataset.BaseTileDegrees / Math.Pow(2, this.dataset.BaseLevel + this.dataset.Levels) / 256 / 2;
+            edges.latMin = (((double)this.dataset.BaseTileDegrees / 2.0 - (((double)this.tileY) * tileDegrees)) + this.dataset.OffsetY) - halfPixelCorrection;
+            edges.latMax = (((double)this.dataset.BaseTileDegrees / 2.0 - (((double)(this.tileY + 1)) * tileDegrees)) + this.dataset.OffsetY) - halfPixelCorrection;
+            edges.lngMin = ((((double)this.tileX * tileDegrees) - (double)this.dataset.BaseTileDegrees / dataset.WidthFactor) + this.dataset.OffsetX) + halfPixelCorrection;
+            edges.lngMax = (((((double)(this.tileX + 1)) * tileDegrees) - (double)this.dataset.BaseTileDegrees / dataset.WidthFactor) + this.dataset.OffsetX) + halfPixelCorrection;
             return edges;
         }
 

--- a/engine/wwtlib/TangentTile.cs
+++ b/engine/wwtlib/TangentTile.cs
@@ -22,18 +22,10 @@ namespace wwtlib
             }
             double tileDegrees = this.dataset.BaseTileDegrees / (Math.Pow(2, this.Level));
 
-
-            // The position needs to be adjusted by half a pixel to make sure that
-            // the center of the pixel is displayed at the target position,
-            // instead of a corner of that pixel. Each tile is 256 pixels and we
-            // want to adjust the entire dataset with one half pixel of the pixel
-            // size of the original image, i.e. the BaseLevel + Levels
-            double halfPixelCorrection = this.dataset.BaseTileDegrees / Math.Pow(2, this.dataset.BaseLevel + this.dataset.Levels) / 256 / 2;
-
-            double latMin = (((double)this.dataset.BaseTileDegrees / 2 - (((double)this.tileY) * tileDegrees)) + dataset.OffsetY) - halfPixelCorrection;
-            double latMax = (((double)this.dataset.BaseTileDegrees / 2 - (((double)(this.tileY + 1)) * tileDegrees)) + dataset.OffsetY) - halfPixelCorrection;
-            double lngMin = ((((double)this.tileX * tileDegrees) - this.dataset.BaseTileDegrees / dataset.WidthFactor) + dataset.OffsetX) + halfPixelCorrection;
-            double lngMax = (((((double)(this.tileX + 1)) * tileDegrees) - (double)this.dataset.BaseTileDegrees / dataset.WidthFactor) + dataset.OffsetX) + halfPixelCorrection;
+            double latMin = (((double)this.dataset.BaseTileDegrees / 2 - (((double)this.tileY) * tileDegrees)) + dataset.OffsetY);
+            double latMax = (((double)this.dataset.BaseTileDegrees / 2 - (((double)(this.tileY + 1)) * tileDegrees)) + dataset.OffsetY);
+            double lngMin = ((((double)this.tileX * tileDegrees) - this.dataset.BaseTileDegrees / dataset.WidthFactor) + dataset.OffsetX);
+            double lngMax = (((((double)(this.tileX + 1)) * tileDegrees) - (double)this.dataset.BaseTileDegrees / dataset.WidthFactor) + dataset.OffsetX);
 
             double latCenter = (latMin + latMax) / 2.0;
             double lngCenter = (lngMin + lngMax) / 2.0;
@@ -92,17 +84,11 @@ namespace wwtlib
         {
             double tileDegrees = (double)this.dataset.BaseTileDegrees / ((double)Math.Pow(2, this.Level));
 
-            // The position needs to be adjusted by half a pixel to make sure that
-            // the center of the pixel is displayed at the target position,
-            // instead of a corner of that pixel. Each tile is 256 pixels and we
-            // want to adjust the entire dataset with one half pixel of the pixel
-            // size of the original image, i.e. the BaseLevel + Levels
-            double halfPixelCorrection = this.dataset.BaseTileDegrees / Math.Pow(2, this.dataset.BaseLevel + this.dataset.Levels) / 256 / 2;
 
-            double latMin = ((double)this.dataset.BaseTileDegrees / 2 + (((double)(this.tileY + 1)) * tileDegrees)) + dataset.OffsetY + halfPixelCorrection;
-            double latMax = ((double)this.dataset.BaseTileDegrees / 2 + (((double)this.tileY) * tileDegrees)) + dataset.OffsetY + halfPixelCorrection;
-            double lngMin = (((double)this.tileX * tileDegrees) - this.dataset.BaseTileDegrees / dataset.WidthFactor) + dataset.OffsetX + halfPixelCorrection;
-            double lngMax = ((((double)(this.tileX + 1)) * tileDegrees) - this.dataset.BaseTileDegrees / dataset.WidthFactor) + dataset.OffsetX + halfPixelCorrection;
+            double latMin = ((double)this.dataset.BaseTileDegrees / 2 + (((double)(this.tileY + 1)) * tileDegrees)) + dataset.OffsetY;
+            double latMax = ((double)this.dataset.BaseTileDegrees / 2 + (((double)this.tileY) * tileDegrees)) + dataset.OffsetY;
+            double lngMin = (((double)this.tileX * tileDegrees) - this.dataset.BaseTileDegrees / dataset.WidthFactor) + dataset.OffsetX;
+            double lngMax = ((((double)(this.tileX + 1)) * tileDegrees) - this.dataset.BaseTileDegrees / dataset.WidthFactor) + dataset.OffsetX;
 
             double latCenter = (latMin + latMax) / 2.0;
             double lngCenter = (lngMin + lngMax) / 2.0;
@@ -242,17 +228,10 @@ namespace wwtlib
         {
             double tileDegrees = this.dataset.BaseTileDegrees / (Math.Pow(2, this.Level));
             LatLngEdges edges = new LatLngEdges();
-
-            // The position needs to be adjusted by half a pixel to make sure that
-            // the center of the pixel is displayed at the target position,
-            // instead of a corner of that pixel. Each tile is 256 pixels and we
-            // want to adjust the entire dataset with one half pixel of the pixel
-            // size of the original image, i.e. the BaseLevel + Levels
-            double halfPixelCorrection = this.dataset.BaseTileDegrees / Math.Pow(2, this.dataset.BaseLevel + this.dataset.Levels) / 256 / 2;
-            edges.latMin = (((double)this.dataset.BaseTileDegrees / 2.0 - (((double)this.tileY) * tileDegrees)) + this.dataset.OffsetY) - halfPixelCorrection;
-            edges.latMax = (((double)this.dataset.BaseTileDegrees / 2.0 - (((double)(this.tileY + 1)) * tileDegrees)) + this.dataset.OffsetY) - halfPixelCorrection;
-            edges.lngMin = ((((double)this.tileX * tileDegrees) - (double)this.dataset.BaseTileDegrees / dataset.WidthFactor) + this.dataset.OffsetX) + halfPixelCorrection;
-            edges.lngMax = (((((double)(this.tileX + 1)) * tileDegrees) - (double)this.dataset.BaseTileDegrees / dataset.WidthFactor) + this.dataset.OffsetX) + halfPixelCorrection;
+            edges.latMin = (((double)this.dataset.BaseTileDegrees / 2.0 - (((double)this.tileY) * tileDegrees)) + this.dataset.OffsetY);
+            edges.latMax = (((double)this.dataset.BaseTileDegrees / 2.0 - (((double)(this.tileY + 1)) * tileDegrees)) + this.dataset.OffsetY);
+            edges.lngMin = ((((double)this.tileX * tileDegrees) - (double)this.dataset.BaseTileDegrees / dataset.WidthFactor) + this.dataset.OffsetX);
+            edges.lngMax = (((((double)(this.tileX + 1)) * tileDegrees) - (double)this.dataset.BaseTileDegrees / dataset.WidthFactor) + this.dataset.OffsetX);
             return edges;
         }
 

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -1988,7 +1988,14 @@ namespace wwtlib
 
         public void GotoRADecZoom(double ra, double dec, double zoom, bool instant, double? roll)
         {
-            ra = DoubleUtilities.Clamp(ra, 0, 24);
+            while (ra > 24)
+            {
+                ra -= 24;
+            }
+            while (ra < 0)
+            {
+                ra += 24;
+            }
             dec = DoubleUtilities.Clamp(dec, -90, 90);
             zoom = DoubleUtilities.Clamp(zoom, ZoomMin, ZoomMax);
             double rotation = roll == null ? WWTControl.Singleton.RenderContext.ViewCamera.Rotation : (double)roll;

--- a/tests/page_objects/researchApp.ts
+++ b/tests/page_objects/researchApp.ts
@@ -141,7 +141,7 @@ module.exports = {
       },
       props: {
         initialCoordinateText: "17:45:35 -28:53:59",
-        phatLayerCoordinates: "00:45:05 +41:45:35", // Both are at the same position
+        phatLayerCoordinates: "00:45:12 +41:45:02", // Both are at the same position
       },
     },
     controls: {


### PR DESCRIPTION
This PR has two parts:
1. Zoom position was wrong for both tiled tangential imagesets and untiled images
2. Half pixel correction for tiled tangential imagesets

**Regarding the first issue:**
For untiled images, `GotoRADecZoom` could be called with a RA < 0, which got clamped to 0, resulting in a wrong position. For tiled tangential imagesets the goto destination was off by the `offsetX` and `offsetY` in the wrong directions. Tbh, I did not look into the exact reason because we need to decide the desired behaviour of the goto action. Right now, we have a mix of solutions, where we sometimes try to go to the center of the image and sometimes to the center of the coordinate system like `CRPIX`. The buttons in the research app seem to always go for the coordinate system position, which arguably is more correct. For now I just removed the `offsetXY`, to get the same goto position inside the engine as in the research app.  Do you think this is the behavior we should converge towards?

The current status with this PR is that all `TilingMethods` (UNTILED, TOAST, TAN, HIPS) goto `CRPIX` if the goto button is pressed inside the research app. The same position is the destination for the automatic engine goto onload for TOAST and TAN. For UNTILED and HIPS, the positions are still the center of the image, so whatever way we go, we should probably align the rest.

**Regarding the second issue:**
This is a tricky one... It is very easy to take a mental misstep here, so I'd highly appreciate a second pair of eyes. Did I get it completely right by flipping the sign in the y axis for the bottoms up etc? What I have here seems to properly handle all the test cases I've thrown at it.

Just like https://github.com/WorldWideTelescope/wwt-webgl-engine/pull/211 we want the pixel center to be the defining feature of the position and not the corner of the pixel. Since the tiled tangential imagesets has levels, we have to make sure to adjust all levels by a half pixel of the _original image_, which in this case is the pixel size of the bottom level.

Here is some handy pywwt code to test different variations:
```
from pywwt.jupyter import connect_to_app
wwt = await connect_to_app().becomes_ready()
import numpy as np
from toasty import TilingMethod
from astropy.wcs import WCS

size = 256 * 16 + 1 # size <  257 results in a SkyImage, which is not yet displayed correctly
array = np.arange(size * size, dtype=float).reshape(size, size)

array[size - 1][size - 1] = 0
array[0][0] = size * size
array[0][size - 1] = size * size
array[size - 1][0] = 0
array[int((size - 1) / 2)][int((size - 1) / 2)] = size * size

wcs = WCS()
wcs.wcs.ctype = 'RA---TAN', 'DEC--TAN'
wcs.wcs.crval = 0, 0
wcs.wcs.crpix = size, size
wcs.wcs.cdelt = 20 / size, 20 / size
wcs._naxis = [size, size]

wwt.layers.add_image_layer(image=(array, wcs), tiling_method=TilingMethod.TAN, override=True, name='tan')
#wwt.layers.add_image_layer(image=(array, wcs), tiling_method=TilingMethod.UNTILED, override=True, name='untiled')
#wwt.layers.add_image_layer(image=(array, wcs), tiling_method=TilingMethod.HIPS, override=True, name='HiPS')
#wwt.layers.add_image_layer(image=(array, wcs), tiling_method=TilingMethod.TOAST, override=True, name='TOAST')
```
There are still some discrepancies at the other corners, which could be investigated later.