### PR TITLE
research-app: Improve point selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "wwt-webgl-engine-monorepo",
       "dependencies": {
         "@types/debounce": "^1.2.0",
+        "@types/express-serve-static-core": "4.17.28",
         "@types/jsdom": "^16.2.13",
         "@types/vue-color": "^2.4.3",
         "@types/vue-select": "3.16.0",
@@ -4648,7 +4649,6 @@
     },
     "node_modules/@types/express-serve-static-core": {
       "version": "4.17.28",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -4738,12 +4738,10 @@
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/serve-static": {
@@ -29445,7 +29443,6 @@
     },
     "@types/express-serve-static-core": {
       "version": "4.17.28",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -29520,12 +29517,10 @@
       "dev": true
     },
     "@types/qs": {
-      "version": "6.9.7",
-      "dev": true
+      "version": "6.9.7"
     },
     "@types/range-parser": {
-      "version": "1.2.4",
-      "dev": true
+      "version": "1.2.4"
     },
     "@types/serve-static": {
       "version": "1.13.10",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@types/debounce": "^1.2.0",
+    "@types/express-serve-static-core": "4.17.28",
     "@types/jsdom": "^16.2.13",
     "@types/vue-color": "^2.4.3",
     "@types/vue-select": "3.16.0",

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -2146,11 +2146,11 @@ export default class App extends WWTAwareComponent {
     this.isMouseMoving = false;
   }
 
-  wwtOnPointerUp(_event: PointerEvent) {
+  wwtOnPointerUp(event: PointerEvent) {
     const message: PointerUpMessage = {
       type: "wwt_pointer_up",
-      clientX: _event.clientX,
-      clientY: _event.clientY,
+      clientX: event.clientX,
+      clientY: event.clientY,
       sessionId: this.statusMessageSessionId,
     };
     if (this.statusMessageDestination != null && this.allowedOrigin != null) {
@@ -2158,7 +2158,9 @@ export default class App extends WWTAwareComponent {
       // need to become smarter about allowedOrigin here.
       this.statusMessageDestination.postMessage(message, this.allowedOrigin);
     }
-    if (!this.isMouseMoving && this.lastClosePt !== null) {
+
+    this.updateLastClosePoint(event);
+    if (this.lastClosePt !== null) {
       const source = this.sourceCreator(this.lastClosePt);
       this.addSource(source);
       this.lastSelectedSource = source;
@@ -3088,6 +3090,7 @@ export default class App extends WWTAwareComponent {
         }
       }
     }
+
     if (closestPt !== null) {
       const closestRADecDeg = { ra: closestPt.ra * R2D, dec: closestPt.dec * R2D };
       const closestScreenPoint = this.findScreenPointForRADec(closestRADecDeg);

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -1154,11 +1154,6 @@ class KeyboardControlSettings {
   }
 }
 
-interface AngleCoordinates {
-  ra: number;
-  dec: number;
-}
-
 interface RawSourceInfo {
   ra: number;
   dec: number;

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -2168,12 +2168,15 @@ export default class App extends WWTAwareComponent {
       this.statusMessageDestination.postMessage(message, this.allowedOrigin);
     }
 
-    this.updateLastClosePoint(event);
-    if (!this.isPointerMoving && this.lastClosePt !== null) {
-      const source = this.sourceCreator(this.lastClosePt);
-      this.addSource(source);
-      this.lastSelectedSource = source;
+    if (!this.isPointerMoving) {
+      this.updateLastClosePoint(event);
+      if (this.lastClosePt !== null) {
+        const source = this.sourceCreator(this.lastClosePt);
+        this.addSource(source);
+        this.lastSelectedSource = source;
+      }
     }
+
     this.pointerStartPosition = null;
     this.isPointerMoving = false;
   }


### PR DESCRIPTION
This PR looks to improve the point selection functionality in the research app, primarily by making use of the functionality added to the engine in #206.

The research app determines whether a moving pointer is over a source by getting the RA/Dec of the pixel coordinate of the event, determining the closest source (using great-circle distance), and checking whether the source is "close enough". Currently this "close enough" threshold is determined by a magic constant whose meaning and units are pretty nebulous (and zoom-dependent). This PR replaces the current "close enough" step with the following:

* Use the new engine functionality to find the pixel coordinate of the closest source
* Check whether the pixel distance between the pointer and the closest source is smaller than some threshold

In this PR the pixel distance threshold is set to 4 pixels. So we're trading one constant for another, but this one has a well-defined meaning. Furthermore, using pixel distance means that we don't need to adjust anything when the zoom level of the app changes.

This PR also makes a couple of changes to make point selection functional on a touchscreen. These changes are:
* We update the last close point on a pointer up event, if the pointer isn't moving. A touchscreen won't be getting the pointer movement events to update the closest source, so we need to add another update here.
* Add a minimum pixel threshold to consider the pointer to be moving when it's pressed down. The reason for this is, at least in my experience, it's essentially impossible to purely trigger a pointerdown event on a touchscreen - the view will move a small amount. This threshold lets touchscreen selections happen despite these micro-movements, while still allowing us to distinguish between a regular move and a drag on a desktop. Currently I've set this threshold to 6 pixels, just based on my own user testing.