### PR TITLE
Ensure that source message doesn't try to send proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "nightwatch": "^2.3.9",
         "sass": "^1.26.3",
         "sass-loader": "^13.0.2",
-        "typedoc": "^0.23.19",
+        "typedoc": "0.23.20",
         "typescript": "^4.8.4",
         "uglify-js": "^3.9.1",
         "vue-template-compiler": "~2.6.11"
@@ -18365,9 +18365,9 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.23.21",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.21.tgz",
-      "integrity": "sha512-VNE9Jv7BgclvyH9moi2mluneSviD43dCE9pY8RWkO88/DrEgJZk9KpUk7WO468c9WWs/+aG6dOnoH7ccjnErhg==",
+      "version": "0.23.20",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.20.tgz",
+      "integrity": "sha512-nfb4Mx05ZZZXux3zPcLuc7+3TVePDW3jTdEBqXdQzJUyEILxoprgPIiTChbvci9crkqNJG9YESmfCptuh9Gn3g==",
       "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
@@ -18382,7 +18382,7 @@
         "node": ">= 14.14"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
@@ -34203,9 +34203,9 @@
       }
     },
     "typedoc": {
-      "version": "0.23.21",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.21.tgz",
-      "integrity": "sha512-VNE9Jv7BgclvyH9moi2mluneSviD43dCE9pY8RWkO88/DrEgJZk9KpUk7WO468c9WWs/+aG6dOnoH7ccjnErhg==",
+      "version": "0.23.20",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.20.tgz",
+      "integrity": "sha512-nfb4Mx05ZZZXux3zPcLuc7+3TVePDW3jTdEBqXdQzJUyEILxoprgPIiTChbvci9crkqNJG9YESmfCptuh9Gn3g==",
       "dev": true,
       "requires": {
         "lunr": "^2.3.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "sass": "^1.26.3",
         "sass-loader": "^13.0.2",
         "typedoc": "0.23.20",
-        "typescript": "^4.8.4",
+        "typescript": "~4.8.4",
         "uglify-js": "^3.9.1",
         "vue-template-compiler": "~2.6.11"
       }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "sass": "^1.26.3",
     "sass-loader": "^13.0.2",
     "typedoc": "0.23.20",
-    "typescript": "^4.8.4",
+    "typescript": "~4.8.4",
     "uglify-js": "^3.9.1",
     "vue-template-compiler": "~2.6.11"
   }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "nightwatch": "^2.3.9",
     "sass": "^1.26.3",
     "sass-loader": "^13.0.2",
-    "typedoc": "^0.23.19",
+    "typedoc": "0.23.20",
     "typescript": "^4.8.4",
     "uglify-js": "^3.9.1",
     "vue-template-compiler": "~2.6.11"

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -429,7 +429,7 @@ import {
   convertPywwtSpreadSheetLayerSetting,
   convertSpreadSheetLayerSetting,
 } from "./settings";
-import { defineComponent } from "vue";
+import { defineComponent, isProxy, toRaw } from "vue";
 
 const D2R = Math.PI / 180.0;
 const R2D = 180.0 / Math.PI;
@@ -3042,10 +3042,11 @@ const App = defineComponent({
       if (this.$options.statusMessageDestination === null || this.allowedOrigin === null)
         return;
 
+      const rawSource = isProxy(source) ? toRaw(source) : source;
       const msg: selections.SelectionStateMessage = {
         type: "wwt_selection_state",
         sessionId: this.statusMessageSessionId,
-        mostRecentSource: this.prepareForMessaging(source),
+        mostRecentSource: this.prepareForMessaging(rawSource),
       };
 
       this.$options.statusMessageDestination.postMessage(msg, this.allowedOrigin);


### PR DESCRIPTION
This PR fixes a small bug from the Vue 3 migration. The research app component's `lastSelectedCount` is now turned into a `Proxy`, which causes a `DOMException` when sending the message describing the last selected source (things work fine app-side). The fix here is to use Vue's `isProxy` and `toRaw`, if necessary, to serialize the original non-proxy object.