### PR TITLE
Allow changing selection proximity in research app

### DIFF
--- a/research-app-messages/src/settings.ts
+++ b/research-app-messages/src/settings.ts
@@ -38,14 +38,16 @@ export function isGenericSetting(obj: any): obj is GenericSetting {  // eslint-d
 /** Settings for the overall application.
  *
  * This should be thought of as an enumeration type, all of whose options are
- * compatible with [[GenericSetting]]. Right now, there is only one option
+ * compatible with [[GenericSetting]]. Right now, there are only two options
  * available, though.
  * */
 export type AppSetting =
-  ["hideAllChrome", boolean];
+  ["hideAllChrome", boolean] |
+  ["selectionProximity", number];
 
-const appSettingTypeInfo: { [i: string]: boolean } = {
+const appSettingTypeInfo: { [i: string]: boolean | number } = {
   "hideAllChrome/boolean": true,
+  "selectionProximity/number": 4
 };
 
 /** Type guard function for [[AppSetting]]. */

--- a/research-app/package.json
+++ b/research-app/package.json
@@ -50,7 +50,7 @@
     "@wwtelescope/engine-helpers": "263bedcc26dd2d13d03ba68daece76aa5e16f145",
     "@wwtelescope/engine-pinia": "thiscommit:2022-11-10:R3G9gH3",
     "@wwtelescope/engine-types": "263bedcc26dd2d13d03ba68daece76aa5e16f145",
-    "@wwtelescope/research-app-messages": "7e45dc1635eddfba744cc4ae924b10ae89fd3473"
+    "@wwtelescope/research-app-messages": "thiscommit:2022-11-30:h6SkuRt"
   },
   "keywords": [
     "AAS WorldWide Telescope"

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -1191,7 +1191,7 @@ const App = defineComponent({
       currentTool: null as ToolType,
       lastClosePt: null as RawSourceInfo | null,
       lastSelectedSource: null as Source | null,
-      distanceThreshold: 4,
+      selectionProximity: 4,
       hideAllChrome: false,
       hipsUrl: "http://www.worldwidetelescope.org/wwtweb/catalog.aspx?W=hips", // Temporary
       isPointerMoving: false,
@@ -2012,6 +2012,7 @@ const App = defineComponent({
       if (appModified !== null) {
         for (const s of appModified) {
           if (s[0] == "hideAllChrome") this.hideAllChrome = s[1];
+          if (s[0] == "selectionProximity") this.selectionProximity = s[1];
         }
 
         return true;
@@ -2055,7 +2056,7 @@ const App = defineComponent({
     
     updateLastClosePoint(event: PointerEvent): void {
       const pt = { x: event.offsetX, y: event.offsetY };
-      const closestPt = this.closestInView(pt, this.distanceThreshold);
+      const closestPt = this.closestInView(pt, this.selectionProximity);
       if (closestPt == null && this.lastClosePt == null) {
         return;
       }


### PR DESCRIPTION
This PR allows changing how close the pointer needs to be (in pixels) for a source to be considered close enough to select (by default, this is 4 pixels). This is done by adding a `selectionProximity` setting to the research app, which allows this to be changed via a `modify_settings` message. The `distanceThreshold` data field in the research app component has also been renamed to `selectionProximity` for consistency (overall, I felt that "selection proximity" gave a more obvious meaning, but I'm open to other suggestions).