### PR TITLE
Expose getting time for some goto movements

### DIFF
--- a/engine-helpers/src/index.ts
+++ b/engine-helpers/src/index.ts
@@ -467,6 +467,27 @@ export class WWTInstance {
     return this.makeArrivePromise(instant);
   }
 
+  /** Returns how long moving to the given position will take, in seconds.
+   *
+   * This wraps the underlying engine function of the same name, but homogenizing some
+   * of the angular arguments to use radians.
+   *
+   * @param raRad The RA to seek to, in radians
+   * @param decRad The declination to seek to, in radians
+   * @param zoomDeg The zoom setting, in *degrees*
+   * @param rollRad If specified, the roll of the target camera position, in radians
+   * @returns A void promise that resolves when the camera arrives at the target position.
+   */
+   timeToRADecZoom(raRad: number, decRad: number, zoomDeg: number, rollRad?: number): number {
+    const time = this.ctl.timeToRADecZoom(
+      raRad * R2H,
+      decRad * R2D,
+      zoomDeg,
+      rollRad
+    );
+    return time;
+  }
+
   /** Command the view to show a Place.
    *
    * @param options The options for the goto command.

--- a/engine-helpers/src/index.ts
+++ b/engine-helpers/src/index.ts
@@ -467,16 +467,16 @@ export class WWTInstance {
     return this.makeArrivePromise(instant);
   }
 
-  /** Returns how long moving to the given position will take, in seconds.
+  /** Returns how long moving to a given position will take, in seconds.
    *
    * This wraps the underlying engine function of the same name, but homogenizing some
    * of the angular arguments to use radians.
    *
-   * @param raRad The RA to seek to, in radians
-   * @param decRad The declination to seek to, in radians
+   * @param raRad The RA of the target position, in radians
+   * @param decRad The declination of the target position, in radians
    * @param zoomDeg The zoom setting, in *degrees*
    * @param rollRad If specified, the roll of the target camera position, in radians
-   * @returns A void promise that resolves when the camera arrives at the target position.
+   * @returns The amount of time, in seconds, that moving to the given position would take.
    */
    timeToRADecZoom(raRad: number, decRad: number, zoomDeg: number, rollRad?: number): number {
     const time = this.ctl.timeToRADecZoom(

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -356,6 +356,20 @@ export interface CreateTableLayerParams {
   dataCsv: string;
 }
 
+export interface TimeToRADecZoomParams {
+  /** The right ascension of the target, in radians. */
+  raRad: number;
+
+  /** The declination of the target, in radians. */
+  decRad: number;
+
+  /** The zoom level of the target, in *degrees*. */
+  zoomDeg: number;
+
+  /** Optional: The target roll of the target, in radians. */
+  rollRad?: number;
+}
+
 /** The parameters for the [[gotoRADecZoom]] action. */
 export interface GotoRADecZoomParams {
   /** The right ascension to go to, in radians. */
@@ -846,6 +860,14 @@ export const engineStore = defineStore('wwt-engine', {
       if (this.$wwt.inst === null)
         throw new Error('cannot gotoRADecZoom without linking to WWTInstance');
       return this.$wwt.inst.gotoRADecZoom(raRad, decRad, zoomDeg, instant, rollRad);
+    },
+
+    timeToRADecZoom(
+      { raRad, decRad, zoomDeg, rollRad }: TimeToRADecZoomParams
+    ): number {
+      if (this.$wwt.inst === null)
+        throw new Error('cannot get timeToRADecZoom without linking to WWTInstance');
+      return this.$wwt.inst.timeToRADecZoom(raRad, decRad, zoomDeg, rollRad);
     },
 
     async gotoTarget(options: GotoTargetOptions): Promise<void> {

--- a/engine-pinia/src/wwtaware.ts
+++ b/engine-pinia/src/wwtaware.ts
@@ -190,7 +190,7 @@ import { engineStore } from "./store";
  * Actions:
  *
  * - [[addCatalogHipsByName]]
- *  * - [[applyTableLayerSettings]]
+ * - [[applyTableLayerSettings]]
  * - [[getCatalogHipsDataInView]]
  * - [[removeCatalogHipsByName]]
  *
@@ -540,6 +540,9 @@ export const WWTAwareComponent = defineComponent({
        * TODO: document semantics when not in 2D sky mode!
        */
       "gotoRADecZoom",
+
+      /** Returns the time it would take, in seconds, to navigate to the given target. */
+      "timeToRADecZoom",
 
       /** Command the view to steer as specified in
        * [the options](../../engine-helpers/interfaces/gototargetoptions.html).

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -2492,6 +2492,16 @@ export class WWTControl {
    */
   gotoRADecZoom(ra_hours: number, dec_deg: number, zoom: number, instant: boolean, roll_deg?: number): void;
 
+    /** Returns how long moving to the given position will take, in seconds.
+   *
+   * @param ra_hours The target right ascension, in hours.
+   * @param dec_deg The target declination, in degrees.
+   * @param zoom The target zoom level (see below)
+   * @param roll_deg Optional, The roll of the camera, in degrees.
+   *
+   */
+  timeToRADecZoom(ra_hours: number, dec_deg: number, zoom: number, roll_deg?: number): number;
+
   /** Start navigating the view to the specified [[Place]].
    *
    * @param place The destination of the view

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -2374,6 +2374,12 @@ namespace wwtlib
             }
         }
 
+        double SlewTimeBetweenTargets(CameraParameters from, CameraParameters to)
+        {
+            ViewMoverSlew mover = ViewMoverSlew.Create(from, to);
+            return mover.MoveTime;
+        }
+
         public double TimeToTargetFull(CameraParameters cameraParams, bool noZoom)
         {
             if (noZoom)
@@ -2382,8 +2388,7 @@ namespace wwtlib
                 cameraParams.Angle = RenderContext.ViewCamera.Angle;
                 cameraParams.Rotation = RenderContext.ViewCamera.Rotation;
             }
-            ViewMoverSlew mover = ViewMoverSlew.Create(WWTControl.Singleton.RenderContext.ViewCamera, cameraParams);
-            return mover.MoveTime;
+            return SlewTimeBetweenTargets(WWTControl.Singleton.RenderContext.ViewCamera, cameraParams);
         }
 
         internal void FreezeView()

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -1997,6 +1997,21 @@ namespace wwtlib
 
         public void GotoRADecZoom(double ra, double dec, double zoom, bool instant, double? roll)
         {
+
+            tracking = false;
+            trackingObject = null;
+
+            GotoTargetFull(
+                false,  // noZoom
+                instant,
+                CameraParametersFromRADecZoom(ra, dec, zoom, roll),
+                WWTControl.Singleton.RenderContext.ForegroundImageset,
+                WWTControl.Singleton.RenderContext.BackgroundImageset
+            );
+        }
+
+        CameraParameters CameraParametersFromRADecZoom(double ra, double dec, double zoom, double? roll)
+        {
             while (ra > 24)
             {
                 ra -= 24;
@@ -2008,24 +2023,27 @@ namespace wwtlib
             dec = DoubleUtilities.Clamp(dec, -90, 90);
             zoom = DoubleUtilities.Clamp(zoom, ZoomMin, ZoomMax);
             double rotation = roll == null ? WWTControl.Singleton.RenderContext.ViewCamera.Rotation : (double)roll;
-
-            tracking = false;
-            trackingObject = null;
-
-            GotoTargetFull(
-                false,  // noZoom
-                instant,
-                CameraParameters.Create(
-                    dec,
-                    WWTControl.Singleton.RenderContext.RAtoViewLng(ra),
-                    zoom,
-                    rotation,
-                    WWTControl.Singleton.RenderContext.ViewCamera.Angle,
-                    (float)WWTControl.Singleton.RenderContext.ViewCamera.Opacity
-                ),
-                WWTControl.Singleton.RenderContext.ForegroundImageset,
-                WWTControl.Singleton.RenderContext.BackgroundImageset
+            CameraParameters cameraParams = CameraParameters.Create(
+                dec,
+                WWTControl.Singleton.RenderContext.RAtoViewLng(ra),
+                zoom,
+                rotation,
+                WWTControl.Singleton.RenderContext.ViewCamera.Angle,
+                (float)WWTControl.Singleton.RenderContext.ViewCamera.Opacity
             );
+            return cameraParams;
+        }
+
+        public double GotoRADecZoomTime(double ra, double dec, double zoom, double? roll)
+        {
+            CameraParameters cameraParams = CameraParametersFromRADecZoom(ra, dec, zoom, roll);
+            return TimeToTargetFull(cameraParams);
+        }
+
+        public double TimeToTargetFull(CameraParameters cameraParams)
+        {
+            ViewMoverSlew mover = ViewMoverSlew.Create(WWTControl.Singleton.RenderContext.ViewCamera, cameraParams);
+            return mover.MoveTime;
         }
 
 

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -2307,6 +2307,14 @@ namespace wwtlib
             GotoTargetFull(noZoom, instant, camParams, RenderContext.ForegroundImageset, RenderContext.BackgroundImageset);
         }
 
+        private bool TooCloseForSlewMove(CameraParameters cameraParams)
+        {
+           return Math.Abs(RenderContext.ViewCamera.Lat - cameraParams.Lat) < .000000000001 &&
+                  Math.Abs(RenderContext.ViewCamera.Lng - cameraParams.Lng) < .000000000001 &&
+                  Math.Abs(RenderContext.ViewCamera.Zoom - cameraParams.Zoom) < .000000000001 &&
+                  Math.Abs(RenderContext.ViewCamera.Rotation - cameraParams.Rotation) < .000000000001;
+        }
+
         public void GotoTargetFull(bool noZoom, bool instant, CameraParameters cameraParams, Imageset studyImageSet, Imageset backgroundImageSet)
         {
             RenderNeeded = true;
@@ -2340,12 +2348,7 @@ namespace wwtlib
                 }
             }
 
-            if (instant ||
-                (Math.Abs(RenderContext.ViewCamera.Lat - cameraParams.Lat) < .000000000001 &&
-                 Math.Abs(RenderContext.ViewCamera.Lng - cameraParams.Lng) < .000000000001 &&
-                 Math.Abs(RenderContext.ViewCamera.Zoom - cameraParams.Zoom) < .000000000001 &&
-                 Math.Abs(RenderContext.ViewCamera.Rotation - cameraParams.Rotation) < .000000000001
-                 ))
+            if (instant || TooCloseForSlewMove(cameraParams))
             {
                 Mover = null;
                 RenderContext.TargetCamera = cameraParams.Copy();
@@ -2388,6 +2391,11 @@ namespace wwtlib
                 cameraParams.Angle = RenderContext.ViewCamera.Angle;
                 cameraParams.Rotation = RenderContext.ViewCamera.Rotation;
             }
+            if (TooCloseForSlewMove(cameraParams))
+            {
+                return 0;
+            }
+            
             return SlewTimeBetweenTargets(WWTControl.Singleton.RenderContext.ViewCamera, cameraParams);
         }
 

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -2034,7 +2034,7 @@ namespace wwtlib
             return cameraParams;
         }
 
-        public double GotoRADecZoomTime(double ra, double dec, double zoom, double? roll)
+        public double TimeToRADecZoom(double ra, double dec, double zoom, double? roll)
         {
             CameraParameters cameraParams = CameraParametersFromRADecZoom(ra, dec, zoom, roll);
             return TimeToTargetFull(cameraParams, false);

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -2037,15 +2037,8 @@ namespace wwtlib
         public double GotoRADecZoomTime(double ra, double dec, double zoom, double? roll)
         {
             CameraParameters cameraParams = CameraParametersFromRADecZoom(ra, dec, zoom, roll);
-            return TimeToTargetFull(cameraParams);
+            return TimeToTargetFull(cameraParams, false);
         }
-
-        public double TimeToTargetFull(CameraParameters cameraParams)
-        {
-            ViewMoverSlew mover = ViewMoverSlew.Create(WWTControl.Singleton.RenderContext.ViewCamera, cameraParams);
-            return mover.MoveTime;
-        }
-
 
         bool tracking = false;
         Place trackingObject = null;
@@ -2379,6 +2372,18 @@ namespace wwtlib
                 RenderNeeded = true;
                 Mover.Midpoint = mover_Midpoint;
             }
+        }
+
+        public double TimeToTargetFull(CameraParameters cameraParams, bool noZoom)
+        {
+            if (noZoom)
+            {
+                cameraParams.Zoom = RenderContext.ViewCamera.Zoom;
+                cameraParams.Angle = RenderContext.ViewCamera.Angle;
+                cameraParams.Rotation = RenderContext.ViewCamera.Rotation;
+            }
+            ViewMoverSlew mover = ViewMoverSlew.Create(WWTControl.Singleton.RenderContext.ViewCamera, cameraParams);
+            return mover.MoveTime;
         }
 
         internal void FreezeView()


### PR DESCRIPTION
This PR adds functionality to the engine to allow obtaining the time necessary for the `GotoRADecZoom` and `GotoTargetFull` motions. This is done via the functions `TimeToRADecZoom` and `TimeToTargetFull`, respectively, along with some refactoring of shared calculations. `TimeToRADecZoom` is also exposed to the Pinia layer - I didn't do this for `TimeToTargetFull` since `GotoTargetFull` isn't exposed.

These implementations are based on the implementations of the corresponding goto functions. A few notes/thoughts:
• I did some testing in the browser, by comparing the reported and actual execution times (nothing fancy - I just surrounded an awaited goto call by `Date.now`s), and agreement is very good - on average, I found the execution time to be about 0.1% more than the reported time.
• Since some of the intermediate values in `ViewMoverSlew` are retained for later use, I determined that the best thing to do was to just create an instance and use its move time.
• `ViewMoverSlew` reports its time in seconds, so I've retained that. But maybe milliseconds would be more natural?
• It would be nice to do the same thing for `GotoTarget`. That's a much more complicated function, so I'll save that for a future PR.