### PR TITLE
Add store functionality for accessing general and imageset layers

### DIFF
--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -24,6 +24,7 @@ import {
   Imageset,
   ImageSetLayer,
   InViewReturnMessage,
+  Layer,
   LayerMap,
   SpreadSheetLayer,
   SpreadSheetLayerSettingsInterfaceRO,
@@ -449,28 +450,6 @@ function availableImagesets(): ImagesetInfo[] {
   return WWTControl.getImageSets().map(ImagesetInfo.fromImageset);
 }
 
-/** This function get a SpreadSheetLayer by the key used to store it in the engine.
- * For regular table layers this is the layer ID; for HiPS catalogs it is the layer name.
- * Keeping this functionality outside of the store allows us to use it from
- * inside either an action or a mutation.
- */
-function spreadSheetLayerByKey(wwt: WWTGlobalState, key: string): SpreadSheetLayer | null {
-  if (wwt.inst === null)
-    throw new Error('cannot get spreadSheetLayerByKey without linking to WWTInstance');
-
-  const layer = wwt.inst.lm.get_layerList()[key];
-
-  if (layer !== null && layer instanceof SpreadSheetLayer) {
-    return layer;
-  } else {
-    return null;
-  }
-}
-
-function catalogLayerKey(catalog: CatalogLayerInfo): string {
-  return catalog.id ?? "";
-}
-
 /** The WWT Pinia implementation.
  *
  * See [[WWTAwareComponent]] for an organized overview of the state variables,
@@ -551,6 +530,12 @@ export const engineStore = defineStore('wwt-engine', {
       return states;
     },
 
+    catalogLayerKey(_state) {
+      return (catalog: CatalogLayerInfo): string => {
+        return catalog.id ?? "";
+      }
+    },
+
     imagesetForLayer(_state){
       return (guidtext: string): Imageset | null => {
         if (this.$wwt.inst === null)
@@ -566,13 +551,34 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
+    imagesetLayerById(_state) {
+      return (id: string): ImageSetLayer | null => {
+        if (this.$wwt.inst === null)
+          throw new Error('cannot get imagesetLayerById without linking to WWTInstance');
+        const layer = this.layerById(id);
+        if (layer !== null && layer instanceof ImageSetLayer) {
+          return layer;
+        } else {
+          return null;
+        }
+      }
+    },
+
     layerForHipsCatalog(_state) {
       return (name: string): SpreadSheetLayer | null => {
         if (this.$wwt.inst === null)
           throw new Error('cannot get layerForHipsCatalog without linking to WWTInstance');
 
         const id = Guid.createFrom(name).toString();
-        return spreadSheetLayerByKey(this.$wwt, id);
+        return this.spreadSheetLayerById(id);
+      }
+    },
+
+    layerById(_state) {
+      return (id: string): Layer | null => {
+        if (this.$wwt.inst === null)
+          throw new Error('cannot get layerById without linking to WWTInstance');
+        return this.$wwt.inst.lm.get_layerList()[id];
       }
     },
 
@@ -590,7 +596,12 @@ export const engineStore = defineStore('wwt-engine', {
       return (id: string): SpreadSheetLayer | null => {
         if (this.$wwt.inst === null)
           throw new Error('cannot get spreadsheetLayerById without linking to WWTInstance');
-        return spreadSheetLayerByKey(this.$wwt, id);
+        const layer = this.layerById(id);
+        if (layer !== null && layer instanceof SpreadSheetLayer) {
+          return layer;
+        } else {
+          return null;
+        }
       }
     },
 
@@ -605,14 +616,14 @@ export const engineStore = defineStore('wwt-engine', {
         if (this.$wwt.inst === null)
           throw new Error('cannot get spreadSheetLayer without linking to WWTInstance');
 
-        const key = catalogLayerKey(catalog);
-        return spreadSheetLayerByKey(this.$wwt, key);
+        const key = this.catalogLayerKey(catalog);
+        return this.spreadSheetLayerById(key);
       }
     },
   
     spreadsheetState(state) {
       return (catalog: CatalogLayerInfo): SpreadSheetLayerSettingsInterfaceRO | null => {
-        const key = catalogLayerKey(catalog);
+        const key = this.catalogLayerKey(catalog);
         return state.spreadSheetLayers[key] || null;
       }
     }


### PR DESCRIPTION
This PR adds functionality to the Pinia store to allow straightforward access to general and imageset layers, in the same way that we currently have access to spreadsheet layers.

Additionally, this also does some refactoring of these layer access functions. We currently have utility functions defined external to the store for spreadsheet layer access. The motivation behind this setup was to allow reuse between Vuex actions and mutations. Since mutations aren't a thing in Pinia, we no longer need this separation. Additionally, the general layer access function added in this PR is used to avoid repeating code inside the more specific access functions.