### PR TITLE
Allow modifying overlay colors and constellation name height

### DIFF
--- a/engine-helpers/package.json
+++ b/engine-helpers/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://worldwidetelescope.org/home/",
   "internalDepVersions": {
     "@wwtelescope/astro": "manual:workspace:>=0.1.0",
-    "@wwtelescope/engine": "thiscommit:2023-01-19:iHXuFYx",
+    "@wwtelescope/engine": "thiscommit:2023-02-06:fcSPVN6",
     "@wwtelescope/engine-types": "57d0450658d758832a11f628e890c061ad331ec2"
   },
   "keywords": [

--- a/engine-helpers/src/engine.ts
+++ b/engine-helpers/src/engine.ts
@@ -20,17 +20,23 @@ import {
 /** A list of the names of the core engine settings. */
 export const engineSettingNames = [
   "actualPlanetScale",
+  "altAzGridColor",
   "constellationArtFilter",
   "constellationBoundariesFilter",
   "constellationFigureColor",
   "constellationFiguresFilter",
   "constellationBoundryColor",
   "constellationNamesFilter",
+  "constellationLabelsHeight",
   "constellations",
   "constellationSelectionColor",
   "constellationsEnabled",
   "crosshairsColor",
   "earthCutawayView",
+  "eclipticColor",
+  "eclipticGridColor",
+  "equatorialGridColor",
+  "galacticGridColor",
   "galacticMode",
   "localHorizonMode",
   "locationAltitude",
@@ -39,6 +45,7 @@ export const engineSettingNames = [
   "milkyWayModel",
   "minorPlanetsFilter",
   "planetOrbitsFilter",
+  "precessionChartColor",
   "showAltAzGrid",
   "showAltAzGridText",
   "showConstellationBoundries",
@@ -82,6 +89,7 @@ export const engineSettingNames = [
 ];
 
 const engineSettingTypeInfo: { [ix: string]: boolean } = {
+  "altAzGridColor/Color": true,
   "constellationArtFilter/ConstellationFilter": true,
   "constellationBoundariesFilter/ConstellationFilter": true,
   "constellationBoundryColor/Color": true,
@@ -90,7 +98,12 @@ const engineSettingTypeInfo: { [ix: string]: boolean } = {
   "constellationNamesFilter/ConstellationFilter": true,
   "constellationSelectionColor/Color": true,
   "crosshairsColor/Color": true,
-}
+  "eclipticColor/Color": true,
+  "eclipticGridColor/Color": true,
+  "equatorialGridColor/Color": true,
+  "galacticGridColor/Color": true,
+  "precessionChartColor/Color": true,
+};
 
 /** Type guard function for `EngineSetting`. */
 export function isEngineSetting(obj: [string, any]): obj is EngineSetting {

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -1682,8 +1682,6 @@ export class Settings implements EngineSettingsInterface {
   set_planetOrbitsFilter(v: number): number;
   get_constellations(): boolean;
   set_constellations(v: boolean): boolean;
-
-  static get_active(): Settings;
 }
 
 export namespace SpaceTimeController {

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -1600,26 +1600,40 @@ export class Settings implements EngineSettingsInterface {
   set_solarSystemScale(v: number): number;
   get_showEquatorialGridText(): boolean;
   set_showEquatorialGridText(v: boolean): boolean;
+  get_equatorialGridColor(): Color;
+  set_equatorialGridColor(v: Color): Color;
   get_showGalacticGrid(): boolean;
   set_showGalacticGrid(v: boolean): boolean;
   get_showGalacticGridText(): boolean;
   set_showGalacticGridText(v: boolean): boolean;
+  get_galacticGridColor(): Color;
+  set_galacticGridColor(v: Color): Color;
   get_showEclipticGrid(): boolean;
   set_showEclipticGrid(v: boolean): boolean;
   get_showEclipticGridText(): boolean;
   set_showEclipticGridText(v: boolean): boolean;
+  get_eclipticGridColor(): Color;
+  set_eclipticGridColor(v: Color): Color;
   get_showEclipticOverviewText(): boolean;
   set_showEclipticOverviewText(v: boolean): boolean;
+  get_eclipticColor(): Color;
+  set_eclipticColor(v: Color): Color;
   get_showAltAzGrid(): boolean;
   set_showAltAzGrid(v: boolean): boolean;
   get_showAltAzGridText(): boolean;
   set_showAltAzGridText(v: boolean): boolean;
+  get_altAzGridColor(): Color;
+  set_altAzGridColor(v: Color): Color;
   get_showPrecessionChart(): boolean;
   set_showPrecessionChart(v: boolean): boolean;
+  get_precessionChartColor(): Color;
+  set_precessionChartColor(v: Color): Color;
   get_showConstellationPictures(): boolean;
   set_showConstellationPictures(v: boolean): boolean;
   get_showConstellationLabels(): boolean;
   set_showConstellationLabels(v: boolean): boolean;
+  get_constellationLabelsHeight(): number;
+  set_constellationLabelsHeight(v: number): number;
   get_solarSystemCMB(): boolean;
   set_solarSystemCMB(v: boolean): boolean;
   get_solarSystemMinorPlanets(): boolean;
@@ -1662,6 +1676,8 @@ export class Settings implements EngineSettingsInterface {
   set_planetOrbitsFilter(v: number): number;
   get_constellations(): boolean;
   set_constellations(v: boolean): boolean;
+
+  static get_active(): Settings;
 }
 
 export namespace SpaceTimeController {

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -658,13 +658,19 @@ export class Constellations {
  */
 // NOTE: isEngineSetting in engine-helpers needs to be kept in sync.
 export type EngineSetting = BaseEngineSetting |
+["altAzGridColor", Color] |
 ["constellationArtFilter", ConstellationFilter] |
 ["constellationBoundariesFilter", ConstellationFilter] |
 ["constellationBoundryColor", Color] |
 ["constellationFigureColor", Color] |
 ["constellationFiguresFilter", ConstellationFilter] |
 ["constellationNamesFilter", ConstellationFilter] |
-["constellationSelectionColor", Color];
+["constellationSelectionColor", Color] |
+["eclipticColor", Color] |
+["eclipticGridColor", Color] |
+["equatorialGridColor", Color] |
+["galacticGridColor", Color] |
+["precessionChartColor", Color];
 
 export class FitsImage extends WcsImage {
   histogramMaxCount: number;

--- a/engine/wwtlib/Constellations.cs
+++ b/engine/wwtlib/Constellations.cs
@@ -470,7 +470,7 @@ namespace wwtlib
             }
 
 
-            NamesBatch = new Text3dBatch(Settings.Active.ConstellationNamesHeight);
+            NamesBatch = new Text3dBatch(Settings.Active.ConstellationLabelsHeight);
 
 
             foreach (string key in ConstellationCentroids.Keys)
@@ -485,7 +485,7 @@ namespace wwtlib
                 {
                     name = name.Replace(" ", "\n   ");
                 }
-                NamesBatch.Add(new Text3d(center, up, name, Settings.Active.ConstellationNamesHeight, .000125));
+                NamesBatch.Add(new Text3d(center, up, name, Settings.Active.ConstellationLabelsHeight, .000125));
             }
         }
 

--- a/engine/wwtlib/Constellations.cs
+++ b/engine/wwtlib/Constellations.cs
@@ -470,7 +470,7 @@ namespace wwtlib
             }
 
 
-            NamesBatch = new Text3dBatch(80);
+            NamesBatch = new Text3dBatch(Settings.Active.ConstellationNamesHeight);
 
 
             foreach (string key in ConstellationCentroids.Keys)
@@ -485,7 +485,7 @@ namespace wwtlib
                 {
                     name = name.Replace(" ", "\n   ");
                 }
-                NamesBatch.Add(new Text3d(center, up, name, 80, .000125));
+                NamesBatch.Add(new Text3d(center, up, name, Settings.Active.ConstellationNamesHeight, .000125));
             }
         }
 

--- a/engine/wwtlib/Settings.cs
+++ b/engine/wwtlib/Settings.cs
@@ -354,8 +354,50 @@ namespace wwtlib
             get { return showAltAzGrid; }
             set { showAltAzGrid = value; }
         }
-        private bool showAltAzGridText = false;
 
+        private Color eclipticGridColor = Colors.Green;
+        public Color EclipticGridColor
+        {
+            get { return eclipticGridColor; }
+            set { eclipticGridColor = value; }
+        }
+
+        private Color galacticGridColor = Colors.Cyan;
+        public Color GalacticGridColor
+        {
+            get { return galacticGridColor; }
+            set { galacticGridColor = value; }
+        }
+
+        private Color altAzGridColor = Colors.Magenta;
+        public Color AltAzGridColor
+        {
+            get { return altAzGridColor; }
+            set { altAzGridColor = value; }
+        }
+
+        private Color precessionChartColor = Colors.Orange;
+        public Color PrecessionChartColor
+        {
+            get { return precessionChartColor; }
+            set { precessionChartColor = value; }
+        }
+
+        private Color eclipticColor = Colors.Blue;
+        public Color EclipticColor
+        {
+            get { return eclipticColor; }
+            set { eclipticColor = value; }
+        }
+
+        private Color equatorialGridColor = Colors.White;
+        public Color EquatorialGridColor
+        {
+            get { return equatorialGridColor; }
+            set { equatorialGridColor = value; }
+        }
+
+        private bool showAltAzGridText = false;
         public bool ShowAltAzGridText
         {
             get { return showAltAzGridText; }

--- a/engine/wwtlib/Settings.cs
+++ b/engine/wwtlib/Settings.cs
@@ -259,14 +259,14 @@ namespace wwtlib
         public bool SolarSystemStars
         {
             get { return solarSystemStars; }
-            set {  solarSystemStars = value; }
+            set { solarSystemStars = value; }
         }
 
         public bool SolarSystemMilkyWay
         {
             get { return solarSystemMilkyWay; }
             set { solarSystemMilkyWay = value; }
-       }
+        }
 
         public bool SolarSystemCosmos
         {
@@ -290,13 +290,13 @@ namespace wwtlib
         {
             get { return solarSystemLighting; }
             set { solarSystemLighting = value; }
-       }
+        }
 
         public bool SolarSystemMultiRes
         {
             get { return true; }
             set { solarSystemMultiRes = value; }
-       }
+        }
 
         public int SolarSystemScale
         {
@@ -423,6 +423,13 @@ namespace wwtlib
         {
             get { return showConstellationLabels; }
             set { showConstellationLabels = value; }
+        }
+
+        private int constellationNamesHeight = 80;
+        public int ConstellationNamesHeight
+        {
+            get { return constellationNamesHeight; }
+            set { constellationNamesHeight = value; }
         }
 
         //public string ConstellationsEnabled = false;

--- a/engine/wwtlib/Settings.cs
+++ b/engine/wwtlib/Settings.cs
@@ -425,11 +425,11 @@ namespace wwtlib
             set { showConstellationLabels = value; }
         }
 
-        private int constellationNamesHeight = 80;
-        public int ConstellationNamesHeight
+        private int constellationLabelsHeight = 80;
+        public int ConstellationLabelsHeight
         {
-            get { return constellationNamesHeight; }
-            set { constellationNamesHeight = value; }
+            get { return constellationLabelsHeight; }
+            set { constellationLabelsHeight = value; }
         }
 
         //public string ConstellationsEnabled = false;

--- a/engine/wwtlib/Tours/ISettings.cs
+++ b/engine/wwtlib/Tours/ISettings.cs
@@ -10,6 +10,7 @@ namespace wwtlib
         ConstellationFilter ConstellationBoundariesFilter { get; }
         ConstellationFilter ConstellationFiguresFilter { get; }
         ConstellationFilter ConstellationNamesFilter { get; }
+        int ConstellationNamesHeight { get; }
         string ConstellationsEnabled { get; }
         bool EarthCutawayView { get; }
         Color EclipticColor { get; }

--- a/engine/wwtlib/Tours/ISettings.cs
+++ b/engine/wwtlib/Tours/ISettings.cs
@@ -10,7 +10,7 @@ namespace wwtlib
         ConstellationFilter ConstellationBoundariesFilter { get; }
         ConstellationFilter ConstellationFiguresFilter { get; }
         ConstellationFilter ConstellationNamesFilter { get; }
-        int ConstellationNamesHeight { get; }
+        int ConstellationLabelsHeight { get; }
         string ConstellationsEnabled { get; }
         bool EarthCutawayView { get; }
         Color EclipticColor { get; }

--- a/engine/wwtlib/Tours/ISettings.cs
+++ b/engine/wwtlib/Tours/ISettings.cs
@@ -5,15 +5,20 @@ namespace wwtlib
     public interface ISettings
     {
         bool ActualPlanetScale { get; }
+        Color AltAzGridColor { get; }
         ConstellationFilter ConstellationArtFilter { get; }
         ConstellationFilter ConstellationBoundariesFilter { get; }
         ConstellationFilter ConstellationFiguresFilter { get; }
         ConstellationFilter ConstellationNamesFilter { get; }
         string ConstellationsEnabled { get; }
         bool EarthCutawayView { get; }
+        Color EclipticColor { get; }
+        Color EclipticGridColor { get; }
+        Color EquatorialGridColor { get; }
         int FovCamera { get; }
         int FovEyepiece { get; }
         int FovTelescope { get; }
+        Color GalacticGridColor { get; }
         bool GalacticMode { get; }
         bool LocalHorizonMode { get; }
         double LocationAltitude { get; }
@@ -22,6 +27,7 @@ namespace wwtlib
         bool MilkyWayModel { get; }
         int MinorPlanetsFilter { get; }
         int PlanetOrbitsFilter { get; }
+        Color PrecessionChartColor { get; }
         bool ShowAltAzGrid { get; }
         bool ShowAltAzGridText { get; }
         bool ShowClouds { get; }

--- a/engine/wwtlib/Tours/TourStop.cs
+++ b/engine/wwtlib/Tours/TourStop.cs
@@ -2016,6 +2016,13 @@ namespace wwtlib
             get { return equatorialGridColor; }
             set { equatorialGridColor = value; }
         }
+
+        private int constellationNamesHeight = 80;
+        public int ConstellationNamesHeight
+        {
+            get { return constellationNamesHeight; }
+            set { constellationNamesHeight = value; }
+        }
     }
 
     public class LayerInfo

--- a/engine/wwtlib/Tours/TourStop.cs
+++ b/engine/wwtlib/Tours/TourStop.cs
@@ -1945,6 +1945,48 @@ namespace wwtlib
 
             return new SettingParameter(false,1,false,null);
         }
+
+        private Color eclipticGridColor = Colors.Green;
+        public Color EclipticGridColor
+        {
+            get { return eclipticGridColor; }
+            set { eclipticGridColor = value; }
+        }
+
+        private Color galacticGridColor = Colors.Cyan;
+        public Color GalacticGridColor
+        {
+            get { return galacticGridColor; }
+            set { galacticGridColor = value; }
+        }
+
+        private Color altAzGridColor = Colors.Magenta;
+        public Color AltAzGridColor
+        {
+            get { return altAzGridColor; }
+            set { altAzGridColor = value; }
+        }
+
+        private Color precessionChartColor = Colors.Orange;
+        public Color PrecessionChartColor
+        {
+            get { return precessionChartColor; }
+            set { precessionChartColor = value; }
+        }
+
+        private Color eclipticColor = Colors.Blue;
+        public Color EclipticColor
+        {
+            get { return eclipticColor; }
+            set { eclipticColor = value; }
+        }
+
+        private Color equatorialGridColor = Colors.White;
+        public Color EquatorialGridColor
+        {
+            get { return equatorialGridColor; }
+            set { equatorialGridColor = value; }
+        }
     }
 
     public class LayerInfo

--- a/engine/wwtlib/Tours/TourStop.cs
+++ b/engine/wwtlib/Tours/TourStop.cs
@@ -1053,6 +1053,7 @@ namespace wwtlib
             xmlWriter.WriteAttributeString("ShowConstellationFigures", showConstellationFigures.ToString());
             xmlWriter.WriteAttributeString("ShowConstellationSelection", showConstellationSelection.ToString());
             xmlWriter.WriteAttributeString("ShowEcliptic", showEcliptic.ToString());
+            xmlWriter.WriteAttributeString("EclipticColor", eclipticColor.Save());
             xmlWriter.WriteAttributeString("ShowElevationModel", showElevationModel.ToString());
             showFieldOfView = false;
             xmlWriter.WriteAttributeString("ShowFieldOfView", showFieldOfView.ToString());
@@ -1087,14 +1088,19 @@ namespace wwtlib
             xmlWriter.WriteAttributeString("ShowEarthSky", showEarthSky.ToString());
 
             xmlWriter.WriteAttributeString("ShowEquatorialGridText", ShowEquatorialGridText.ToString());
+            xmlWriter.WriteAttributeString("EquatorialGridColor", EquatorialGridColor.Save());
             xmlWriter.WriteAttributeString("ShowGalacticGrid", ShowGalacticGrid.ToString());
             xmlWriter.WriteAttributeString("ShowGalacticGridText", ShowGalacticGridText.ToString());
+            xmlWriter.WriteAttributeString("GalacticGridColor", GalacticGridColor.Save());
             xmlWriter.WriteAttributeString("ShowEclipticGrid", ShowEclipticGrid.ToString());
             xmlWriter.WriteAttributeString("ShowEclipticGridText", ShowEclipticGridText.ToString());
+            xmlWriter.WriteAttributeString("EclipticGridColor", EclipticGridColor.Save());
             xmlWriter.WriteAttributeString("ShowEclipticOverviewText", ShowEclipticOverviewText.ToString());
             xmlWriter.WriteAttributeString("ShowAltAzGrid", ShowAltAzGrid.ToString());
             xmlWriter.WriteAttributeString("ShowAltAzGridText", ShowAltAzGridText.ToString());
+            xmlWriter.WriteAttributeString("AltAzGridColor", AltAzGridColor.Save());
             xmlWriter.WriteAttributeString("ShowPrecessionChart", ShowPrecessionChart.ToString());
+            xmlWriter.WriteAttributeString("PrecessionChartColor", PrecessionChartColor.Save());
             xmlWriter.WriteAttributeString("ConstellationPictures", ShowConstellationPictures.ToString());
             xmlWriter.WriteAttributeString("ConstellationsEnabled", ConstellationsEnabled);
             xmlWriter.WriteAttributeString("ShowConstellationLabels", ShowConstellationLabels.ToString());
@@ -1323,6 +1329,10 @@ namespace wwtlib
                 {
                     newTourStop.showEcliptic = bool.Parse(tourStop.Attributes.GetNamedItem("ShowEcliptic").Value);
                 }
+                if (tourStop.Attributes.GetNamedItem("EclipticColor") != null)
+                {
+                    newTourStop.eclipticColor = Color.Load(tourStop.Attributes.GetNamedItem("EclipticColor").Value);
+                }
 
                 if (tourStop.Attributes.GetNamedItem("ShowElevationModel") != null)
                 {
@@ -1430,14 +1440,22 @@ namespace wwtlib
                 {
                     newTourStop.showEquatorialGridText = bool.Parse(tourStop.Attributes.GetNamedItem("ShowEquatorialGridText").Value);
                 }
+                if (tourStop.Attributes.GetNamedItem("EquatorialGridColor") != null)
+                {
+                    newTourStop.equatorialGridColor = Color.Load(tourStop.Attributes.GetNamedItem("EquatorialGridColor").Value);
+                }
+
                 if (tourStop.Attributes.GetNamedItem("ShowGalacticGrid") != null)
                 {
                     newTourStop.showGalacticGrid = bool.Parse(tourStop.Attributes.GetNamedItem("ShowGalacticGrid").Value);
                 }
-
                 if (tourStop.Attributes.GetNamedItem("ShowGalacticGridText") != null)
                 {
                     newTourStop.showGalacticGridText = bool.Parse(tourStop.Attributes.GetNamedItem("ShowGalacticGridText").Value);
+                }
+                if (tourStop.Attributes.GetNamedItem("GalacticGridColor") != null)
+                {
+                    newTourStop.galacticGridColor = Color.Load(tourStop.Attributes.GetNamedItem("GalacticGridColor").Value);
                 }
 
                 if (tourStop.Attributes.GetNamedItem("ShowEclipticGrid") != null)
@@ -1447,6 +1465,10 @@ namespace wwtlib
                 if (tourStop.Attributes.GetNamedItem("ShowEclipticGridText") != null)
                 {
                     newTourStop.showEclipticGridText = bool.Parse(tourStop.Attributes.GetNamedItem("ShowEclipticGridText").Value);
+                }
+                if (tourStop.Attributes.GetNamedItem("EclipticGridColor") != null)
+                {
+                    newTourStop.eclipticGridColor = Color.Load(tourStop.Attributes.GetNamedItem("EclipticGridColor").Value);
                 }
 
                 if (tourStop.Attributes.GetNamedItem("ShowEclipticOverviewText") != null)
@@ -1458,15 +1480,22 @@ namespace wwtlib
                 {
                     newTourStop.showAltAzGrid = bool.Parse(tourStop.Attributes.GetNamedItem("ShowAltAzGrid").Value);
                 }
-
                 if (tourStop.Attributes.GetNamedItem("ShowAltAzGridText") != null)
                 {
                     newTourStop.showAltAzGridText = bool.Parse(tourStop.Attributes.GetNamedItem("ShowAltAzGridText").Value);
+                }
+                if (tourStop.Attributes.GetNamedItem("AltAzGridColor") != null)
+                {
+                    newTourStop.altAzGridColor = Color.Load(tourStop.Attributes.GetNamedItem("AltAzGridColor").Value);
                 }
 
                 if (tourStop.Attributes.GetNamedItem("ShowPrecessionChart") != null)
                 {
                     newTourStop.showPrecessionChart = bool.Parse(tourStop.Attributes.GetNamedItem("ShowPrecessionChart").Value);
+                }
+                if (tourStop.Attributes.GetNamedItem("PrecessionChartColor") != null)
+                {
+                    newTourStop.precessionChartColor = Color.Load(tourStop.Attributes.GetNamedItem("PrecessionChartColor").Value);
                 }
 
                 if (tourStop.Attributes.GetNamedItem("ShowConstellationPictures") != null)

--- a/engine/wwtlib/Tours/TourStop.cs
+++ b/engine/wwtlib/Tours/TourStop.cs
@@ -2017,11 +2017,11 @@ namespace wwtlib
             set { equatorialGridColor = value; }
         }
 
-        private int constellationNamesHeight = 80;
-        public int ConstellationNamesHeight
+        private int constellationLabelsHeight = 80;
+        public int ConstellationLabelsHeight
         {
-            get { return constellationNamesHeight; }
-            set { constellationNamesHeight = value; }
+            get { return constellationLabelsHeight; }
+            set { constellationLabelsHeight = value; }
         }
     }
 

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -907,52 +907,52 @@ namespace wwtlib
 
             if (Settings.Active.ShowEclipticGrid)
             {
-                Grids.DrawEclipticGrid(RenderContext, 1, Colors.Green);
+                Grids.DrawEclipticGrid(RenderContext, 1, Settings.Active.EclipticGridColor);
                 if (Settings.Active.ShowEclipticGridText)
                 {
-                    Grids.DrawEclipticGridText(RenderContext, 1, Colors.Green);
+                    Grids.DrawEclipticGridText(RenderContext, 1, Settings.Active.EclipticGridColor);
                 }
             }
 
             if (Settings.Active.ShowGalacticGrid)
             {
-                Grids.DrawGalacticGrid(RenderContext, 1, Colors.Cyan);
+                Grids.DrawGalacticGrid(RenderContext, 1, Settings.Active.GalacticGridColor);
                 if (Settings.Active.ShowGalacticGridText)
                 {
-                    Grids.DrawGalacticGridText(RenderContext, 1, Colors.Cyan);
+                    Grids.DrawGalacticGridText(RenderContext, 1, Settings.Active.GalacticGridColor);
                 }
             }
 
             if (Settings.Active.ShowAltAzGrid)
             {
-                Grids.DrawAltAzGrid(RenderContext, 1, Colors.Magenta);
+                Grids.DrawAltAzGrid(RenderContext, 1, Settings.Active.AltAzGridColor);
                 if (Settings.Active.ShowAltAzGridText)
                 {
-                    Grids.DrawAltAzGridText(RenderContext, 1, Colors.Magenta);
+                    Grids.DrawAltAzGridText(RenderContext, 1, Settings.Active.AltAzGridColor);
                 }
             }
 
             if (Settings.Active.ShowPrecessionChart)
             {
-                Grids.DrawPrecessionChart(RenderContext, 1, Colors.Orange);
+                Grids.DrawPrecessionChart(RenderContext, 1, Settings.Active.PrecessionChartColor);
 
             }
 
             if (Settings.Active.ShowEcliptic)
             {
-                Grids.DrawEcliptic(RenderContext, 1, Colors.Blue);
+                Grids.DrawEcliptic(RenderContext, 1, Settings.Active.EclipticColor);
                 if (Settings.Active.ShowEclipticOverviewText)
                 {
-                    Grids.DrawEclipticText(RenderContext, 1, Colors.Blue);
+                    Grids.DrawEclipticText(RenderContext, 1, Settings.Active.EclipticColor);
                 }
             }
 
             if (Settings.Active.ShowGrid)
             {
-                Grids.DrawEquitorialGrid(RenderContext, 1, Colors.White);
+                Grids.DrawEquitorialGrid(RenderContext, 1, Settings.Active.EquatorialGridColor);
                 if (Settings.Active.ShowEquatorialGridText)
                 {
-                    Grids.DrawEquitorialGridText(RenderContext, 1, Colors.White);
+                    Grids.DrawEquitorialGridText(RenderContext, 1, Settings.Active.EquatorialGridColor);
                 }
             }
 


### PR DESCRIPTION
This PR adds functionality to the engine to allow changing the colors for the various sky overlays that can be drawn, and exposes these new settings to the TypeScript layer. The default values for all of these settings are the values that are currently hard-coded into the engine. This also does the same for the height of the constellation name text. (Note that the function that draws the constellation names also takes a scale parameter, but from my experimentation with different values, the display only depended on the product of these two values).

Note that these color settings don't respect the opacity of the given color. The reason for that is [this line](https://github.com/WorldWideTelescope/wwt-webgl-engine/blob/master/engine/wwtlib/Graphics/Shaders.cs#L101), and similar ones throughout that file, which keep the opacity passed to the shader equal to 1. I experimented with changing the 1 to use the color's alpha and was able to change the opacity of the overlays, but I want to save changing those for later to check that this wouldn't unintentionally change any other displays.