### PR TITLE
Use correct image for point and circle modes

### DIFF
--- a/engine/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/engine/wwtlib/Layers/SpreadSheetLayer.cs
@@ -2678,10 +2678,10 @@ namespace wwtlib
                         pointList.DrawTextured(renderContext, CircleTexture.Texture2d, opacity * Opacity);
                         break;
                     case PlotTypes.Point:
-                        pointList.DrawTextured(renderContext, PushPin.GetPushPinTexture(35), opacity * Opacity);
+                        pointList.DrawTextured(renderContext, PushPin.GetPushPinTexture(19), opacity * Opacity);
                         break;
                     case PlotTypes.Square:
-                        pointList.DrawTextured(renderContext, PushPin.GetPushPinTexture(67), opacity * Opacity);
+                        pointList.DrawTextured(renderContext, PushPin.GetPushPinTexture(35), opacity * Opacity);
                         break;
                     case PlotTypes.Custom:
                     case PlotTypes.PushPin:

--- a/engine/wwtlib/Layers/VoTableLayer.cs
+++ b/engine/wwtlib/Layers/VoTableLayer.cs
@@ -969,9 +969,13 @@ namespace wwtlib
                         pointList.Draw(renderContext, opacity * Opacity, false);
                         break;
                     case PlotTypes.Circle:
-                    case PlotTypes.Point:
-                    case PlotTypes.Square:
                         pointList.DrawTextured(renderContext, CircleTexture.Texture2d, opacity * Opacity);
+                        break;
+                    case PlotTypes.Point:
+                        pointList.DrawTextured(renderContext, PushPin.GetPushPinTexture(19), opacity * Opacity);
+                        break;
+                    case PlotTypes.Square:
+                        pointList.DrawTextured(renderContext, PushPin.GetPushPinTexture(35), opacity * Opacity);
                         break;
                     case PlotTypes.Custom:
                     case PlotTypes.PushPin:

--- a/research-app/src/SpreadsheetItem.vue
+++ b/research-app/src/SpreadsheetItem.vue
@@ -144,9 +144,8 @@ const uiPlotTypes: UiPlotTypes[] = [
   { wwt: PlotTypes.gaussian, desc: "Gaussian" },
   { wwt: PlotTypes.circle, desc: "Circle" },
   { wwt: PlotTypes.pushPin, desc: "Push-pin" },
-  // The other types don't currently render well.
-  // "point": starts out OK but gets gnarly if the catalog is dense and you zoom in.
-  // "square": actually renders as a flag
+  { wwt: PlotTypes.point, desc: "Point" },
+  { wwt: PlotTypes.square, desc: "Square" },
   // "custom": handled same as push-pin in the engine
 ];
 


### PR DESCRIPTION
This PR modifies spreadsheet and VO table layers to use the correct images when the plot mode is `point` or `square`. Previously these modes were using an incorrect marker.

The reason for this is that, with the exception of the circle, the images for the layer markers come from [here](https://web.wwtassets.org/engine/assets/pins.png). Each sub-image here is 32 pixels square. The appropriate image is accessed via an index, which is zero-indexed and runs through the grid in reading order. This index is converted into a row and column, and then a 32 pixel square starting from the appropriate point is used for the image texture. However, the circle and square cases were using the wrong index, so the wrong image was being used. This PR fixes those indices.

I suppose this is a breaking change, in the sense that anyone who relied on this incorrect behavior will now see something different be displayed. But I think there's a benefit here of both allowing access to more plot types, and just having options be correct.