### PR TITLE
Expose roll angle in `ViewStateMessage`

### DIFF
--- a/research-app-messages/src/index.ts
+++ b/research-app-messages/src/index.ts
@@ -74,6 +74,9 @@ export interface ViewStateMessage {
   /** The current height of the viewport (zoom level), in degrees. */
   fovDeg: number;
 
+  /** The current roll angle of the view, in degrees */
+  rollDeg: number;
+
   /** The current value of WWT's internal clock, as an
    * [ISO-T](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations)
    * datetime string.

--- a/research-app/package.json
+++ b/research-app/package.json
@@ -51,7 +51,7 @@
     "@wwtelescope/engine-helpers": "263bedcc26dd2d13d03ba68daece76aa5e16f145",
     "@wwtelescope/engine-pinia": "thiscommit:2022-11-10:R3G9gH3",
     "@wwtelescope/engine-types": "263bedcc26dd2d13d03ba68daece76aa5e16f145",
-    "@wwtelescope/research-app-messages": "thiscommit:2022-11-30:h6SkuRt"
+    "@wwtelescope/research-app-messages": "thiscommit:2023-02-19:Kuk5Ppd"
   },
   "keywords": [
     "AAS WorldWide Telescope"

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -1216,6 +1216,7 @@ const App = defineComponent({
       lastUpdatedRA: 0.0,
       lastUpdatedDec: 0.0,
       lastUpdatedFov: 1.0,
+      lastUpdatedRoll: 0.0,
       lastUpdatedClockRate: 1.0,
       lastUpdatedTimestamp: 0, // `Date.now()` value
       
@@ -2406,12 +2407,14 @@ const App = defineComponent({
       const ra = this.wwtRARad;
       const dec = this.wwtDecRad;
       const fov = this.wwtZoomDeg / 6; // WWT convention, zoom = 6*fov
+      const roll = this.wwtRollRad * R2D;
       const clockRate = this.wwtClockRate;
 
       const needUpdate =
         ra != this.lastUpdatedRA ||
         dec != this.lastUpdatedDec ||
         fov != this.lastUpdatedFov ||
+        roll != this.lastUpdatedRoll ||
         clockRate != this.lastUpdatedClockRate ||
         Date.now() - this.lastUpdatedTimestamp > 60000;
 
@@ -2423,6 +2426,7 @@ const App = defineComponent({
         raRad: ra,
         decRad: dec,
         fovDeg: fov,
+        rollDeg: roll,
         engineClockISOT: this.wwtCurrentTime.toISOString(),
         systemClockISOT: new Date().toISOString(),
         engineClockRateFactor: clockRate,
@@ -2435,6 +2439,7 @@ const App = defineComponent({
       this.lastUpdatedRA = ra;
       this.lastUpdatedDec = dec;
       this.lastUpdatedFov = fov;
+      this.lastUpdatedRoll = roll;
       this.lastUpdatedClockRate = clockRate;
       this.lastUpdatedTimestamp = Date.now();
     },


### PR DESCRIPTION
This PR modifies the research app and `ViewStateMessage` to expose the roll angle in the application state updates. The intended downstream use case is for a client like `glue-wwt` or CosmicDS, which may want to save and restore the state of the WWT view. For consistency with [`CenterOnCoordinatesMessage`](https://github.com/WorldWideTelescope/wwt-webgl-engine/blob/master/research-app-messages/src/classic_pywwt.ts#L115), I decided to expose this number in degrees.