### PR TITLE
Allow importing engine in non-browser context

### DIFF
--- a/engine/wwtlib/Graphics/Texture.cs
+++ b/engine/wwtlib/Graphics/Texture.cs
@@ -61,6 +61,7 @@ namespace wwtlib
         public void Load(string url)
         {
             URL = url;
+            Script.Literal("if (typeof document === \"undefined\") { return; }");
             if (!Downloading)
             {
                 Downloading = true;

--- a/engine/wwtlib/MainView.cs
+++ b/engine/wwtlib/MainView.cs
@@ -15,7 +15,8 @@ namespace wwtlib
     {
         static MainView()
         {
-            CanvasElement canvas = (CanvasElement) Document.GetElementById("canvas");
+            Script.Literal("if (typeof document === \"undefined\") { canvas = null; return; }");
+            CanvasElement canvas = (CanvasElement)Document.GetElementById("canvas");
         }
 
         static void DrawTest()

--- a/engine/wwtlib/URLHelpers.cs
+++ b/engine/wwtlib/URLHelpers.cs
@@ -39,8 +39,8 @@ namespace wwtlib
         Dictionary<String, bool> flagship_static_lcpaths;
 
         public URLHelpers() {
-            this.origin_protocol = (string) Script.Literal("window.location.protocol");
-            this.origin_domain = (string) Script.Literal("window.location.hostname");
+            this.origin_protocol = (string) Script.Literal("typeof window === \"undefined\" ? \"https:\" : window.location.protocol");
+            this.origin_domain = (string)Script.Literal("typeof window === \"undefined\" ? \"\" :window.location.hostname");
             this.force_https = (this.origin_protocol == "https:");
 
             this.domain_handling = new Dictionary<string, DomainHandling>();

--- a/engine/wwtlib/WebFile.cs
+++ b/engine/wwtlib/WebFile.cs
@@ -30,6 +30,7 @@ namespace wwtlib
 
         public void Send()
         {
+            Script.Literal("if (typeof navigator === \"undefined\") { return; }");
             //send the appropriate request based on browser type
             // have to do this because IE8 and 9 don't support CORS
             string version = Navigator.AppVersion;


### PR DESCRIPTION
This PR adds the minimal set of guards necessary to import the engine package in a non-browser context. The intended use case for this is for server-side code that doesn't need the browser APIs. We need these guards because there are a few objects that get instantiated on the module load (e.g. `URLHelpers.singleton`) that call browser APIs.

FWIW, I originally tried using some ScriptSharp functionality (see [this branch](https://github.com/Carifio24/wwt-webgl-engine/tree/ssr-guards-v1)), but that didn't help - it looks like the `typeof` check needs to be in the same scope as the browser API use.