### PR TITLE
Update BrowserStack configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ To run the test suite on a local version of the app with ChromeDriver:
 yarn run serve-research &  # or equivalent
 cd tests
 yarn build
-yarn run local
+yarn local
 ```
 
 To run tests on a local version of the app via BrowserStack's multi-browser,
@@ -200,14 +200,14 @@ username and access key, respectively. You can find these values in your Browser
 
 [Account Settings]: https://www.browserstack.com/accounts/settings
 
-* Run the test suite as above but with the final command: `yarn run bs-local`
+* Run the test suite as above but with the final command: `yarn bs-local`
 
 By default, both of these local options will run the tests in Chrome. You can
 adjust the testing environments adding the `-e` option, which can be
 accomplished with syntax such as
 
 ```
-yarn run bs-local -- -e firefox,edge
+yarn bs-local -e firefox,edge
 ```
 
 

--- a/ci/azure-main-build.yml
+++ b/ci/azure-main-build.yml
@@ -156,7 +156,7 @@ jobs:
       yarn run serve-research &
       sleep 10 # give the local service time to start up
       cd tests
-      yarn run bs-local -- -e default,firefox,edge,safari -o reports
+      yarn bs-local -e default,firefox,edge,safari -o reports
       pkill -f vue-cli-service  # stop the servers
     displayName: BrowserStack test local research app
 

--- a/tests/bslocal.conf.ts
+++ b/tests/bslocal.conf.ts
@@ -75,7 +75,7 @@ addBrowsers(environments, BSLOCAL_CAPABILITIES, 'OS X', ['Big Sur'], ['Safari'],
 
 // Code to copy seleniumhost/port into test settings
 for (const i in nightwatch_config.test_settings) {
-  let config = nightwatch_config.test_settings[i];
+  const config = nightwatch_config.test_settings[i];
   if (config === undefined || nightwatch_config.selenium === undefined) {
     continue;
   }

--- a/tests/config.ts
+++ b/tests/config.ts
@@ -19,15 +19,15 @@ export interface Capabilities {
 }
 
 export interface BrowserCapabilities extends Capabilities {
-  browser_version: string,
+  browserVersion: string,
   os: string,
-  os_version: string;
+  osVersion: string;
 }
 
 export interface MobileCapabilities extends Capabilities {
   device: string,
-  real_mobile: boolean,
-  os_version: string;
+  realMobile: boolean,
+  osVersion: string;
 }
 
 export interface TestEnvironment {
@@ -51,17 +51,17 @@ export interface Configuration {
 export function browserCapabilities(browserName: string, browserVersion: string, osName: string, osVersion: string): BrowserCapabilities {
   return {
     'browserName': browserName,
-    'browser_version': browserVersion,
+    'browserVersion': browserVersion,
     'os': osName,
-    'os_version': osVersion,
+    'osVersion': osVersion,
   }
 }
 
-export function mobileCapabilities(deviceOS: string, deviceName: string, osVersion: string, realMobile: boolean=true): MobileCapabilities {
+export function mobileCapabilities(deviceOS: string, deviceName: string, osVersion: string, realMobile=true): MobileCapabilities {
   return {
     'device': deviceName,
-    'os_version': osVersion,
-    'real_mobile': realMobile,
+    'osVersion': osVersion,
+    'realMobile': realMobile,
     'browserName': deviceOS, // Seems strange, but this is what BrowserStack shows in their examples
   }
 }
@@ -80,7 +80,7 @@ export function addBrowsers(environments: { [env: string]: TestEnvironment | und
   }
 }
 
-export function addPhones(environments: { [env: string]: TestEnvironment | undefined }, baseCapabilities: object, osType: string, devicesAndVersions: string[][], envKeyMaker: (device: string, osVersion: string) => string, realMobile: boolean=true) {
+export function addPhones(environments: { [env: string]: TestEnvironment | undefined }, baseCapabilities: object, osType: string, devicesAndVersions: string[][], envKeyMaker: (device: string, osVersion: string) => string, realMobile=true) {
   for (const [device, osVersion] of devicesAndVersions) {
     const key = envKeyMaker(device, osVersion);
     environments[key] = {

--- a/tests/local.conf.ts
+++ b/tests/local.conf.ts
@@ -98,19 +98,19 @@ function loadServices(): Services {
   const s: Services = {};
     try {
     s.seleniumServer = require('selenium-server');
-  } catch (err) {}
+  } catch (err) { /* empty */ }
 
   try {
     s.chromedriver = require('chromedriver');
-  } catch (err) {}
+  } catch (err) { /* empty */ }
 
   try {
     s.geckodriver = require('geckodriver');
-  } catch (err) {}
+  } catch (err) { /* empty */ }
 
   try {
     s.edgedriver = require('edgedriver');
-  } catch (err) {}
+  } catch (err) { /* empty */ }
   return s;
 }
   

--- a/tests/scripts/bslocal.runner.js
+++ b/tests/scripts/bslocal.runner.js
@@ -8,7 +8,7 @@ const browserstack = require('browserstack-local');
 let bs_local;
 
 try {
-  require.main.filename = './node_modules/.bin/nightwatch';
+  require.main.filename = '../node_modules/.bin/nightwatch';
   // Code to start browserstack local before start of test
   console.log('Connecting local');
   Nightwatch.bs_local = bs_local = new browserstack.Local();


### PR DESCRIPTION
While setting up a BrowserStack configuration for the MiniDS repo, I noticed that BrowserStack has seemingly updated the format of the field names in their configurations. We had been using snake_case, but they seem to now want camelCase: see [here](https://www.browserstack.com/docs/automate/selenium/select-browsers-and-devices) (note that Nightwatch uses Selenium). This PR makes those updates. Looking back at our most recent CI logs, it seems that only the default browser environment was running, rather than the several specified in the workflow, which I suspect is related to this. I also fixed a few minor things that my linter was complaining about.