### PR TITLE
Generalize and expose capture functionality

### DIFF
--- a/engine-helpers/package.json
+++ b/engine-helpers/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://worldwidetelescope.org/home/",
   "internalDepVersions": {
     "@wwtelescope/astro": "manual:workspace:>=0.1.0",
-    "@wwtelescope/engine": "thiscommit:2023-02-13:TOq6VEF",
+    "@wwtelescope/engine": "thiscommit:2023-03-14:6sp5H0w",
     "@wwtelescope/engine-types": "57d0450658d758832a11f628e890c061ad331ec2"
   },
   "keywords": [

--- a/engine-helpers/src/index.ts
+++ b/engine-helpers/src/index.ts
@@ -303,6 +303,18 @@ export interface SetupForImagesetOptions {
   background?: Imageset;
 }
 
+/** Options for [CaptureFrame] */
+export interface CaptureFrameOptions {
+  /** The desired image width. */
+  width: number;
+
+  /** The desired image height. */
+  height: number;
+
+  /** The desired image format (e.g. `"image/jpeg"`). */
+  format: string;
+}
+
 interface ResolveFunction<T> {
   (value: T): void;
 }
@@ -994,5 +1006,19 @@ export class WWTInstance {
 
     // Apply the change.
     player.playFromTourstop(stops[index]);
+  }
+
+  /** Capture the current frame as an image.
+   *
+   * This function returns a Promise whose resolved value is the image
+   * represented as a `Blob`.
+  */
+  captureFrame(options: CaptureFrameOptions): Promise<Blob | null> {
+    return new Promise((resolve, _reject) => {
+      this.ctl.captureFrame(blob => resolve(blob),
+        options.width,
+        options.height,
+        options.format);
+    });
   }
 }

--- a/engine-helpers/src/index.ts
+++ b/engine-helpers/src/index.ts
@@ -305,13 +305,13 @@ export interface SetupForImagesetOptions {
 
 /** Options for [CaptureFrame] */
 export interface CaptureFrameOptions {
-  /** The desired image width. */
+  /** The desired image width, in pixels. */
   width: number;
 
-  /** The desired image height. */
+  /** The desired image height, in pixels. */
   height: number;
 
-  /** The desired image format (e.g. `"image/jpeg"`). */
+  /** The MIME type for the desired image format (e.g. `"image/jpeg"`). */
   format: string;
 }
 

--- a/engine-pinia/package.json
+++ b/engine-pinia/package.json
@@ -32,7 +32,7 @@
   "internalDepVersions": {
     "@wwtelescope/astro": "thiscommit:2022-11-29:pfBFAzl",
     "@wwtelescope/engine": "thiscommit:2023-02-13:v0AI7YY",
-    "@wwtelescope/engine-helpers": "thiscommit:2023-02-13:dGSo0xM",
+    "@wwtelescope/engine-helpers": "thiscommit:2023-03-14:xwj6VYX",
     "@wwtelescope/engine-types": "thiscommit:2022-11-29:OIQ6vzL"
   },
   "keywords": [

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -38,6 +38,7 @@ import {
   ApplyTableLayerSettingsOptions,
   applyImageSetLayerSetting,
   applySpreadSheetLayerSetting,
+  CaptureFrameOptions,
   GetCatalogHipsDataInViewOptions,
   GotoTargetOptions,
   ImageSetLayerState as ImageSetLayerSettings,
@@ -1178,8 +1179,15 @@ export const engineStore = defineStore('wwt-engine', {
       if (this.$wwt.inst === null)
         throw new Error('cannot clearAnnotations without linking to WWTInstance');
       this.$wwt.inst.si.clearAnnotations();
-    }
+    },
 
+    // Capturing the current display
+
+    captureFrame(options: CaptureFrameOptions): Promise<Blob | null> {
+      if (this.$wwt.inst === null)
+        throw new Error('cannot captureThumbnail without linking to WWTInstance');
+      return this.$wwt.inst.captureFrame(options);
+    }
   },
 
 });

--- a/engine-pinia/src/wwtaware.ts
+++ b/engine-pinia/src/wwtaware.ts
@@ -618,6 +618,10 @@ export const WWTAwareComponent = defineComponent({
       /** Alter one [WWT engine setting](../../engine/modules.html#enginesetting). */
       "applySetting",
 
+      /** Capture the current frame as an image `Blob` with the desired width, height, and format.
+       * The first argument is a callback function to execute on the created `Blob`. */
+      'captureFrame',
+
       /** Clear all [Annotations](../../engine/classes/annotation.html) from the view. */
       "clearAnnotations",
 

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -2686,6 +2686,16 @@ export class WWTControl {
   /** Create a new tour */
   createTour(name: string): TourDocument;
 
+  /** Capture the current frame as an image.
+   *
+   * @param blobReady A callback function to execute on the `Blob` representing
+   * the captured image.
+   * @param width The desired image width.
+   * @param height The desired image height.
+   * @param string The desired image format (e.g. `"image/jpeg"`)
+  */
+  captureFrame(blobReady: BlobCallback, width: number, height: number, format: string): void;
+
   /** Set the maximum allowed user zoom level in 3D ("solar system") mode.
    *
    * @param limit The new zoom limit.

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -2847,6 +2847,11 @@ namespace wwtlib
 
         public void CaptureThumbnail(BlobReady blobReady)
         {
+            CaptureFrame(blobReady, 96, 45, "image/jpeg");
+        }
+
+        public void CaptureFrame(BlobReady blobReady, int width, int height, string format)
+        {
             RenderOneFrame(); // NB: this used to be Render() but that was almost surely not what we want
 
             ImageElement image = (ImageElement)Document.CreateElement("img");
@@ -2854,10 +2859,10 @@ namespace wwtlib
             {
                 double imageAspect = ((double)image.Width) / (image.Height);
 
-                double clientAspect = 96 / 45;
+                double clientAspect = width / height;
 
-                int cw = 96;
-                int ch = 45;
+                int cw = width;
+                int ch = height;
 
                 if (imageAspect < clientAspect)
                 {
@@ -2868,17 +2873,17 @@ namespace wwtlib
                  cw = (int)((double)ch * imageAspect);
                 }
 
-                int cx = (96 - cw) / 2;
-                int cy = (45 - ch) / 2;
+                int cx = (width - cw) / 2;
+                int cy = (height - ch) / 2;
 
                 CanvasElement temp = (CanvasElement)Document.CreateElement("canvas");
-                temp.Height = 45;
-                temp.Width = 96;
+                temp.Height = height;
+                temp.Width = width;
                 CanvasContext2D ctx = (CanvasContext2D)temp.GetContext(Rendering.Render2D);
                 ctx.DrawImage(image, cx, cy, cw, ch);
                 //Script.Literal("{0}.toBlob({1}, 'image/jpeg')", temp, blobReady);
 
-                Script.Literal("if ( typeof {0}.msToBlob == 'function') {{ var blob = {0}.msToBlob(); {1}(blob); }} else {{ {0}.toBlob({1}, 'image/jpeg'); }}", temp, blobReady);
+                Script.Literal("if ( typeof {0}.msToBlob == 'function') {{ var blob = {0}.msToBlob(); {1}(blob); }} else {{ {0}.toBlob({1}, {2}); }}", temp, blobReady, format);
 
 
               //  thumb.Src = temp.GetDataUrl();


### PR DESCRIPTION
This PR generalizes the current `CaptureThumbnail` functionality with a new `CaptureFrame` method of the `WWTControl` class. This method captures the current frame of the WWT view, and allows specifying the width, height, and format of the image output. `CaptureThumbnail` now simply calls the more general function. Additionally, this PR exposes this method to the Vue layer via the Pinia store.

Internally, the frame capture uses `toBlob`, which uses a `BlobCallback` to allow manipulation of the created image blob. Since our API is Promise-based, the exposure to the store is done via a Promise that resolves to the blob in the callback.