### PR TITLE
Respect opacity when drawing annotations

### DIFF
--- a/engine/wwtlib/Annotation.cs
+++ b/engine/wwtlib/Annotation.cs
@@ -298,16 +298,22 @@ namespace wwtlib
 
                     if (strokeWidth > 0 && vertexList.Count > 1)
                     {
+                        Color lineColorWithOpacity = lineColor.Clone();
+                        lineColorWithOpacity.A = Math.Round(lineColorWithOpacity.A * Opacity);
+
                         for (int i = 0; i < (vertexList.Count - 1); i++)
                         {
-                            LineList.AddLine(vertexList[i], vertexList[i + 1], lineColor, new Dates(0, 1));
+                            LineList.AddLine(vertexList[i], vertexList[i + 1], lineColorWithOpacity, new Dates(0, 1));
                         }
                     }
                     if (fill)
                     {
+                        Color fillColorWithOpacity = fillColor.Clone();
+                        fillColorWithOpacity.A = Math.Round(fillColorWithOpacity.A * Opacity);
+
                         Vector3d pos = Vector3d.Create(center.X, center.Y, center.Z);
                         vertexList.Insert(0, pos);
-                        TriangleFanPointList.AddShape(vertexList, fillColor, new Dates(0, 1));
+                        TriangleFanPointList.AddShape(vertexList, fillColorWithOpacity, new Dates(0, 1));
                     }
                     AnnotationDirty = false;
                 }
@@ -445,22 +451,27 @@ namespace wwtlib
                     //todo can we save this work for later?
                     List<Vector3d> vertexList = points;
 
-
                     if (strokeWidth > 0 && points.Count > 1)
                     {
+                        Color lineColorWithOpacity = lineColor.Clone();
+                        lineColorWithOpacity.A = Math.Round(lineColorWithOpacity.A * Opacity);
+
                         for (int i = 0; i < (points.Count - 1); i++)
                         {
-                            LineList.AddLine(vertexList[i], vertexList[i + 1], lineColor, new Dates(0, 1));
+                            LineList.AddLine(vertexList[i], vertexList[i + 1], lineColorWithOpacity, new Dates(0, 1));
                         }
-                        LineList.AddLine(vertexList[points.Count - 1], vertexList[0], lineColor, new Dates(0, 1));
+                        LineList.AddLine(vertexList[points.Count - 1], vertexList[0], lineColorWithOpacity, new Dates(0, 1));
                     }
                     if (fill)
                     {
+                        Color fillColorWithOpacity = fillColor.Clone();
+                        fillColorWithOpacity.A = Math.Round(fillColorWithOpacity.A * Opacity);
+
                         List<int> indexes = Tessellator.TesselateSimplePoly(vertexList);
 
                         for (int i = 0; i < indexes.Count; i += 3)
                         {
-                            TriangleList.AddSubdividedTriangles(vertexList[indexes[i]], vertexList[indexes[i + 1]], vertexList[indexes[i + 2]], fillColor, new Dates(0, 1), 2);
+                            TriangleList.AddSubdividedTriangles(vertexList[indexes[i]], vertexList[indexes[i + 1]], vertexList[indexes[i + 2]], fillColorWithOpacity, new Dates(0, 1), 2);
                         }
                     }
                     AnnotationDirty = false;
@@ -565,12 +576,14 @@ namespace wwtlib
                     //todo can we save this work for later?
                     List<Vector3d> vertexList = points;
 
-
                     if (strokeWidth > 0)
                     {
+                        Color lineColorWithOpacity = lineColor.Clone();
+                        lineColorWithOpacity.A = Math.Round(lineColorWithOpacity.A * Opacity);
+
                         for (int i = 0; i < (points.Count - 1); i++)
                         {
-                            LineList.AddLine(vertexList[i], vertexList[i + 1], lineColor, new Dates(0, 1));
+                            LineList.AddLine(vertexList[i], vertexList[i + 1], lineColorWithOpacity, new Dates(0, 1));
                         }
                     }
                    


### PR DESCRIPTION
This PR resolves #237, allowing the engine to respect the opacity value of annotations when drawing them.

The implementation here is meant to work with the way that the engine handles drawing annotations (which I hadn't really understood when I opened the original issue). Basically, the primitives for each annotation don't get passed into the relevant shader(s) separately - what happens is that they get added to global collections of the relevant primitive type ("global" here meaning static member values of the `Annotation` base class). Then the shader calls for each "list of primitives" type are made inside of the drawing methods in `DrawBatch`.

What this means is that we can't use the opacity argument of each annotation in the `Draw`/`DrawLines` calls (e.g. [here](https://github.com/WorldWideTelescope/wwt-webgl-engine/blob/master/engine/wwtlib/Annotation.cs#L45) and similar calls), because these calls are made in a static method without access to a particular annotation's opacity. Thus, I think the only good way to do this is to inject the opacity into the passed color - basically, if an annotation has color (A,R,G,B) and opacity α, we pass the shader (A*α,R,G,B). This is the approach taken here. Note that I had to round the values for this to work correctly - `Color.A` is typed as a float, but only seemed to work when I gave it an integer.

For testing this, I used the example code I gave in #237, plus some similar code for `Poly` and `Circle` annotations.