### PR TITLE
Add video capture as frames functionality

### DIFF
--- a/engine-helpers/package.json
+++ b/engine-helpers/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://worldwidetelescope.org/home/",
   "internalDepVersions": {
     "@wwtelescope/astro": "manual:workspace:>=0.1.0",
-    "@wwtelescope/engine": "thiscommit:2023-03-14:6sp5H0w",
+    "@wwtelescope/engine": "thiscommit:2023-03-27:FgymqIb",
     "@wwtelescope/engine-types": "57d0450658d758832a11f628e890c061ad331ec2"
   },
   "keywords": [

--- a/engine-helpers/src/index.ts
+++ b/engine-helpers/src/index.ts
@@ -1048,13 +1048,13 @@ export class WWTInstance {
     const videoStream = new ReadableStream<Blob | null>({
       start(controller: ReadableStreamDefaultController) {
         function stream() {
+          let received = 0;
           wwtControl.captureVideo(blob => {
-              console.log(blob);
+              received++;
               controller.enqueue(blob);
-            },
-            () => {
-              controller.close();
-              console.log("Stream closed!");
+              if (received >= options.totalFrames) {
+                controller.close();
+              }
             },
             options.name,
             options.width,

--- a/engine-helpers/src/index.ts
+++ b/engine-helpers/src/index.ts
@@ -315,6 +315,26 @@ export interface CaptureFrameOptions {
   format: string;
 }
 
+export interface CaptureVideoOptions {
+  /** The video name */
+  name: string;
+
+  /** The desired image width, in pixels. */
+  width: number;
+
+  /** The desired image height, in pixels. */
+  height: number;
+
+  /** The number of frames per second */
+  framesPerSecond: number;
+
+  /** The total number of frames to capture */
+  totalFrames: number;
+
+  /** The MIME type for the desired image format of output frames (e.g. `"image/jpeg"`). */
+  format: string;
+}
+
 interface ResolveFunction<T> {
   (value: T): void;
 }
@@ -1020,5 +1040,33 @@ export class WWTInstance {
         options.height,
         options.format);
     });
+  }
+
+  /** Capture a video */
+  captureVideo(options: CaptureVideoOptions): ReadableStream<Blob | null> {
+    const wwtControl = this.ctl;
+    const videoStream = new ReadableStream<Blob | null>({
+      start(controller: ReadableStreamDefaultController) {
+        function stream() {
+          wwtControl.captureVideo(blob => {
+              console.log(blob);
+              controller.enqueue(blob);
+            },
+            () => {
+              controller.close();
+              console.log("Stream closed!");
+            },
+            options.name,
+            options.width,
+            options.height,
+            options.framesPerSecond,
+            options.totalFrames,
+            options.format
+          );
+        }
+        return stream();
+      }
+    });
+    return videoStream;
   }
 }

--- a/engine-helpers/src/index.ts
+++ b/engine-helpers/src/index.ts
@@ -1042,7 +1042,10 @@ export class WWTInstance {
     });
   }
 
-  /** Capture a video */
+  /** Capture a video as a sequence of frames using the given parameters
+   *
+   * This function returns a readable stream whose values are the exported frames.
+  */
   captureVideo(options: CaptureVideoOptions): ReadableStream<Blob | null> {
     const wwtControl = this.ctl;
     const videoStream = new ReadableStream<Blob | null>({
@@ -1056,7 +1059,6 @@ export class WWTInstance {
                 controller.close();
               }
             },
-            options.name,
             options.width,
             options.height,
             options.framesPerSecond,

--- a/engine-pinia/package.json
+++ b/engine-pinia/package.json
@@ -31,8 +31,8 @@
   "homepage": "https://worldwidetelescope.org/home/",
   "internalDepVersions": {
     "@wwtelescope/astro": "thiscommit:2022-11-29:pfBFAzl",
-    "@wwtelescope/engine": "thiscommit:2023-02-13:v0AI7YY",
-    "@wwtelescope/engine-helpers": "thiscommit:2023-03-14:xwj6VYX",
+    "@wwtelescope/engine": "thiscommit:2023-03-27:SDdBd18",
+    "@wwtelescope/engine-helpers": "thiscommit:2023-03-27:OlDb7AO",
     "@wwtelescope/engine-types": "thiscommit:2022-11-29:OIQ6vzL"
   },
   "keywords": [

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -50,6 +50,7 @@ import {
   StretchFitsLayerOptions,
   UpdateTableLayerOptions,
   WWTInstance,
+  CaptureVideoOptions,
 } from "@wwtelescope/engine-helpers";
 
 interface WWTLinkedCallback {
@@ -1187,6 +1188,13 @@ export const engineStore = defineStore('wwt-engine', {
       if (this.$wwt.inst === null)
         throw new Error('cannot captureThumbnail without linking to WWTInstance');
       return this.$wwt.inst.captureFrame(options);
+    },
+
+    // Capturing a video
+    captureVideo(options: CaptureVideoOptions): ReadableStream<Blob | null> {
+      if (this.$wwt.inst === null)
+        throw new Error("cannot captureVideo without linking to WWTInstance");
+      return this.$wwt.inst.captureVideo(options);
     }
   },
 

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -1190,7 +1190,8 @@ export const engineStore = defineStore('wwt-engine', {
       return this.$wwt.inst.captureFrame(options);
     },
 
-    // Capturing a video
+    // Capturing a video as a readable stream
+
     captureVideo(options: CaptureVideoOptions): ReadableStream<Blob | null> {
       if (this.$wwt.inst === null)
         throw new Error("cannot captureVideo without linking to WWTInstance");

--- a/engine-pinia/src/wwtaware.ts
+++ b/engine-pinia/src/wwtaware.ts
@@ -622,6 +622,8 @@ export const WWTAwareComponent = defineComponent({
        * The first argument is a callback function to execute on the created `Blob`. */
       'captureFrame',
 
+      'captureVideo',
+
       /** Clear all [Annotations](../../engine/classes/annotation.html) from the view. */
       "clearAnnotations",
 

--- a/engine-pinia/src/wwtaware.ts
+++ b/engine-pinia/src/wwtaware.ts
@@ -622,6 +622,8 @@ export const WWTAwareComponent = defineComponent({
        * The first argument is a callback function to execute on the created `Blob`. */
       'captureFrame',
 
+      /** Capture a video as a stream of image `Blob`s with the desired width, height and format.
+       * The number of frames per second and total frame count are specified as well. */
       'captureVideo',
 
       /** Clear all [Annotations](../../engine/classes/annotation.html) from the view. */

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -2697,7 +2697,7 @@ export class WWTControl {
   captureFrame(blobReady: BlobCallback, width: number, height: number, format: string): void;
 
   /** Start a video capture */
-  captureVideo(blobReady: BlobCallback, videoCaptureDone: () => void, name: string, width: number, height: number, framesPerSecond: number, totalFrames: number, format: string): void;
+  captureVideo(blobReady: BlobCallback, name: string, width: number, height: number, framesPerSecond: number, totalFrames: number, format: string): void;
 
   /** Set the maximum allowed user zoom level in 3D ("solar system") mode.
    *

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -2696,6 +2696,9 @@ export class WWTControl {
   */
   captureFrame(blobReady: BlobCallback, width: number, height: number, format: string): void;
 
+  /** Start a video capture */
+  captureVideo(blobReady: BlobCallback, videoCaptureDone: () => void, name: string, width: number, height: number, framesPerSecond: number, totalFrames: number, format: string): void;
+
   /** Set the maximum allowed user zoom level in 3D ("solar system") mode.
    *
    * @param limit The new zoom limit.

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -2692,12 +2692,21 @@ export class WWTControl {
    * the captured image.
    * @param width The desired image width.
    * @param height The desired image height.
-   * @param string The desired image format (e.g. `"image/jpeg"`)
+   * @param format The desired image format (e.g. `"image/jpeg"`)
   */
   captureFrame(blobReady: BlobCallback, width: number, height: number, format: string): void;
 
-  /** Start a video capture */
-  captureVideo(blobReady: BlobCallback, name: string, width: number, height: number, framesPerSecond: number, totalFrames: number, format: string): void;
+  /** Capture a video as a sequence of images
+   *
+   * @param blobReady A callback function to execute on each `Blob` representing
+   * a captured frame.
+   * @param width The desired frame width.
+   * @param height The desired frame height.
+   * @param framesPerSecond The number of frames captured per second.
+   * @param totalFrames The total number of frames to capture.
+   * @param format The desired image format (e.g. `"image/jpeg"`)
+  */
+  captureVideo(blobReady: BlobCallback, width: number, height: number, framesPerSecond: number, totalFrames: number, format: string): void;
 
   /** Set the maximum allowed user zoom level in 3D ("solar system") mode.
    *

--- a/engine/wwtlib/SpaceTimeController.cs
+++ b/engine/wwtlib/SpaceTimeController.cs
@@ -100,9 +100,10 @@ namespace wwtlib
         }
         public static Date last = MetaNow;
 
+        public static double FramesPerSecond = 30;
+
         public static bool FrameDumping = false;
         public static bool CancelFrameDump = false;
-        public static double FramesPerSecond = 30;
 
         public static int CurrentFrameNumber = 0;
         public static int TotalFrames = 0;

--- a/engine/wwtlib/SpaceTimeController.cs
+++ b/engine/wwtlib/SpaceTimeController.cs
@@ -11,7 +11,7 @@ namespace wwtlib
         {
             if (syncToClock)
             {
-                Date justNow = Date.Now;
+                Date justNow = MetaNow;
 
                 if (timeRate != 1.0)
                 {
@@ -29,19 +29,19 @@ namespace wwtlib
                 catch
                 {
                     now = new Date(1, 12, 25, 23, 59, 59);
-                    offset = now - Date.Now;
+                    offset = now - MetaNow;
                 }
 
                 if (now.GetFullYear() > 4000)
                 {
                     now = new Date(4000, 12, 31, 23, 59, 59);
-                    offset = now - Date.Now;
+                    offset = now - MetaNow;
                 }
 
                 if (now.GetFullYear() < 1)
                 {
                     now = new Date(0, 12, 25, 23, 59, 59);
-                    offset = now - Date.Now;
+                    offset = now - MetaNow;
                 }
 
             }
@@ -94,11 +94,48 @@ namespace wwtlib
             set
             {
                 now = value;
-                offset = now - Date.Now;
-                last = Date.Now;
+                offset = now - MetaNow;
+                last = MetaNow;
             }
         }
-        public static Date last = Date.Now;
+        public static Date last = MetaNow;
+
+        public static bool FrameDumping = false;
+        public static bool CancelFrameDump = false;
+        public static double FramesPerSecond = 30;
+
+        public static int CurrentFrameNumber = 0;
+        public static int TotalFrames = 0;
+
+        static Date metaNow = Date.Now;
+        public static Date MetaNow
+        {
+            get
+            {
+                return metaNow;
+            }
+            set
+            {
+                if (!FrameDumping)
+                {
+                    metaNow = value;
+                }
+            }
+        }
+
+        public static void NextFrame()
+        {
+            metaNow.SetMilliseconds(metaNow.GetMilliseconds() + Math.Round(1000.0 / FramesPerSecond));
+            CurrentFrameNumber += 1;
+        }
+
+        public static bool DoneDumping
+        {
+            get
+            {
+                return !FrameDumping || CancelFrameDump || (CurrentFrameNumber >= TotalFrames);
+            }
+        }
 
 
         public static void SyncTime()
@@ -124,12 +161,12 @@ namespace wwtlib
 
         public static bool SyncToClock
         {
-            get { return SpaceTimeController.syncToClock; }
+            get { return syncToClock; }
             set
             {
-                if (SpaceTimeController.syncToClock != value)
+                if (syncToClock != value)
                 {
-                    SpaceTimeController.syncToClock = value;
+                    syncToClock = value;
                     if (value)
                     {
                         last = Date.Now;
@@ -156,8 +193,8 @@ namespace wwtlib
 
         public static double Altitude
         {
-            get { return SpaceTimeController.altitude; }
-            set { SpaceTimeController.altitude = value; }
+            get { return altitude; }
+            set { altitude = value; }
         }
 
         static public Coordinates Location

--- a/engine/wwtlib/TileCache.cs
+++ b/engine/wwtlib/TileCache.cs
@@ -7,6 +7,13 @@ namespace wwtlib
     class TileCache
     {
         private static Dictionary<String, Tile> queue = new Dictionary<String, Tile>();
+        public static int QueueCount
+        {
+            get
+            {
+                return queue.Count;
+            }
+        }
         static Dictionary<String, Tile> tiles = new Dictionary<string, Tile>();
         //internal static void AddTileToQueue(Tile tile)
         //{

--- a/engine/wwtlib/VideoOutputType.cs
+++ b/engine/wwtlib/VideoOutputType.cs
@@ -1,0 +1,24 @@
+﻿namespace wwtlib
+{
+    public class VideoOutputType
+    {
+        public string Name;
+        public double Fps;
+        public int Width;
+        public int Height;
+        public int TotalFrames = 0;
+        public int StartFrame = 0;
+        public bool WaitDownload = false;
+        public string Format = "image/jpeg";
+
+        public VideoOutputType(string name, int width, int height, double fps, string format, bool waitDownload)
+        {
+            Name = name;
+            Width = width;
+            Height = height;
+            Fps = fps;
+            Format = format;
+            WaitDownload = waitDownload;
+        }
+    }
+}

--- a/engine/wwtlib/VideoOutputType.cs
+++ b/engine/wwtlib/VideoOutputType.cs
@@ -2,18 +2,15 @@
 {
     public class VideoOutputType
     {
-        public string Name;
         public double Fps;
         public int Width;
         public int Height;
         public int TotalFrames = 0;
-        public int StartFrame = 0;
         public bool WaitDownload = false;
         public string Format = "image/jpeg";
 
-        public VideoOutputType(string name, int width, int height, double fps, string format, bool waitDownload)
+        public VideoOutputType(int width, int height, double fps, string format, bool waitDownload)
         {
-            Name = name;
             Width = width;
             Height = height;
             Fps = fps;

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -318,11 +318,11 @@ namespace wwtlib
 
         public VideoOutputType dumpFrameParams = null;
 
-        public void CaptureVideo(BlobReady VideoBlobReady, string Name, int Width, int Height, double FramesPerSecond, int TotalFrames, string Format)
+        public void CaptureVideo(BlobReady VideoBlobReady, int Width, int Height, double FramesPerSecond, int TotalFrames, string Format)
         {
             CapturingVideo = true;
             videoBlobReady = VideoBlobReady;
-            dumpFrameParams = new VideoOutputType(Name, Width, Height, FramesPerSecond, Format, true);
+            dumpFrameParams = new VideoOutputType(Width, Height, FramesPerSecond, Format, true);
             SpaceTimeController.FrameDumping = true;
             SpaceTimeController.FramesPerSecond = FramesPerSecond;
             SpaceTimeController.TotalFrames = TotalFrames;

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -312,6 +312,17 @@ namespace wwtlib
 
         private Imageset milkyWayBackground = null;
 
+        public bool CapturingVideo = false;
+
+        public void CaptureVideo(double FramesPerSecond, int TotalFrames)
+        {
+            CapturingVideo = true;
+            SpaceTimeController.FrameDumping = true;
+            SpaceTimeController.FramesPerSecond = FramesPerSecond;
+            SpaceTimeController.TotalFrames = TotalFrames;
+            SpaceTimeController.CurrentFrameNumber = 0;
+        }
+
         // To preserve semantic backwards compatibility, this function must requeue itself
         // to be called again in a timeout.
         public void Render()
@@ -373,6 +384,8 @@ namespace wwtlib
             Tile.TilesInView = 0;
             Tile.TilesTouched = 0;
             Tile.deepestLevel = 0;
+
+            SpaceTimeController.MetaNow = Date.Now;
 
             if (Mover != null)
             {
@@ -758,6 +771,8 @@ namespace wwtlib
                 }
             }
 
+            bool tilesAllLoaded = TileCache.QueueCount == 0;
+
             RenderContext.SetupMatricesOverlays();
             FadeFrame();
             //RenderContext.Clear();
@@ -790,6 +805,18 @@ namespace wwtlib
                 frameCount = 0;
                 RenderTriangle.TrianglesRendered = 0;
                 RenderTriangle.TrianglesCulled = 0;
+            }
+
+            if (CapturingVideo && tilesAllLoaded)
+            {
+                // TODO: What do we do with the frame that we've created?
+                SpaceTimeController.NextFrame();
+            }
+            if (SpaceTimeController.DoneDumping)
+            {
+                SpaceTimeController.FrameDumping = false;
+                SpaceTimeController.CancelFrameDump = false;
+                CapturingVideo = false;
             }
         }
 

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -315,15 +315,13 @@ namespace wwtlib
         public bool CapturingVideo = false;
 
         private BlobReady videoBlobReady = null;
-        private Action onVideoCaptureDone = null;
 
         public VideoOutputType dumpFrameParams = null;
 
-        public void CaptureVideo(BlobReady VideoBlobReady, Action VideoCaptureDone, string Name, int Width, int Height, double FramesPerSecond, int TotalFrames, string Format)
+        public void CaptureVideo(BlobReady VideoBlobReady, string Name, int Width, int Height, double FramesPerSecond, int TotalFrames, string Format)
         {
             CapturingVideo = true;
             videoBlobReady = VideoBlobReady;
-            onVideoCaptureDone = VideoCaptureDone;
             dumpFrameParams = new VideoOutputType(Name, Width, Height, FramesPerSecond, Format, true);
             SpaceTimeController.FrameDumping = true;
             SpaceTimeController.FramesPerSecond = FramesPerSecond;
@@ -828,8 +826,6 @@ namespace wwtlib
                     SpaceTimeController.CancelFrameDump = false;
                     CapturingVideo = false;
                     videoBlobReady = null;
-                    onVideoCaptureDone();
-                    onVideoCaptureDone = null;
                 }
             }
         }

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -314,9 +314,15 @@ namespace wwtlib
 
         public bool CapturingVideo = false;
 
-        public void CaptureVideo(double FramesPerSecond, int TotalFrames)
+        private BlobReady videoBlobReady = null;
+
+        public VideoOutputType dumpFrameParams = new VideoOutputType();
+
+        public void CaptureVideo(BlobReady VideoBlobReady, string Name, int Width, int Height, double FramesPerSecond, int TotalFrames)
         {
             CapturingVideo = true;
+            videoBlobReady = VideoBlobReady;
+            dumpFrameParams = new VideoOutputType(Name, Width, Height, FramesPerSecond);
             SpaceTimeController.FrameDumping = true;
             SpaceTimeController.FramesPerSecond = FramesPerSecond;
             SpaceTimeController.TotalFrames = TotalFrames;
@@ -807,7 +813,7 @@ namespace wwtlib
                 RenderTriangle.TrianglesCulled = 0;
             }
 
-            if (CapturingVideo && tilesAllLoaded)
+            if (CapturingVideo && (!dumpFrameParams.WaitDownload || tilesAllLoaded))
             {
                 // TODO: What do we do with the frame that we've created?
                 SpaceTimeController.NextFrame();

--- a/engine/wwtlib/wwtlib.csproj
+++ b/engine/wwtlib/wwtlib.csproj
@@ -45,6 +45,7 @@
     <RunPostBuildEvent>Always</RunPostBuildEvent>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="VideoOutputType.cs" />
     <Compile Include="FitsProperties.cs" />
     <Compile Include="Imports.cs" />
     <Compile Include="HipsProperties.cs" />


### PR DESCRIPTION
This PR is my proposal for adding the "video capture as frames" functionality, which exists in the Windows client, into the web engine. The C# code for handling this is largely stolen from the Windows client implementation, with a few small tweaks to fit this context.

For the sake of completeness, the basic idea is that this adds a notion of being in a "frame dumping" state to the engine. The main change is that this affects how the `SpaceTimeController` updates its current time, which is now controlled by a new `metaNow` member value. If we aren't frame dumping, things update as normal. But if we are, setting this value via the setter is a no-op - to move time forward we need to call `NextFrame`, which increments time by the appropriate amount for the frame dumping FPS. This method is called when the tile cache is empty (or if we set the `WaitDownload = false` in the frame dumping parameters). If that's not the case, we continue to process the queue and re-check during the next `RenderOneFrame` call.

The other question that this addresses is how what to do with the created `Blob` objects that represent the captured frames. This question has an obvious answer on the desktop - save to the specified directory with an appropriate filename. That's obviously not an option here, so the approach this takes is to expose a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API/Using_readable_streams) of frame blobs that the client can handle however it likes. The implementation is relatively straightforward - the `BlobCallback` passed into the engine adds the blob into the stream. When the number of received blobs meets the specified total number of frames, the stream is closed (engine-side, this `BlobReady` is set to `null`). It seems a bit redundant to keep track of frames both engine- and TS-side, but I think we need to. I initially tried passing in an "on capture complete" callback to close the stream, but the issue is that when the engine captures the last frame and when the stream receives it will be different, and this will lead to the stream being closed prematurely.