### PR TITLE
Video capture, part 2

### DIFF
--- a/engine-helpers/src/index.ts
+++ b/engine-helpers/src/index.ts
@@ -316,9 +316,6 @@ export interface CaptureFrameOptions {
 }
 
 export interface CaptureVideoOptions {
-  /** The video name */
-  name: string;
-
   /** The desired image width, in pixels. */
   width: number;
 

--- a/engine/wwtlib/IViewMover.cs
+++ b/engine/wwtlib/IViewMover.cs
@@ -50,7 +50,7 @@ namespace wwtlib
 
             this.from = from.Copy();
             this.to = to.Copy();
-            fromTime = Date.Now;
+            fromTime = SpaceTimeController.MetaNow;
             toTargetTime = time;
 
         }
@@ -70,7 +70,7 @@ namespace wwtlib
         {
             get
             {
-                int elapsed = Date.Now - fromTime;
+                int elapsed = SpaceTimeController.MetaNow - fromTime;
                 double elapsedSeconds = ((double)elapsed) / 1000;
 
                 double alpha = elapsedSeconds / (toTargetTime );
@@ -102,7 +102,7 @@ namespace wwtlib
         {
             get
             {
-                int elapsed = Date.Now - fromTime;
+                int elapsed = SpaceTimeController.MetaNow - fromTime;
                 double elapsedSeconds = ((double)elapsed) / 1000;
 
                 double alpha = elapsedSeconds / (toTargetTime);
@@ -194,7 +194,7 @@ namespace wwtlib
             }
             this.from = from;
             this.to = to;
-            fromTime = Date.Now;
+            fromTime = SpaceTimeController.MetaNow;
             double zoomUpTarget = 360.0;
             double travelTime;
 
@@ -252,7 +252,7 @@ namespace wwtlib
         {
             get
             {
-                int elapsed = Date.Now - fromTime;
+                int elapsed = SpaceTimeController.MetaNow - fromTime;
                 double elapsedSeconds = ((double)elapsed) / 1000;
 
                 if (elapsedSeconds < upTargetTime)


### PR DESCRIPTION
This PR makes some improvements to the video capture functionality introduced in #239. It turns out there was an issue with that implementation where frames could sometimes arrive out of order, which is obviously not good. This PR looks to fix that by adding adding a queue for frames that we aren't yet ready to pass into the stream.

The basic way that this works is that we intercept the `BlobReady` (C# for `BlobCallback`) callback that is passed into `CaptureVideo`, and use it to create a more complicated callback that manages a queue of frames, keyed by frame number. We keep track of which frames have already been "processed" (passed in to the callback) via an index. This method also makes sure to capture the frame number as soon as it's called, in the scope where the callback is created, because the static member of `SpaceTimeController` will almost certainly have moved forward when the callback is executed. Finally, since the spec allows a `null` blob to come in, we keep track of any "empty frames" where we've received a null blob.

When a blob is received by the wrapper callback, the flow is:
* If it's the next frame we need, great! Process it and move the index forward one.
    - We may already have frame(s) directly after this one. If so, keep moving the index forward by 1 until we hit the next frame number that's missing
* If it's not the next frame we need, put it into the queue (a `Dictionary<int,Blob>`), with the frame number as the key
* If it's `null`, mark the frame as empty
* If the frame index tells us that we're done (since we know the total number of frames), clean up and stop capturing frames

This PR also updates the movers (Ken Burns and slew) to use `SpaceTimeController.MetaNow` to determine their camera positions, as their lack of awareness of this could sometimes cause too much movement between frames.