### PR TITLE
Expose `SpaceTimeController::get_metaNow` to TypeScript

### DIFF
--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -1704,6 +1704,13 @@ export namespace SpaceTimeController {
    */
   export function set_now(date: Date): Date;
 
+  /** Get the current internal time of the WWT clock as a JavaScript Date.
+   *
+   * In some situations (such as frame-dumping mode for video capture), this will
+   * not be in sync with the current actual time.
+   */
+  export function get_metaNow(): Date;
+
   /** Get whether the WWT clock moves at the same rate as the system clock.
    *
    * Note that this value may be true but there may still be a constant offset


### PR DESCRIPTION
This PR adds a TypeScript declaration for the `SpaceTimeController`'s `get_metaNow` getter, which returns the `metaNow` property that was added in #239. This is useful for Vue-side stuff where we're capturing video frames and need the current time (my current case is for adding tweening to the preview videos).

@pkgw Note that not having this exposed isn't blocking what I'm doing at all  - the function exists in the engine JS, so I can just `ts-ignore` the TypeScript complaints or add the declaration locally for now.