### PR TITLE
Update HiPS URL and message handler setup

### DIFF
--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -2858,7 +2858,9 @@ const App = defineComponent({
       this.loadImageCollection({
         url: this.hipsUrl,
         loadChildFolders: true,
-      }).then(() => {
+      }).catch((error) => {
+        console.error(error);
+      }).finally(() => {
         // Handle the query script
         // We (potentially) need the catalogs to have finished loading for this
         if (script !== null) {

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -1193,7 +1193,7 @@ const App = defineComponent({
       lastSelectedSource: null as Source | null,
       selectionProximity: 4,
       hideAllChrome: false,
-      hipsUrl: "http://www.worldwidetelescope.org/wwtweb/catalog.aspx?W=hips", // Temporary
+      hipsUrl: `${window.location.protocol}//www.worldwidetelescope.org/wwtweb/catalog.aspx?W=hips`, // Temporary
       isPointerMoving: false,
       messageQueue: [] as Message[],
       pointerMoveThreshold: 6,


### PR DESCRIPTION
This PR is to address an issue discovered while trying to run CosmicDS in an environment with restrictive (i.e. HTTPS-only) internet. The issue is that we use an HTTP URL [for the HiPS WTML](https://github.com/WorldWideTelescope/wwt-webgl-engine/blob/master/research-app/src/App.vue#L1196), together with the fact that message handlers aren't properly set up if the collection load [here](https://github.com/WorldWideTelescope/wwt-webgl-engine/blob/master/research-app/src/App.vue#L2858) fails.

This attempts to address the issue by:
* Having the HiPS URL protocol match that of the window - in particular, we'll use an HTTPS URL in an HTTPS context
* Moving the message handler setup into a `finally` block for the HiPS collection load. In the case that load fails, a query script that wants to set up HiPS catalogs won't be able to do so, but that was already going to be the case anyways.
  - Note that we aren't using a return value here, so there's no issue with moving this functionality from `then` -> `finally`.