### PR TITLE
Ensure that source list message doesn't try to send proxy

### DIFF
--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -2525,8 +2525,9 @@ const App = defineComponent({
         layer = sourceLayer;
       }
 
+      const rawSource = isProxy(source) ? toRaw(source) : source;
       return {
-        ...source,
+        ...rawSource,
         catalogLayer: layer,
       };
     },
@@ -3050,11 +3051,10 @@ const App = defineComponent({
       if (this.$options.statusMessageDestination === null || this.allowedOrigin === null)
         return;
 
-      const rawSource = isProxy(source) ? toRaw(source) : source;
       const msg: selections.SelectionStateMessage = {
         type: "wwt_selection_state",
         sessionId: this.statusMessageSessionId,
-        mostRecentSource: this.prepareForMessaging(rawSource),
+        mostRecentSource: this.prepareForMessaging(source),
       };
 
       this.$options.statusMessageDestination.postMessage(msg, this.allowedOrigin);


### PR DESCRIPTION
This PR solves the same problem as #218, just in a slightly different place. That PR ensured that the last selected source couldn't be sent as a proxy, but we can actually get the same issue when sending the message describing the list of currently selected sources. This is a problem for downstream applications where the app's `statusMessageDestination` is non-null (e.g. pywwt), since the `postMessage` call app-side will fail as the proxy can't be cloned.

This PR refactors the `isProxy`/`toRaw` logic into the `prepareForMessaging` method, which gets called during the dispatch for both message types (and fits logically, as this is necessary to prepare the data for messaging).