### PR TITLE
Ensure that catalog layer info is not a proxy

### DIFF
--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -2526,9 +2526,10 @@ const App = defineComponent({
       }
 
       const rawSource = isProxy(source) ? toRaw(source) : source;
+      const rawLayer = isProxy(layer) ? toRaw(layer): layer;
       return {
         ...rawSource,
-        catalogLayer: layer,
+        catalogLayer: rawLayer,
       };
     },
 


### PR DESCRIPTION
This PR contains the next (and hopefully final) installment in my ongoing proxy war. This time, it's the catalog layer info that can also be a proxy. So far I've only seen this issue in a CosmicDS context - when I was using pywwt as e.g. a widget in a Jupyter notebook, this didn't pop up (as opposed to #251, which was a problem in that context).

Also, unlike #251, this issue isn't urgent for CosmicDS - I was able to directly hotfix the minified research app JS on our server to work around this.