### PR TITLE
Have the `addImagesetToRepository` method return an imageset

### DIFF
--- a/engine-helpers/package.json
+++ b/engine-helpers/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://worldwidetelescope.org/home/",
   "internalDepVersions": {
     "@wwtelescope/astro": "manual:workspace:>=0.1.0",
-    "@wwtelescope/engine": "thiscommit:2023-03-30:FyhxlT7",
+    "@wwtelescope/engine": "thiscommit:2023-06-08:wiuLDxn",
     "@wwtelescope/engine-types": "57d0450658d758832a11f628e890c061ad331ec2"
   },
   "keywords": [

--- a/engine-helpers/src/index.ts
+++ b/engine-helpers/src/index.ts
@@ -549,9 +549,12 @@ export class WWTInstance {
    * If an imageset with the same URL has already been loaded, this is a no-op.
    *
    * @param imgset The imageset to add
+   * @returns Either the input argument, if it was added to the engine's
+   *   database, or the pre-existing imageset. The pre-existing imageset will
+   *   have the same URL but might differ in other respects, such as its name.
    */
-  addImagesetToRepository(imgset: Imageset) {
-    WWTControl.addImageSetToRepository(imgset);
+  addImagesetToRepository(imgset: Imageset): Imageset {
+    return WWTControl.addImageSetToRepository(imgset);
   }
 
   // Collection-loaded promises. To simplify the handling, we never load the

--- a/engine-pinia/package.json
+++ b/engine-pinia/package.json
@@ -31,8 +31,8 @@
   "homepage": "https://worldwidetelescope.org/home/",
   "internalDepVersions": {
     "@wwtelescope/astro": "thiscommit:2022-11-29:pfBFAzl",
-    "@wwtelescope/engine": "thiscommit:2023-03-30:E9kU1cB",
-    "@wwtelescope/engine-helpers": "thiscommit:2023-03-30:8kh57fd",
+    "@wwtelescope/engine": "thiscommit:2023-06-08:jlRxuZ3",
+    "@wwtelescope/engine-helpers": "thiscommit:2023-06-08:51W7HwZ",
     "@wwtelescope/engine-types": "thiscommit:2022-11-29:OIQ6vzL"
   },
   "keywords": [

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -935,11 +935,11 @@ export const engineStore = defineStore('wwt-engine', {
       return result;
     },
 
-    addImagesetToRepository(imgset: Imageset): void {
+    addImagesetToRepository(imgset: Imageset): Imageset {
       if (this.$wwt.inst === null)
         throw new Error('cannot addImagesetToRepository without linking to WWTInstance');
 
-      this.$wwt.inst.addImagesetToRepository(imgset);
+      return this.$wwt.inst.addImagesetToRepository(imgset);
     },
 
     // General layers

--- a/engine-pinia/src/wwtaware.ts
+++ b/engine-pinia/src/wwtaware.ts
@@ -566,7 +566,12 @@ export const WWTAwareComponent = defineComponent({
 
       /** Add an imageset directly into the engine's database.
        *
-       * If an imageset with the same URL has already been loaded, this is a no-op.
+       * If an imageset with the same URL has already been loaded, this is a
+       * no-op.
+       *
+       * This returns the imageset that ultimately resides in the engine's
+       * database. It could either be the input argument, if it was newly added,
+       * or a pre-existing imageset in the no-op condition.
        */
       "addImagesetToRepository",
 

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -2216,14 +2216,14 @@ export interface UiController { }
  * path.
 * */
 export namespace URLHelpers {
-    /** Rewrite URL to deal with CORS issues, HTTPS issues, or similar issues.
-   *
-   * @param url The URL to be rewritten.
-   * @param rwmode URLRewriteMode Either AsIfAbsolute or OriginRelative.
-   * AsIfAbsolute if the input URL should be treated as an absolute URL.
-   * OriginRelative if the input URL is relative to the browser origin.
-   * @returns The new URL.
-   * */
+  /** Rewrite URL to deal with CORS issues, HTTPS issues, or similar issues.
+ *
+ * @param url The URL to be rewritten.
+ * @param rwmode URLRewriteMode Either AsIfAbsolute or OriginRelative.
+ * AsIfAbsolute if the input URL should be treated as an absolute URL.
+ * OriginRelative if the input URL is relative to the browser origin.
+ * @returns The new URL.
+ * */
   export function rewrite(url: string, rwmode: URLRewriteMode): string;
   export const singleton: URLHelpers;
 }
@@ -2485,10 +2485,14 @@ export class WcsImage {
 export class WWTControl {
   /** Add an imageset directly into the engine's database.
    *
-   * If another imageset with the same image URL is already loaded,
-   * this is a no-op.
+   * If another imageset with the same image URL is already loaded, this is a
+   * no-op, and the pre-existing imageset is returned. The difference might
+   * matter for future name-based lookups.
+   *
+   * @returns Either the input imageset, or the pre-existing imageset in
+   * the no-op condition.
    */
-  static addImageSetToRepository(img: Imageset): void;
+  static addImageSetToRepository(img: Imageset): Imageset;
 
   /** The image sets that have been loaded into the engine */
   static getImageSets(): Imageset[];

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -44,15 +44,17 @@ namespace wwtlib
 
         public IUiController uiController = null;
 
-        public static void AddImageSetToRepository(Imageset imagesetToAdd)
+        public static Imageset AddImageSetToRepository(Imageset imagesetToAdd)
         {
-            foreach(Imageset imageset in ImageSets){
-                if(imageset.ImageSetID == imagesetToAdd.ImageSetID)
+            foreach (Imageset imageset in ImageSets) {
+                if (imageset.ImageSetID == imagesetToAdd.ImageSetID)
                 {
-                    return;
+                    return imageset;
                 }
             }
+
             ImageSets.Add(imagesetToAdd);
+            return imagesetToAdd;
         }
 
         public static List<Imageset> GetImageSets()
@@ -3068,7 +3070,7 @@ namespace wwtlib
 
     //public delegate void BlobFrameReady(System.Html.Data.Files.Blob blob, int FrameNumber);
 
-    public class WWTElementEvent 
+    public class WWTElementEvent
     {
         public double OffsetX;
         public double OffsetY;


### PR DESCRIPTION
This method now returns that imageset that actually ended up in the repository. This might be the imageset that the caller wanted to add, or it might be a preexisting one, if there is already an imageset with the same URL in the database. The difference might matter if one wishes to do a name-based lookup of the imageset, since the two equivalent imagesets might have different name fields.