### PR TITLE
Change grid color settings to be strings

### DIFF
--- a/engine-types/src/index.ts
+++ b/engine-types/src/index.ts
@@ -261,6 +261,7 @@ export interface Thumbnail {
  * the engine itself. */
 export type BaseEngineSetting =
   ["actualPlanetScale", boolean] |
+  ["altAzGridColor", string] |
   ["constellations", boolean] |
   ["constellationBoundryColor", string] |
   ["constellationFigureColor", string] |
@@ -268,15 +269,20 @@ export type BaseEngineSetting =
   ["constellationSelectionColor", string] |
   ["crosshairsColor", string] |
   ["earthCutawayView", boolean] |
+  ["eclipticColor", string] |
+  ["eclipticGridColor", string] |
+  ["equatorialGridColor", string] |
   //["fovCamera", number] |  // skipping because not settable
   //["fovEyepiece", number] |  // skipping because not settable
   //["fovTelescope", number] |  // skipping because not settable
   ["localHorizonMode", boolean] |
   ["galacticMode", boolean] |
+  ["galacticGridColor", string] |
   ["locationAltitude", number] |
   ["locationLat", number] |
   ["locationLng", number] |
   ["milkyWayModel", boolean] |
+  ["precessionGridColor", string] |
   ["showAltAzGrid", boolean] |
   ["showAltAzGridText", boolean] |
   //["showClouds", boolean] |  // skipping because not settable
@@ -327,6 +333,7 @@ export type BaseEngineSetting =
 // I'm not aware of any smart TypeScripty way to automate the construction of this table :-(
 const baseEngineSettingTypeInfo = {
   "actualPlanetScale/boolean": true,
+  "altAzGridColor/string": true,
   "constellations/boolean": true,
   "constellationBoundryColor/string": true,
   "constellationFigureColor/string": true,
@@ -334,15 +341,20 @@ const baseEngineSettingTypeInfo = {
   "constellationSelectionColor/string": true,
   "crosshairsColor/string": true,
   "earthCutawayView/boolean": true,
+  "eclipticColor/string": true,
+  "eclipticGridColor/string": true,
+  "equatorialGridColor/string": true,
   //"fovCamera/number": true,  // skipping because not settable
   //"fovEyepiece/number": true,  // skipping because not settable
   //"fovTelescope/number": true,  // skipping because not settable
+  "galacticGridColor/string": true,
   "localHorizonMode/boolean": true,
   "galacticMode/boolean": true,
   "locationAltitude/number": true,
   "locationLat/number": true,
   "locationLng/number": true,
   "milkyWayModel/boolean": true,
+  "precessionGridColor/string": true,
   "showAltAzGrid/boolean": true,
   "showAltAzGridText/boolean": true,
   //"showClouds/boolean": true,  // skipping because not settable

--- a/engine/wwtlib/Settings.cs
+++ b/engine/wwtlib/Settings.cs
@@ -355,43 +355,43 @@ namespace wwtlib
             set { showAltAzGrid = value; }
         }
 
-        private Color eclipticGridColor = Colors.Green;
-        public Color EclipticGridColor
+        private string eclipticGridColor = Colors.Green.Name;
+        public string EclipticGridColor
         {
             get { return eclipticGridColor; }
             set { eclipticGridColor = value; }
         }
 
-        private Color galacticGridColor = Colors.Cyan;
-        public Color GalacticGridColor
+        private string galacticGridColor = Colors.Cyan.Name;
+        public string GalacticGridColor
         {
             get { return galacticGridColor; }
             set { galacticGridColor = value; }
         }
 
-        private Color altAzGridColor = Colors.Magenta;
-        public Color AltAzGridColor
+        private string altAzGridColor = Colors.Magenta.Name;
+        public string AltAzGridColor
         {
             get { return altAzGridColor; }
             set { altAzGridColor = value; }
         }
 
-        private Color precessionChartColor = Colors.Orange;
-        public Color PrecessionChartColor
+        private string precessionChartColor = Colors.Orange.Name;
+        public string PrecessionChartColor
         {
             get { return precessionChartColor; }
             set { precessionChartColor = value; }
         }
 
-        private Color eclipticColor = Colors.Blue;
-        public Color EclipticColor
+        private string eclipticColor = Colors.Blue.Name;
+        public string EclipticColor
         {
             get { return eclipticColor; }
             set { eclipticColor = value; }
         }
 
-        private Color equatorialGridColor = Colors.White;
-        public Color EquatorialGridColor
+        private string equatorialGridColor = Colors.White.Name;
+        public string EquatorialGridColor
         {
             get { return equatorialGridColor; }
             set { equatorialGridColor = value; }

--- a/engine/wwtlib/Tours/ISettings.cs
+++ b/engine/wwtlib/Tours/ISettings.cs
@@ -5,7 +5,7 @@ namespace wwtlib
     public interface ISettings
     {
         bool ActualPlanetScale { get; }
-        Color AltAzGridColor { get; }
+        string AltAzGridColor { get; }
         ConstellationFilter ConstellationArtFilter { get; }
         ConstellationFilter ConstellationBoundariesFilter { get; }
         ConstellationFilter ConstellationFiguresFilter { get; }
@@ -13,13 +13,13 @@ namespace wwtlib
         int ConstellationLabelsHeight { get; }
         string ConstellationsEnabled { get; }
         bool EarthCutawayView { get; }
-        Color EclipticColor { get; }
-        Color EclipticGridColor { get; }
-        Color EquatorialGridColor { get; }
+        string EclipticColor { get; }
+        string EclipticGridColor { get; }
+        string EquatorialGridColor { get; }
         int FovCamera { get; }
         int FovEyepiece { get; }
         int FovTelescope { get; }
-        Color GalacticGridColor { get; }
+        string GalacticGridColor { get; }
         bool GalacticMode { get; }
         bool LocalHorizonMode { get; }
         double LocationAltitude { get; }
@@ -28,7 +28,7 @@ namespace wwtlib
         bool MilkyWayModel { get; }
         int MinorPlanetsFilter { get; }
         int PlanetOrbitsFilter { get; }
-        Color PrecessionChartColor { get; }
+        string PrecessionChartColor { get; }
         bool ShowAltAzGrid { get; }
         bool ShowAltAzGridText { get; }
         bool ShowClouds { get; }

--- a/engine/wwtlib/Tours/TourStop.cs
+++ b/engine/wwtlib/Tours/TourStop.cs
@@ -1053,7 +1053,7 @@ namespace wwtlib
             xmlWriter.WriteAttributeString("ShowConstellationFigures", showConstellationFigures.ToString());
             xmlWriter.WriteAttributeString("ShowConstellationSelection", showConstellationSelection.ToString());
             xmlWriter.WriteAttributeString("ShowEcliptic", showEcliptic.ToString());
-            xmlWriter.WriteAttributeString("EclipticColor", eclipticColor.Save());
+            xmlWriter.WriteAttributeString("EclipticColor", eclipticColor);
             xmlWriter.WriteAttributeString("ShowElevationModel", showElevationModel.ToString());
             showFieldOfView = false;
             xmlWriter.WriteAttributeString("ShowFieldOfView", showFieldOfView.ToString());
@@ -1088,19 +1088,19 @@ namespace wwtlib
             xmlWriter.WriteAttributeString("ShowEarthSky", showEarthSky.ToString());
 
             xmlWriter.WriteAttributeString("ShowEquatorialGridText", ShowEquatorialGridText.ToString());
-            xmlWriter.WriteAttributeString("EquatorialGridColor", EquatorialGridColor.Save());
+            xmlWriter.WriteAttributeString("EquatorialGridColor", equatorialGridColor);
             xmlWriter.WriteAttributeString("ShowGalacticGrid", ShowGalacticGrid.ToString());
             xmlWriter.WriteAttributeString("ShowGalacticGridText", ShowGalacticGridText.ToString());
-            xmlWriter.WriteAttributeString("GalacticGridColor", GalacticGridColor.Save());
+            xmlWriter.WriteAttributeString("GalacticGridColor", galacticGridColor);
             xmlWriter.WriteAttributeString("ShowEclipticGrid", ShowEclipticGrid.ToString());
             xmlWriter.WriteAttributeString("ShowEclipticGridText", ShowEclipticGridText.ToString());
-            xmlWriter.WriteAttributeString("EclipticGridColor", EclipticGridColor.Save());
+            xmlWriter.WriteAttributeString("EclipticGridColor", eclipticGridColor);
             xmlWriter.WriteAttributeString("ShowEclipticOverviewText", ShowEclipticOverviewText.ToString());
             xmlWriter.WriteAttributeString("ShowAltAzGrid", ShowAltAzGrid.ToString());
             xmlWriter.WriteAttributeString("ShowAltAzGridText", ShowAltAzGridText.ToString());
-            xmlWriter.WriteAttributeString("AltAzGridColor", AltAzGridColor.Save());
+            xmlWriter.WriteAttributeString("AltAzGridColor", altAzGridColor);
             xmlWriter.WriteAttributeString("ShowPrecessionChart", ShowPrecessionChart.ToString());
-            xmlWriter.WriteAttributeString("PrecessionChartColor", PrecessionChartColor.Save());
+            xmlWriter.WriteAttributeString("PrecessionChartColor", precessionChartColor);
             xmlWriter.WriteAttributeString("ConstellationPictures", ShowConstellationPictures.ToString());
             xmlWriter.WriteAttributeString("ConstellationsEnabled", ConstellationsEnabled);
             xmlWriter.WriteAttributeString("ShowConstellationLabels", ShowConstellationLabels.ToString());
@@ -1331,7 +1331,7 @@ namespace wwtlib
                 }
                 if (tourStop.Attributes.GetNamedItem("EclipticColor") != null)
                 {
-                    newTourStop.eclipticColor = Color.Load(tourStop.Attributes.GetNamedItem("EclipticColor").Value);
+                    newTourStop.EclipticColor = tourStop.Attributes.GetNamedItem("EclipticColor").Value;
                 }
 
                 if (tourStop.Attributes.GetNamedItem("ShowElevationModel") != null)
@@ -1442,7 +1442,7 @@ namespace wwtlib
                 }
                 if (tourStop.Attributes.GetNamedItem("EquatorialGridColor") != null)
                 {
-                    newTourStop.equatorialGridColor = Color.Load(tourStop.Attributes.GetNamedItem("EquatorialGridColor").Value);
+                    newTourStop.EquatorialGridColor = tourStop.Attributes.GetNamedItem("EquatorialGridColor").Value;
                 }
 
                 if (tourStop.Attributes.GetNamedItem("ShowGalacticGrid") != null)
@@ -1455,7 +1455,7 @@ namespace wwtlib
                 }
                 if (tourStop.Attributes.GetNamedItem("GalacticGridColor") != null)
                 {
-                    newTourStop.galacticGridColor = Color.Load(tourStop.Attributes.GetNamedItem("GalacticGridColor").Value);
+                    newTourStop.GalacticGridColor = tourStop.Attributes.GetNamedItem("GalacticGridColor").Value;
                 }
 
                 if (tourStop.Attributes.GetNamedItem("ShowEclipticGrid") != null)
@@ -1468,7 +1468,7 @@ namespace wwtlib
                 }
                 if (tourStop.Attributes.GetNamedItem("EclipticGridColor") != null)
                 {
-                    newTourStop.eclipticGridColor = Color.Load(tourStop.Attributes.GetNamedItem("EclipticGridColor").Value);
+                    newTourStop.EclipticGridColor = tourStop.Attributes.GetNamedItem("EclipticGridColor").Value;
                 }
 
                 if (tourStop.Attributes.GetNamedItem("ShowEclipticOverviewText") != null)
@@ -1486,7 +1486,7 @@ namespace wwtlib
                 }
                 if (tourStop.Attributes.GetNamedItem("AltAzGridColor") != null)
                 {
-                    newTourStop.altAzGridColor = Color.Load(tourStop.Attributes.GetNamedItem("AltAzGridColor").Value);
+                    newTourStop.AltAzGridColor = tourStop.Attributes.GetNamedItem("AltAzGridColor").Value;
                 }
 
                 if (tourStop.Attributes.GetNamedItem("ShowPrecessionChart") != null)
@@ -1495,7 +1495,7 @@ namespace wwtlib
                 }
                 if (tourStop.Attributes.GetNamedItem("PrecessionChartColor") != null)
                 {
-                    newTourStop.precessionChartColor = Color.Load(tourStop.Attributes.GetNamedItem("PrecessionChartColor").Value);
+                    newTourStop.PrecessionChartColor = tourStop.Attributes.GetNamedItem("PrecessionChartColor").Value;
                 }
 
                 if (tourStop.Attributes.GetNamedItem("ShowConstellationPictures") != null)
@@ -1975,43 +1975,43 @@ namespace wwtlib
             return new SettingParameter(false,1,false,null);
         }
 
-        private Color eclipticGridColor = Colors.Green;
-        public Color EclipticGridColor
+        private string eclipticGridColor = Colors.Green.Name;
+        public string EclipticGridColor
         {
             get { return eclipticGridColor; }
             set { eclipticGridColor = value; }
         }
 
-        private Color galacticGridColor = Colors.Cyan;
-        public Color GalacticGridColor
+        private string galacticGridColor = Colors.Cyan.Name;
+        public string GalacticGridColor
         {
             get { return galacticGridColor; }
             set { galacticGridColor = value; }
         }
 
-        private Color altAzGridColor = Colors.Magenta;
-        public Color AltAzGridColor
+        private string altAzGridColor = Colors.Magenta.Name;
+        public string AltAzGridColor
         {
             get { return altAzGridColor; }
             set { altAzGridColor = value; }
         }
 
-        private Color precessionChartColor = Colors.Orange;
-        public Color PrecessionChartColor
+        private string precessionChartColor = Colors.Orange.Name;
+        public string PrecessionChartColor
         {
             get { return precessionChartColor; }
             set { precessionChartColor = value; }
         }
 
-        private Color eclipticColor = Colors.Blue;
-        public Color EclipticColor
+        private string eclipticColor = Colors.Blue.Name;
+        public string EclipticColor
         {
             get { return eclipticColor; }
             set { eclipticColor = value; }
         }
 
-        private Color equatorialGridColor = Colors.White;
-        public Color EquatorialGridColor
+        private string equatorialGridColor = Colors.White.Name;
+        public string EquatorialGridColor
         {
             get { return equatorialGridColor; }
             set { equatorialGridColor = value; }

--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -962,52 +962,52 @@ namespace wwtlib
 
             if (Settings.Active.ShowEclipticGrid)
             {
-                Grids.DrawEclipticGrid(RenderContext, 1, Settings.Active.EclipticGridColor);
+                Grids.DrawEclipticGrid(RenderContext, 1, Color.Load(Settings.Active.EclipticGridColor));
                 if (Settings.Active.ShowEclipticGridText)
                 {
-                    Grids.DrawEclipticGridText(RenderContext, 1, Settings.Active.EclipticGridColor);
+                    Grids.DrawEclipticGridText(RenderContext, 1, Color.Load(Settings.Active.EclipticGridColor));
                 }
             }
 
             if (Settings.Active.ShowGalacticGrid)
             {
-                Grids.DrawGalacticGrid(RenderContext, 1, Settings.Active.GalacticGridColor);
+                Grids.DrawGalacticGrid(RenderContext, 1, Color.Load(Settings.Active.GalacticGridColor));
                 if (Settings.Active.ShowGalacticGridText)
                 {
-                    Grids.DrawGalacticGridText(RenderContext, 1, Settings.Active.GalacticGridColor);
+                    Grids.DrawGalacticGridText(RenderContext, 1, Color.Load(Settings.Active.GalacticGridColor));
                 }
             }
 
             if (Settings.Active.ShowAltAzGrid)
             {
-                Grids.DrawAltAzGrid(RenderContext, 1, Settings.Active.AltAzGridColor);
+                Grids.DrawAltAzGrid(RenderContext, 1, Color.Load(Settings.Active.AltAzGridColor));
                 if (Settings.Active.ShowAltAzGridText)
                 {
-                    Grids.DrawAltAzGridText(RenderContext, 1, Settings.Active.AltAzGridColor);
+                    Grids.DrawAltAzGridText(RenderContext, 1, Color.Load(Settings.Active.AltAzGridColor));
                 }
             }
 
             if (Settings.Active.ShowPrecessionChart)
             {
-                Grids.DrawPrecessionChart(RenderContext, 1, Settings.Active.PrecessionChartColor);
+                Grids.DrawPrecessionChart(RenderContext, 1, Color.Load(Settings.Active.PrecessionChartColor));
 
             }
 
             if (Settings.Active.ShowEcliptic)
             {
-                Grids.DrawEcliptic(RenderContext, 1, Settings.Active.EclipticColor);
+                Grids.DrawEcliptic(RenderContext, 1, Color.Load(Settings.Active.EclipticColor));
                 if (Settings.Active.ShowEclipticOverviewText)
                 {
-                    Grids.DrawEclipticText(RenderContext, 1, Settings.Active.EclipticColor);
+                    Grids.DrawEclipticText(RenderContext, 1, Color.Load(Settings.Active.EclipticColor));
                 }
             }
 
             if (Settings.Active.ShowGrid)
             {
-                Grids.DrawEquitorialGrid(RenderContext, 1, Settings.Active.EquatorialGridColor);
+                Grids.DrawEquitorialGrid(RenderContext, 1, Color.Load(Settings.Active.EquatorialGridColor));
                 if (Settings.Active.ShowEquatorialGridText)
                 {
-                    Grids.DrawEquitorialGridText(RenderContext, 1, Settings.Active.EquatorialGridColor);
+                    Grids.DrawEquitorialGridText(RenderContext, 1, Color.Load(Settings.Active.EquatorialGridColor));
                 }
             }
 


### PR DESCRIPTION
In #226 the ability to change the colors of the various grid overlays was added to the engine. Inside the engine this works great, but I noticed an issue when attempting to expose these color options to `pywwt`.

The issue is that these new grid color settings expect a WWT `Color` object, but the pywwt's Color traitlet sends over a string, meaning that it can't be used to change the grid color. After looking into this a bit more, I realized that the way that I added in the color settings in #226 was inconsistent with the existing color settings (such as the colors for drawing constellations, see [here](https://github.com/WorldWideTelescope/wwt-webgl-engine/blob/master/engine/wwtlib/Settings.cs#L95)).

The approach this PR takes is to change the grid colors to be represented by strings, and then use `Color.Load` to get an actual `Color` instance for drawing the grids (similar to what is done e.g. [here](https://github.com/WorldWideTelescope/wwt-webgl-engine/blob/master/engine/wwtlib/Constellations.cs#L288)). This required relatively minimal code changes, and is consistent with how the constellation setting colors are defined.

The alternate approach would be to leave these settings as colors, and add some logic somewhere to parse the string into a color when it gets assigned to the relevant setting. Since C# doesn't let property setters accept values that differ from the property's type, this felt more involved to me.