### PR TITLE
Have opacity set annotation batch as dirty

### DIFF
--- a/engine/wwtlib/Annotation.cs
+++ b/engine/wwtlib/Annotation.cs
@@ -97,7 +97,11 @@ namespace wwtlib
         public double Opacity
         {
             get { return opacity; }
-            set { opacity = value; }
+            set
+            {
+                Annotation.BatchDirty = true;
+                opacity = value;
+            }
         }
         string id;
         


### PR DESCRIPTION
While working on https://github.com/glue-viz/glue-wwt/pull/96, I noticed some issues with changing the opacity of the line, even though we added support for annotation opacity in #238. Since the opacity would update when other properties were changed, I realized that the issue is that we don't mark the annotation batch as dirty when opacity is updated. This means that opacity updates are only realized after another property that _does_ mark the batch as dirty has been changed. This PR remedies this by marking the batch as dirty when the opacity has changed.

Do we also want to do the same thing for the `Label` and `ShowHoverLabel` properties? It seems like we would, but I don't know enough about what these are used for.