### PR TITLE
Actually use crosshairs color setting

### DIFF
--- a/engine/wwtlib/WWTControl.cs
+++ b/engine/wwtlib/WWTControl.cs
@@ -2940,7 +2940,7 @@ namespace wwtlib
                     crossHairs.AddLine(Vector3d.Create(0, -halfHeight, 0), Vector3d.Create(0, halfHeight, 0));
                 }
 
-                crossHairs.DrawLines(context, 1.0f, Colors.White);
+                crossHairs.DrawLines(context, 1.0f, Color.Load(Settings.Current.CrosshairsColor));
             }
         }
 


### PR DESCRIPTION
In the course of exposing some pywwt stuff to glue-wwt, I noticed that the `crosshairsColor` setting, while exposed downstream, doesn't actually have any effect. The reason for this is that the WebGL crosshair color is hardcoded to white, rather than using the setting value. The HTML5 canvas implementation does use this setting (which I assume is why it had already been exposed to pywwt). This PR updates the code that draws the crosshair to take the setting into account. Note that the `crosshairsColor` setting is stored in the engine as a string, not a `Color`.