### PR TITLE
Allow multiple instances to be mounted

### DIFF
--- a/docs/engine/engine-pinia-index.md
+++ b/docs/engine/engine-pinia-index.md
@@ -91,7 +91,23 @@ createApp(App, {
 
 Note that for now, **you can only include one WWT component in each app**,
 because the WWT engine library maintains global state. To work around this, use
-iframes.
+iframes. 
+
+Alternatively, it is possible to mount separate *full instances* of
+the application to the same web page by passing in a unique `id` when creating
+the Vue app using the `customId` prop.
+
+```ts
+...
+
+createApp(App, {
+    wwtNamespace: "mywwt",
+    customId: "myCustomId"
+  })
+  .use(wwtPinia)
+  .component('WorldWideTelescope', WWTComponent)
+  .mount("#app");
+```
 
 Finally, if you’re using [Webpack], you may run into a pitfall because this
 library must explicitly depend on the Vue package to obtain its TypeScript

--- a/engine-pinia/src/Component.vue
+++ b/engine-pinia/src/Component.vue
@@ -23,6 +23,7 @@ export default defineComponent({
   props: {
     wwtNamespace: { type: String, default: "wwt", required: true },
     wwtFreestandingAssetBaseurl: String,
+    customId: String
   },
 
   data(): ComponentData {
@@ -45,7 +46,7 @@ export default defineComponent({
 
   created() {
     // Create a globally unique ID for the div that the WWT engine can latch onto.
-    const uid = `wwtcmpt${idCounter}`;
+    const uid = this.customId === undefined ? `wwtcmpt${idCounter}` : this.customId;
     Object.defineProperties(this, {
       uniqueId: { get() { return uid; } },
     });


### PR DESCRIPTION
We've a use case in which multiple instances of the Vue application are being mounted to the same dom (specifically in an ipywidget context with Solara). In this case, however, the id of the div is always the same, causing issues in rendering. This PR allows for passing in a custom id to which the Vue component can be mounted, falling back to the default case of an incremented id when the prop is not provided.