### PR TITLE
Yet more docs work

### DIFF
--- a/docs/engine/content/apiref/_index.md
+++ b/docs/engine/content/apiref/_index.md
@@ -29,5 +29,5 @@ check out the following sections of the documentation:
   [@wwtelescope/research-app-messages](./research-app-messages/).
 - For a custom component-based web app built with Vue (the [Vue component
   model](../getting-started/vue-component-model.md)) see [the WWT Pinia
-  interface](engine-pinia/classes/WWTAwareComponent.html#md:the-wwt-pinia-interface)
+  interface](engine-pinia/functions/engineStore.html#md:the-wwt-pinia-interface)
   in [@wwtelescope/engine-pinia](./engine-pinia/).

--- a/docs/engine/engine-pinia-index.md
+++ b/docs/engine/engine-pinia-index.md
@@ -23,21 +23,22 @@ tutorials for these popular packages around the web as well.
 This package provides the following building blocks:
 
 - A system that lets you control the WWT engine using the [Pinia]
-  state-management framework. This integration provides a standardized way for
-  different pieces of code (say, different components of a web app) to observe
-  the state of the WWT engine (say, the current coordinates of its view center)
-  as well as control it (say, trigger a slew to a new location).
+  state-management framework, accessed with the {@link engineStore} function.
+  This integration provides a standardized way for different pieces of code
+  (say, different components of a web app) to observe the state of the WWT
+  engine (say, the current coordinates of its view center) as well as control it
+  (say, trigger a slew to a new location).
 - A reusable [Vue] component, {@link WWTComponent}, that contains a WWT view and
   links it up to the Pinia system. If you include a {@link WWTComponent} in your
   Vue-based web application, you can control it from anywhere else in your
-  codebase by using Pinia actions like {@link WWTAwareComponent.gotoRADecZoom}.
+  codebase by using Pinia actions like {@link engineStore.gotoRADecZoom}.
 - Finally, this package also provides a helper called {@link WWTAwareComponent}.
   If you are using Vue’s [“options API”][opt-api], you can use it as a base
   class for your own Vue components (say, a readout of the current view
   coordinates) to gain easy access to the WWT state. Specifically, this base
   class provides a full suite of getters and methods that are automagically
   wired up to the engine’s Pinia state. In Vue’s [“composition API”][opt-api],
-  the recommended style is use the Pinia store directly.
+  the recommended style is use the {@link engineStore} directly.
 
 [Vue component]: https://vuejs.org/guide/essentials/component-basics.html
 [opt-api]: https://vuejs.org/guide/introduction.html#api-styles
@@ -50,20 +51,22 @@ wrapping it — can do so, thanks to Pinia.
 
 # API Overview
 
-If you‘re constructing a Vue app based on this system, you’ll need to use two
+If you‘re constructing a Vue app based on this system, you’ll need to use these
 key interfaces:
 
 - {@link WWTComponent} to include an actual WWT view in your app somewhere
-- {@link wwtPinia} to set up the WWT Pinia linkage.
+- If that you have any code that needs to interact with WWT, also:
+  - {@link wwtPinia} to set up the WWT Pinia linkage.
+  - {@link engineStore} or {@link WWTAwareComponent} to talk to the engine.
 
-See the next section for a minimal example of how to do this. You may also find
-it convenient to use {@link WWTAwareComponent} as a base class for some of your
-components to get pre-wired methods for interacting with the WWT engine Pinia
-state.
+See the next section for a minimal example of how to do this. If you’re using
+Vue’s Options API, you may also find it convenient to use {@link
+WWTAwareComponent} as a base class for some of your components to get pre-wired
+methods for interacting with the WWT engine Pinia state.
 
 Once you have wired things up, you presumably want to know what WWT is doing and
 to command it! See [The WWT Pinia
-Interface](classes/WWTAwareComponent.html#md:the-wwt-pinia-interface) for an
+Interface](functions/engineStore.html#md:the-wwt-pinia-interface) for an
 overview of all the possible ways that your application code can interact with
 the WWT engine.
 
@@ -79,7 +82,7 @@ If you’re familiar with Vue, you might want to see what a minimal
 <template>
   <div id="app">
     <!-- Include a WWT Component: -->
-    <WorldWideTelescope wwt-namespace="mywwt"></WorldWideTelescope>
+    <WorldWideTelescope></WorldWideTelescope>
     <p class="coord-overlay">{{ coordText }}</p>
   </div>
 </template>
@@ -132,9 +135,7 @@ import { wwtPinia, WWTComponent } from "@wwtelescope/engine-pinia";
 
 import App from "./App.vue";
 
-createApp(App, {
-    wwtNamespace: "mywwt"
-  })
+createApp(App)
   .use(wwtPinia)
   .component('WorldWideTelescope', WWTComponent)
   .mount("#app");
@@ -152,7 +153,6 @@ the Vue app using the `customId` prop.
 ...
 
 createApp(App, {
-    wwtNamespace: "mywwt",
     customId: "myCustomId"
   })
   .use(wwtPinia)

--- a/engine-pinia/src/index.ts
+++ b/engine-pinia/src/index.ts
@@ -44,6 +44,9 @@ import { WWTGlobalState } from "./store";
  *   .mount("#app");
  * ```
  *
+ * Once you’ve activated the special WWT Pinia instance in this way, you can
+ * interact with the WWT engine state via the {@link engineStore} interface.
+ *
  * This Pinia instance is initialized with a special `$wwt` singleton value that
  * the {@link WWTComponent} uses to share global state with Pinia.
  */

--- a/engine-pinia/src/index.ts
+++ b/engine-pinia/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2020 the .NET Foundation
+// Copyright 2020-2023 the .NET Foundation
 // Licensed under the MIT License
 
 // This type moved to a lower-level dependency, but we re-export it to maintain
@@ -19,12 +19,8 @@ export {
   engineStore,
 } from "./store";
 
+export { default as WWTComponent } from "./Component.vue";
 export { WWTAwareComponent } from "./wwtaware";
-
-// Can't figure out a one-liner way to re-export the default export from
-// Component.vue under a specific name, so:
-import WWTComponent from "./Component.vue";
-export { WWTComponent }
 
 // Finally, we define the `wwtPinia` thingie.
 

--- a/engine-pinia/src/shims-vue.d.ts
+++ b/engine-pinia/src/shims-vue.d.ts
@@ -25,7 +25,7 @@ declare module "*.vue" {
    * Then, one of your app’s component templates could use a
    * `<WorldWideTelescope>` tag to insert a WWT display. Your other components
    * could then use the APIs defined in [The WWT Pinia
-   * Interface](../classes/WWTAwareComponent.html#md:the-wwt-pinia-interface) to
+   * Interface](../functions/engineStore.html#md:the-wwt-pinia-interface) to
    * monitor and control the WWT’s status.
    */
   const component: ReturnType<typeof defineComponent>;

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -1,9 +1,5 @@
-// Copyright 2020-2021 the .NET Foundation
+// Copyright 2020-2023 the .NET Foundation
 // Licensed under the MIT License
-
-// The high-level docs in `wwtaware.ts` contain the developer-friendly
-// descriptions of pretty much everything in this file. Update those docs when
-// adding new features here.
 
 import { defineStore } from 'pinia';
 
@@ -53,6 +49,7 @@ import {
   CaptureVideoOptions,
 } from "@wwtelescope/engine-helpers";
 
+/** @hidden */
 interface WWTLinkedCallback {
   (): void;
 }
@@ -82,7 +79,7 @@ export class WWTGlobalState {
 
 /** This class holds basic information about an imageset.
  *
- * Discover imagesets through the {@link WWTAwareComponent.wwtAvailableImagesets}
+ * Discover imagesets through the {@link engineStore.availableImagesets}
  * state variable. In standard practice there will be hundreds of available
  * imagesets of many different kinds.
  *
@@ -210,9 +207,9 @@ export class ImageSetLayerState {
  * names prefixed with `wwt`.
  *
  * **This support interface is intentionally undocumented — see [The WWT Pinia
- * Interface](../classes/WWTAwareComponent.html#md:the-wwt-pinia-interface)
+ * Interface](../functions/engineStore.html#md:the-wwt-pinia-interface)
  * instead!** This interface is entirely redundant with the items defined
- * {@link WWTAwareComponent} and we have opted to centralize the in-depth
+ * {@link engineStore} and we have opted to centralize the in-depth
  * documentation there.
  */
 export interface WWTEnginePiniaState {
@@ -222,35 +219,237 @@ export interface WWTEnginePiniaState {
   // NOTE 2: as per the above, any items changed here should also be changed in
   // the definition of WWTAwareComponent, and documentation should go there.
 
+  /** Information about the imagesets that are available to be used as a background.
+   *
+   * The info includes the name, which can then be used to set the background image
+   * via the {@link setBackgroundImageByName} mutation.
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtAvailableImagesets`.
+   */
   availableImagesets: ImagesetInfo[];
+
+  /** The current background [Imageset](../../engine/classes/Imageset-1.html), or
+   * null if it is undefined.
+   *
+   * You can cause this state variable to change using the
+   * {@link setBackgroundImageByName} mutation.
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtBackgroundImageset`.
+   */
   backgroundImageset: Imageset | null;
+
+  /** The number of times that the progression of the WWT internal clock has
+   * been changed discontinuously.
+   *
+   * The main use of this state variable is that you can
+   * [watch](https://vuejs.org/api/reactivity-core.html#watch) for changes to it and be alerted
+   * when the clock has been altered.
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtClockDiscontinuities`.
+   */
   clockDiscontinuities: number;
+
+  /** The rate at which the WWT internal clock progresses compared to real time.
+   * If the WWT clock is paused, this will be zero. Negative and fractional
+   * values are both possible.
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtClockRate`.
+   */
   clockRate: number;
+
+  /** The current time of WWT internal clock. In normal operation this variable
+   * will change with every rendered WWT frame, or every 30 ms or so.
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtCurrentTime`.
+   */
   currentTime: Date;
+
+  /** The current declination of the center of the WWT view, in radians.
+   *
+   * TODO: define the meaning here for view modes other than "sky."
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtDecRad`.
+   */
   decRad: number;
+
+  /** The current foreground [Imageset](../../engine/classes/Imageset-1.html), or
+   * null if it is undefined.
+   *
+   * You can cause this state variable to change using the
+   * {@link setForegroundImageByName} mutation.
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtForegroundImageset`.
+   */
   foregroundImageset: Imageset | null;
+
+  /** The opacity of the foreground imageset. Values range between 0 (invisible)
+    * and 100 (fully opaque).
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtForegroundOpacity`.
+    */
   foregroundOpacity: number;
+
+  /** Whether a tour has been loaded up and is available for playback.
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtIsTourPlayerActive`.
+   */
   isTourPlayerActive: boolean;
+
+  /** Whether a tour is actively playing back right now. This can spontaneously become
+   * false if the tour completes playing.
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtIsTourPlaying`.
+   */
   isTourPlaying: boolean;
+
+  /** The current right ascension of the center of the WWT view, in radians.
+   *
+   * TODO: define the meaning here for view modes other than "sky."
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtRARad`.
+   */
   raRad: number;
+
+  /** The current mode of the WWT renderer.
+   *
+   * This is derived from the "type" of the active background imageset. To
+   * change the mode, change the background imageset with
+   * {@link setBackgroundImageByName}.
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtRenderType`.
+   */
   renderType: ImageSetType;
+
+  /** The current roll of the view camera, in radians.
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtRollRad`.
+   */
   rollRad: number;
+
+  /** The time at which the Vue/Pinia system started up. */
   timeAtStartup: number;
+
+  /** The number of times that a WWT tour has completed playing.
+   *
+   * The main use of this state variable is that you can
+   * [watch](https://vuejs.org/api/reactivity-core.html#watch) for changes to it and be alerted
+   * when a tour finishes. Watching {@link isTourPlaying} doesn't suffice because
+   * that will trigger when a tour is paused.
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtTourCompletions`.
+   */
   tourCompletions: number;
+
+  /** The total runtime of the current tour, in seconds, if there is one.
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtTourRunTime`.
+   */
   tourRunTime: number | null;
+
+  /** The timecodes at which the current tour’s "stops" begin, in seconds.
+   *
+   * Each WWT tour is composed of one or more "stops", each of which has a fixed
+   * wall-clock duration. This variable gives the start times of the stops under
+   * the assumption that they all follow one another in sequence. It is possible
+   * to have nonlinear flow from one stop to the next.
+   *
+   * If no tour is loaded, this is an empty array.
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtTourStopStartTimes`.
+   */
   tourStopStartTimes: number[];
+
+  /** The "timecode" of the current tour playback progression.
+   *
+   * The "timecode" is approximately the number of seconds elapsed since tour
+   * playback began. More precisely, however, it is the start time of the
+   * current tour stop, plus however much wall-clock time has elapsed while at
+   * that stop. Because it is possible for stops to link to each other
+   * non-linearly, it is also possible for the timecode to progress non-linearly
+   * even when the tour plays back without user interaction.
+   *
+   * In combination with {@link tourStopStartTimes}, you can use this value to
+   * determine the index number of the currently active tour stop.
+   *
+   * If no tour is loaded, this is zero.
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtTourTimecode`.
+   */
   tourTimecode: number;
+
+  /** Whether or not to show a warning about recommending WebGL 2
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtShowWebGl2Warning`.
+   */
   showWebGl2Warning: boolean;
+
+  /** The WWT zoom level, in degrees.
+   *
+   * TODO: define the semantics here in 3D and other modes.
+   *
+   * In 2D sky mode, the zoom level is the angular height of the viewport,
+   * *times six*.
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtZoomDeg`.
+   */
   zoomDeg: number;
 
   // Layers and layer management
 
+  /** The GUIDs of all rendered layers, in their draw order.
+   *
+   * This list gives the GUIDs of the layers that are currently candidates for
+   * rendering. This list is determined by the hierarchy of "layer maps"
+   * registered with the engine and its current rendering mode. Layers in this
+   * list might not be actually rendered if their `enabled` flag is false, if
+   * they are fully transparent, and so on.
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtActiveLayers`.
+   */
   activeLayers: string[];
+
+  /** A table of activated imageset layers.
+   *
+   * Use {@link imagesetStateForLayer} to access information about a particular
+   * layer.
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtImagesetLayers`.
+   */
   imagesetLayers: { [guidtext: string]: ImageSetLayerState };
+
+  /** A table of activated imageset layers.
+   *
+   * Use {@link imagesetStateForLayer} to access information about a particular
+   * layer.
+   *
+   * In {@link WWTAwareComponent} this item is exposed under the name
+   * `wwtSpreadSheetLayers`.
+   */
   spreadSheetLayers: { [guidtext: string]: SpreadSheetLayerState };
 }
 
-/** The parameters for the {@link WWTAwareComponent.createTableLayer} action. */
+/** The parameters for the {{@link engineStore.createTableLayer} action. */
 export interface CreateTableLayerParams {
   /** The name to assign the layer. TODO: understand where (if anywhere) this name is exposed. */
   name: string;
@@ -262,7 +461,7 @@ export interface CreateTableLayerParams {
   dataCsv: string;
 }
 
-/** The parameters for the {@link WWTAwareComponent.timeToRADecZoom} action. */
+/** The parameters for the {{@link engineStore.timeToRADecZoom} action. */
 export interface TimeToRADecZoomParams {
   /** The right ascension of the target, in radians. */
   raRad: number;
@@ -277,7 +476,7 @@ export interface TimeToRADecZoomParams {
   rollRad?: number;
 }
 
-/** The parameters for the {@link WWTAwareComponent.gotoRADecZoom} action. */
+/** The parameters for the {{@link engineStore.gotoRADecZoom} action. */
 export interface GotoRADecZoomParams {
   /** The right ascension to go to, in radians. */
   raRad: number;
@@ -301,7 +500,7 @@ export interface GotoRADecZoomParams {
   rollRad?: number;
 }
 
-/** The parameters for the {@link WWTAwareComponent.loadTour} action. */
+/** The parameters for the {{@link engineStore.loadTour} action. */
 export interface LoadTourParams {
   /** The tour URL to load. */
   url: string;
@@ -310,7 +509,7 @@ export interface LoadTourParams {
   play: boolean;
 }
 
-/** The parameters for the {@link WWTAwareComponent.loadImageCollection} action. */
+/** The parameters for the {{@link engineStore.loadImageCollection} action. */
 export interface LoadImageCollectionParams {
   /** The WTML URL to load. */
   url: string;
@@ -366,12 +565,9 @@ function availableImagesets(): ImagesetInfo[] {
  * objects may be used  in general, [explore the Pinia
  * documentation](https://pinia.vuejs.org/core-concepts/).
  *
- * **The detailed API associated with this interface is intentionally undocumented
- * — see [The WWT Pinia
- * Interface](../classes/WWTAwareComponent.html#md:the-wwt-pinia-interface)
- * instead!** The store returned by this function has an API that is identical
- * to that of {@link WWTAwareComponent} and we have opted to centralize the
- * in-depth documentation there.
+ * See [The WWT Pinia Interface](#md:the-wwt-pinia-interface) below for an
+ * organized overview of all of the ways your code can control WWT using this
+ * framework.
  *
  * ## Example
  *
@@ -404,8 +600,9 @@ function availableImagesets(): ImagesetInfo[] {
  * </style>
  * ```
  *
- * If you wanted to define a Vue component manually in TypeScript and manually
- * connect some of its state or methods to the WWT Pinia store, you might write:
+ * If you wanted to define a Vue component manually in TypeScript using the
+ * Options API, you could manually connect some of its state or methods to the
+ * WWT Pinia store with code like:
  *
  * ```ts
  * import { defineComponent } from "vue";
@@ -426,11 +623,203 @@ function availableImagesets(): ImagesetInfo[] {
  * all of the store’s state and methods in a predefined component. Instead of
  * manually mapping out of the store as written above, you can just extend it
  * and get everything “for free”.
+ *
+ * # The WWT Pinia Interface
+ *
+ * Here we document all of the available WWT interfaces, grouping them by
+ * category. As a reminder, in the Pinia paradigm, state is expressed in [state
+ * variables] and [getters], and modified either directly or through [actions]
+ * (which can be asynchronous).
+ *
+ * [state variables]: https://pinia.vuejs.org/core-concepts/state.html
+ *
+ * [getters]: https://pinia.vuejs.org/core-concepts/getters.html
+ *
+ * [actions]: https://pinia.vuejs.org/core-concepts/actions.html
+ *
+ * ## Initialization
+ *
+ * Actions:
+ *
+ * - {@link waitForReady}
+ * - {@link setupForImageset}
+ *
+ * ## Basic View Information
+ *
+ * State:
+ *
+ * - {@link currentTime}
+ * - {@link clockDiscontinuities}
+ * - {@link clockRate}
+ * - {@link decRad}
+ * - {@link raRad}
+ * - {@link zoomDeg}
+ * - {@link rollRad}
+ *
+ * Getters:
+ *
+ * - {@link findRADecForScreenPoint}
+ * - {@link findScreenPointForRADec}
+ *
+ * Actions:
+ *
+ * - {@link gotoRADecZoom}
+ * - {@link timeToRADecZoom}
+ * - {@link gotoTarget}
+ * - {@link setClockRate}
+ * - {@link setClockSync}
+ * - {@link setTime}
+ * - {@link setTrackedObject}
+ * - {@link zoom}
+ * - {@link move}
+ * - {@link tilt}
+ *
+ * ## Image Sets
+ *
+ * State:
+ *
+ * - {@link availableImagesets}
+ * - {@link backgroundImageset}
+ * - {@link foregroundImageset}
+ * - {@link foregroundOpacity}
+ * - {@link renderType}
+ *
+ * Getters:
+ *
+ * - {@link lookupImageset}
+ *
+ * Actions:
+ *
+ * - {@link loadImageCollection}
+ * - {@link addImagesetToRepository}
+ * - {@link setBackgroundImageByName}
+ * - {@link setForegroundImageByName}
+ * - {@link setForegroundOpacity}
+ * - {@link setupForImageset}
+ *
+ *
+ * ## General Layer Management
+ *
+ * State:
+ *
+ * - {@link activeLayers}
+ *
+ * Getters:
+ *
+ * - {@link layerById}
+ *
+ * Actions:
+ *
+ * - {@link deleteLayer}
+ *
+ * ## Imageset Layers (including FITS imagery)
+ *
+ * State:
+ *
+ * - {@link activeLayers}
+ * - {@link imagesetLayers}
+ *
+ * Getters:
+ *
+ * - {@link activeImagesetLayerStates}
+ * - {@link imagesetForLayer}
+ * - {@link imagesetStateForLayer}
+ * - {@link imagesetLayerById}
+ *
+ * Actions:
+ *
+ * - {@link addImageSetLayer}
+ * - {@link loadFitsLayer} (deprecated)
+ * - {@link applyFitsLayerSettings}
+ * - {@link setFitsLayerColormap}
+ * - {@link stretchFitsLayer}
+ * - {@link setImageSetLayerOrder}
+ * - {@link deleteLayer}
+ *
+ * ## Tabular (“Spreadsheet”) Data Layers
+ *
+ * State:
+ *
+ * - {@link activeLayers}
+ * - {@link spreadSheetLayers}
+ *
+ * Getters:
+ *
+ * - {@link spreadSheetLayer}
+ * - {@link spreadsheetState}
+ * - {@link spreadSheetLayerById}
+ * - {@link spreadsheetStateById}
+ *
+ * Actions:
+ *
+ * - {@link createTableLayer}
+ * - {@link applyTableLayerSettings}
+ * - {@link updateTableLayer}
+ * - {@link deleteLayer}
+ *
+ * ## Annotations
+ *
+ * Actions:
+ *
+ * - {@link addAnnotation}
+ * - {@link clearAnnotations}
+ * - {@link removeAnnotation}
+ *
+ * ## Progressive HiPS Catalogs
+ *
+ * These have some characteristics of both imagesets and tabular ("spreadsheet")
+ * data layers.
+ *
+ * Getters:
+ *
+ * - {@link layerForHipsCatalog}
+ * - {@link spreadsheetStateForHipsCatalog}
+ *
+ * Actions:
+ *
+ * - {@link addCatalogHipsByName}
+ * - {@link applyTableLayerSettings}
+ * - {@link getCatalogHipsDataInView}
+ * - {@link removeCatalogHipsByName}
+ *
+ * ## Tours
+ *
+ * State:
+ *
+ * - {@link isTourPlayerActive}
+ * - {@link isTourPlaying}
+ * - {@link tourCompletions}
+ * - {@link tourRunTime}
+ * - {@link tourStopStartTimes}
+ * - {@link tourTimecode}
+ *
+ * Actions:
+ *
+ * - {@link loadTour}
+ * - {@link seekToTourTimecode}
+ * - {@link setTourPlayerLeaveSettingsWhenStopped}
+ * - {@link startTour}
+ * - {@link toggleTourPlayPauseState}
+ *
+ * ## Miscellaneous
+ *
+ * State:
+ *
+ * - {@link showWebGl2Warning}
+ *
+ * Actions:
+ *
+ * - {@link applySetting}
+ * - {@link viewAsTourXml}
+ * - {@link captureFrame}
+ * - {@link captureVideo}
  */
 export const engineStore = defineStore('wwt-engine', {
   // NOTE: We were originally alphabetizing these all, but now I think it will
   // be better to group topically related fields.
 
+  // Through typedoc magic, these fields are documented via the docstrings that
+  // appear in the `WWTEnginePiniaState` interface definition.
   state: (): WWTEnginePiniaState => ({
     activeLayers: [],
     availableImagesets: [],
@@ -457,8 +846,19 @@ export const engineStore = defineStore('wwt-engine', {
     zoomDeg: 0.0,
   }),
 
-  // Everything here should be documented in wwtaware.ts!
   getters: {
+    /** Look up an [Imageset](../../engine/classes/Imageset-1.html) in the engine’s
+     * table of ones with registered names.
+     *
+     * This delegates to
+     * [WWTControl.getImagesetByName()](../../engine/classes/WWTControl-1.html#getimagesetbyname),
+     * which has very eager name-matching rules. But if nothing matches, null is
+     * returned.
+     *
+     * Imagesets are not added to the engine’s list of names automatically. In
+     * order for an imageset to be findable by this function, its containing
+     * folder must have been loaded using the {@link loadImageCollection} action.
+     */
     lookupImageset(_state) {
       return (imagesetName: string) => {
         if (this.$wwt.inst === null)
@@ -467,6 +867,7 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
+    /** Get the right ascension and declination, in degrees, for x, y coordinates on the screen */
     findRADecForScreenPoint(_state) {
       return (pt: { x: number; y: number }): { ra: number; dec: number } => {
         if (this.$wwt.inst === null)
@@ -476,6 +877,7 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
+    /** Given an RA and Dec position, return the x, y coordinates of the screen point */
     findScreenPointForRADec(_state) {
       return (pt: { ra: number; dec: number }): { x: number; y: number } => {
         if (this.$wwt.inst === null)
@@ -484,12 +886,37 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
+    /** Look up the reactive state for an active imageset layer.
+     *
+     * These layers are created using the {@link addImageSetLayer} action. The state
+     * returned by this function is part of the reactive store, so you can
+     * wire it up to your UI and it will update as the layer settings are changed.
+     * If you need "runtime" state not captured in the reactivity system, you may
+     * need to use {@link imagesetForLayer} instead.
+     *
+     * @param guidtext The GUID of the layer to query, as a string
+     * @returns The layer state, or null if the GUID is unrecognized
+     */
     imagesetStateForLayer(state) {
       return (guidtext: string): ImageSetLayerState | null => {
         return state.imagesetLayers[guidtext] || null;
       }
     },
 
+    // NOTE that this getter is defined in a weird way. This is intentional as a
+    // "bug fix" but I forget the reasoning: see commit
+    // efa9bf14656aa97b6f7609ec411e768dfb42bdf8 . This makes it so tha this
+    // docstring is no rendered in the HTML docs :-(
+
+    /** Get the reactive state for the active imageset layers
+     *
+     * These layers are created using the {@link addImageSetLayer} action. The state
+     * structures returned by this function are part of the reactive store, so
+     * you can wire them up to your UI and they will update correctly. The list is
+     * returned in the engine's render order.
+     *
+     * @returns The layer states
+     */
     activeImagesetLayerStates(): ImageSetLayerState[] {
       const states: ImageSetLayerState[] = [];
 
@@ -509,6 +936,18 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
+    /** Look up the WWT engine object for an active imageset layer.
+     *
+     * This getter gets the WWT `Imageset` object associated with an imageset
+     * layer. The returned object is *not* part of the Vue(x) reactivity system,
+     * so you shouldn't use it to set up UI elements, but you can obtain more
+     * detailed information about the imageset than is stored in the state
+     * management system. For UI purposes, use {@link imagesetStateForLayer}.
+     *
+     * @param guidtext The GUID of the layer to query, as a string
+     * @returns The layer's underlying imageset, or null if the GUID is
+     * unrecognized
+     */
     imagesetForLayer(_state) {
       return (guidtext: string): Imageset | null => {
         if (this.$wwt.inst === null)
@@ -524,6 +963,15 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
+    /** Get the actual WWT `ImageSetLayer` for the imageset layer with the given ID.
+     *
+     * Do not use this function for UI purposes -- the WWT layer object is not
+     * integrated into the reactive state system, and so if you use it as a basis
+     * for UI elements, those elements will not be updated properly if/when the
+     * layer's settings change. Use {@link imagesetStateForLayer} instead.
+     *
+     * @param id The imageset layer's identifier.
+     */
     imagesetLayerById(_state) {
       return (id: string): ImageSetLayer | null => {
         if (this.$wwt.inst === null)
@@ -537,6 +985,15 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
+    /** Get the actual WWT `SpreadSheetLayer` for the named HiPS catalog.
+     *
+     * Do not use this function for UI purposes -- the WWT layer object is not
+     * integrated into the reactive state system, and so if you use it as a basis
+     * for UI elements, those elements will not be updated properly if/when the
+     * layer's settings change. Use {@link spreadsheetStateForHipsCatalog} instead.
+     *
+     * @param name The `datasetName` of the HiPS catalog
+     */
     layerForHipsCatalog(_state) {
       return (name: string): SpreadSheetLayer | null => {
         if (this.$wwt.inst === null)
@@ -547,6 +1004,17 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
+    /** Get the actual WWT `Layer` for the layer with the given ID.
+     *
+     * Do not use this function for UI purposes -- the WWT layer object is not
+     * integrated into the reactive state system, and so if you use it as a
+     * basis for UI elements, those elements will not be updated properly
+     * if/when the layer's settings change. If you know the specific type of
+     * your layer, you can use functions like {@link imagesetStateForLayer} or
+     * {@link spreadSheetStateById} to get reactive data structures.
+     *
+     * @param id The layer's identifier.
+     */
     layerById(_state) {
       return (id: string): Layer | null => {
         if (this.$wwt.inst === null)
@@ -555,6 +1023,15 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
+    /** Get reactive `SpreadSheetLayer` settings for the named HiPS catalog.
+     *
+     * The returned data structure is a component of the app's reactive state. You can
+     * therefore use the settings to construct UI elements, and they will update
+     * reactively as the state evolves. The actual data structures used by WWT are
+     * separate, but the two mirror each other.
+     *
+     * @param name The `datasetName` of the HiPS catalog
+     */
     spreadsheetStateForHipsCatalog(state) {
       return (name: string): SpreadSheetLayerSettingsInterfaceRO | null => {
         if (this.$wwt.inst === null)
@@ -565,6 +1042,15 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
+    /** Get the actual WWT `SpreadSheetLayer` for the table layer with the given ID.
+     *
+     * Do not use this function for UI purposes -- the WWT layer object is not
+     * integrated into the reactive state system, and so if you use it as a basis
+     * for UI elements, those elements will not be updated properly if/when the
+     * layer's settings change. Use {@link spreadsheetState} instead.
+     *
+     * @param id The table layer's identifier.
+     */
     spreadSheetLayerById(_state) {
       return (id: string): SpreadSheetLayer | null => {
         if (this.$wwt.inst === null)
@@ -578,12 +1064,31 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
+    /** Get reactive `SpreadSheetLayer` settings for the table layer with the given ID.
+     *
+     * The returned data structure is a component of the app's reactive state. You can
+     * therefore use the settings to construct UI elements, and they will update
+     * reactively as the state evolves. The actual data structures used by WWT are
+     * separate, but the two mirror each other.
+     *
+     * @param id The identifier of the table layer.
+     */
     spreadsheetStateById(state) {
       return (id: string): SpreadSheetLayerSettingsInterfaceRO | null => {
         return state.spreadSheetLayers[id] || null;
       }
     },
 
+    /** Get the actual WWT `SpreadSheetLayer` for the table layer corresponding
+     * to the given CatalogLayerInfo.
+     *
+     * Do not use this function for UI purposes -- the WWT layer object is not
+     * integrated into the reactive state system, and so if you use it as a basis
+     * for UI elements, those elements will not be updated properly if/when the
+     * layer's settings change. Use {@link spreadsheetState} instead.
+     *
+     * @param id The table layer's identifier.
+     */
     spreadSheetLayer(_state) {
       return (catalog: CatalogLayerInfo): SpreadSheetLayer | null => {
         if (this.$wwt.inst === null)
@@ -594,6 +1099,16 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
+    /** Get reactive `SpreadSheetLayer` settings for the table layer corresponding to
+     * the given CatalogLayerInfo.
+     *
+     * The returned data structure is a component of the app's reactive state. You can
+     * therefore use the settings to construct UI elements, and they will update
+     * reactively as the state evolves. The actual data structures used by WWT are
+     * separate, but the two mirror each other.
+     *
+     * @param catalog A CatalogLayerInfo object corresponding to the layer.
+     */
     spreadsheetState(state) {
       return (catalog: CatalogLayerInfo): SpreadSheetLayerSettingsInterfaceRO | null => {
         const key = this.catalogLayerKey(catalog);
@@ -602,16 +1117,18 @@ export const engineStore = defineStore('wwt-engine', {
     }
   },
 
-  // Everything here should be documented in wwtaware.ts!
   actions: {
+    /** @hidden */
     internalLinkToInstance(wwt: WWTInstance): void {
       this.$wwt.link(wwt);
     },
 
+    /** @hidden */
     internalUnlinkFromInstance(): void {
       this.$wwt.unlink();
     },
 
+    /** @hidden */
     internalUpdate(): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot internalUpdate without linking to WWTInstance');
@@ -670,28 +1187,49 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
+    /** @hidden */
     internalIncrementTourCompletions(): void {
       this.tourCompletions += 1;
     },
 
+    /** Alter one [WWT engine setting](../../engine/modules.html#enginesetting). */
     applySetting(setting: EngineSetting): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot applySetting without linking to WWTInstance');
       this.$wwt.inst.applySetting(setting);
     },
 
+    /** Set the current background [Imageset](../../engine/classes/Imageset-1.html)
+     * based on its name.
+     *
+     * The name lookup here is effectively done using {@link lookupImageset}. If
+     * the name is not found, the current background imageset remains unchanged.
+     *
+     * Changing the background imageset may change the value of {@link renderType},
+     * and the overall "mode" of the WWT renderer.
+     */
     setBackgroundImageByName(imagesetName: string): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot setBackgroundImageByName without linking to WWTInstance');
       this.$wwt.inst.setBackgroundImageByName(imagesetName);
     },
 
+    /** Set the current foreground [Imageset](../../engine/classes/Imageset-1.html)
+     * based on its name.
+     *
+     * The name lookup here is effectively done using {@link lookupImageset}. If
+     * the name is not found, the current foreground imageset remains unchanged.
+     */
     setForegroundImageByName(imagesetName: string): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot setForegroundImageByName without linking to WWTInstance');
       this.$wwt.inst.setForegroundImageByName(imagesetName);
     },
 
+    /** Set the opacity of the foreground imageset.
+     *
+     * Valid values are between 0 (invisible) and 100 (fully opaque).
+     */
     setForegroundOpacity(opacity: number): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot setForegroundOpacity without linking to WWTInstance');
@@ -699,30 +1237,50 @@ export const engineStore = defineStore('wwt-engine', {
       this.foregroundOpacity = opacity;
     },
 
+    /** Set up the background and foreground imagesets according to
+     * [the options](../../engine-helpers/interfaces/SetupForImagesetOptions.html)
+     *
+     * The main use of this interface is that it provides a mechanism to guess
+     * the appropriate background imageset given a foreground imageset that you
+     * want to show.
+     */
     setupForImageset(options: SetupForImagesetOptions): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot setupForImageset without linking to WWTInstance');
       this.$wwt.inst.setupForImageset(options);
     },
 
+    /** Set the zoom level of the view.
+     *
+     * This action may result in an action that takes a perceptible amount of
+     * time to resolve, if the "smooth pan" renderer option is enabled. To have
+     * proper asynchronous feedback about when the zoom operation completes, use
+     * {@link gotoRADecZoom}.
+     */
     zoom(factor: number): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot zoom without linking to WWTInstance');
       this.$wwt.inst.ctl.zoom(factor);
     },
 
+    /** Moves the position of the view */
     move(args: { x: number; y: number }): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot move without linking to WWTInstance');
       this.$wwt.inst.ctl.move(args.x, args.y);
     },
 
+    /** Tilts the position of the view */
     tilt(args: { x: number; y: number }): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot tilt without linking to WWTInstance');
       this.$wwt.inst.ctl._tilt(args.x, args.y);
     },
 
+    /** Set the current time of WWT's internal clock.
+     *
+     * Altering this causes an increment in {@link clockDiscontinuities}.
+     */
     setTime(time: Date): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot setTime without linking to WWTInstance');
@@ -730,6 +1288,14 @@ export const engineStore = defineStore('wwt-engine', {
       this.clockDiscontinuities += 1;
     },
 
+    /** Set the rate at which the WWT clock progresses compared to wall-clock time.
+     *
+     * A value of 10 means that the WWT clock progresses ten times faster than
+     * real time. A value of -0.1 means that the WWT clock moves backwards, ten
+     * times slower than real time.
+     *
+     * Altering this causes an increment in {@link clockDiscontinuities}.
+     */
     setClockRate(rate: number): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot setClockRate without linking to WWTInstance');
@@ -741,6 +1307,14 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
+    /** Set whether the WWT clock should progress with real time.
+     *
+     * See
+     * [SpaceTimeController.set_syncToClock()](../../engine/modules/SpaceTimeController.html#set_synctoclock).
+     * This interface effectively allows you to pause the WWT clock.
+     *
+     * Altering this causes an increment in {@link clockDiscontinuities}.
+     */
     setClockSync(isSynced: boolean): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot setClockSync without linking to WWTInstance');
@@ -758,6 +1332,10 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
+    /** Start playback of the currently loaded tour.
+     *
+     * Nothing happens if no tour is loaded.
+     */
     startTour(): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot start tour without linking to WWTInstance');
@@ -769,6 +1347,10 @@ export const engineStore = defineStore('wwt-engine', {
       player.play();
     },
 
+    /** Toggle the play/pause state of the current tour.
+     *
+     * Nothing happens if no tour is loaded.
+     */
     toggleTourPlayPauseState(): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot play/pause tour without linking to WWTInstance');
@@ -781,6 +1363,15 @@ export const engineStore = defineStore('wwt-engine', {
       player.pauseTour();
     },
 
+    /** Set whether the renderer settings of tours should remain applied after
+     * those tours finish playing back.
+     *
+     * This specialized option helps avoid jarring visual effects when tours
+     * finish playing. If a tour activates a renderer option like "local horizon
+     * mode", by default that option will turn off when the tour finishes, causing
+     * the view to suddenly change. If this option is set to True, that setting
+     * will remain active, preventing the sudden change.
+     */
     setTourPlayerLeaveSettingsWhenStopped(value: boolean): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot setTourPlayerLeaveSettingsWhenStopped without linking to WWTInstance');
@@ -792,6 +1383,14 @@ export const engineStore = defineStore('wwt-engine', {
       player.set_leaveSettingsWhenStopped(value);
     },
 
+    /** Seek tour playback to the specified timecode.
+     *
+     * See {@link tourTimecode} for a definition of the tour timecode.
+     *
+     * An important limitation is that the engine can only seek to the very
+     * beginning of a tour stop. If you request a timecode in the middle of a
+     * slide, the seek will actually occur to the start time of that slide.
+     */
     seekToTourTimecode(value: number): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot seekToTourTimecode without linking to WWTInstance');
@@ -799,6 +1398,7 @@ export const engineStore = defineStore('wwt-engine', {
       this.$wwt.inst.seekToTourTimecode(value);
     },
 
+    /** Get the current view as a one-slide tour, serialized to XML */
     async viewAsTourXml(name: string): Promise<string | null> {
       WWTControl.singleton.createTour(name || "");
       const editor = WWTControl.singleton.tourEdit;
@@ -820,6 +1420,13 @@ export const engineStore = defineStore('wwt-engine', {
       });
     },
 
+    /** Wait for the WWT engine to become ready for usage.
+     *
+     * You should invoke this action and wait for is completion before trying to
+     * do anything else with a WWT-aware component. The action resolves when the
+     * WWT engine has completed its initialization, which involes the download of
+     * some supporting data files.
+     */
     async waitForReady(): Promise<void> {
       if (this.$wwt.inst !== null) {
         return this.$wwt.inst.waitForReady();
@@ -838,6 +1445,13 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
+    /** Command the view to steer to a specific configuration.
+     *
+     * The async action completes when the view arrives, or when
+     * a subsequent view command overrides this one.
+     *
+     * TODO: document semantics when not in 2D sky mode!
+     */
     async gotoRADecZoom(
       { raRad, decRad, zoomDeg, instant, rollRad }: GotoRADecZoomParams
     ): Promise<void> {
@@ -846,6 +1460,7 @@ export const engineStore = defineStore('wwt-engine', {
       return this.$wwt.inst.gotoRADecZoom(raRad, decRad, zoomDeg, instant, rollRad);
     },
 
+    /** Returns the time it would take, in seconds, to navigate to the given target. */
     timeToRADecZoom(
       { raRad, decRad, zoomDeg, rollRad }: TimeToRADecZoomParams
     ): number {
@@ -854,18 +1469,34 @@ export const engineStore = defineStore('wwt-engine', {
       return this.$wwt.inst.timeToRADecZoom(raRad, decRad, zoomDeg, rollRad);
     },
 
+    /** Command the view to steer as specified in
+     * [the options](../../engine-helpers/interfaces/GotoTargetOptions.html).
+     *
+     * The async action completes when the view arrives, or when
+     * a subsequent view command overrides this one.
+     */
     async gotoTarget(options: GotoTargetOptions): Promise<void> {
       if (this.$wwt.inst === null)
         throw new Error('cannot gotoTarget without linking to WWTInstance');
       return this.$wwt.inst.gotoTarget(options);
     },
 
+    /** Set the "tracked object" in the 3D solar system view.
+     *
+     * Allowed values are
+     * [defined in @wwtelescope/engine-types](../../engine-types/enums/SolarSystemObjects.html).
+     */
     setTrackedObject(obj: SolarSystemObjects): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot setTrackedObject without linking to WWTInstance');
       this.$wwt.inst.ctl.renderContext.set_solarSystemTrack(obj);
     },
 
+    /** Request the engine to load a tour file.
+     *
+     * The action resolves when the load is complete. It’s asynchronous because
+     * the full WTT tour file has to be downloaded.
+    */
     async loadTour(
       { url, play }: LoadTourParams
     ): Promise<{ tourRunTime: number | null; tourStopStartTimes: number[]; }> {
@@ -896,6 +1527,15 @@ export const engineStore = defineStore('wwt-engine', {
       return { tourRunTime, tourStopStartTimes };
     },
 
+    /** Request the engine to load the specified image collection.
+     *
+     * The image collection is a [WTML file](https://docs.worldwidetelescope.org/data-guide/1/data-file-formats/collections/)
+     * Images in collections loaded this way become usable for name-based lookup
+     * by interfaces such as {@link setForegroundImageByName}.
+     *
+     * The action resolves to a [Folder](../../engine/classes/Folder.html) instance.
+     * It’s asynchronous because the specified WTML file has to be downloaded.
+     */
     async loadImageCollection(
       { url, loadChildFolders }: LoadImageCollectionParams
     ): Promise<Folder> {
@@ -906,6 +1546,15 @@ export const engineStore = defineStore('wwt-engine', {
       return result;
     },
 
+    /** Add an imageset directly into the engine's database.
+     *
+     * If an imageset with the same URL has already been loaded, this is a
+     * no-op.
+     *
+     * This returns the imageset that ultimately resides in the engine's
+     * database. It could either be the input argument, if it was newly added,
+     * or a pre-existing imageset in the no-op condition.
+     */
     addImagesetToRepository(imgset: Imageset): Imageset {
       if (this.$wwt.inst === null)
         throw new Error('cannot addImagesetToRepository without linking to WWTInstance');
@@ -915,6 +1564,10 @@ export const engineStore = defineStore('wwt-engine', {
 
     // General layers
 
+    /** Delete the specified layer from the layer manager.
+     *
+     * A layer may be identified by either its name or its [id](../../engine/classes/Layer.html#id).
+     */
     deleteLayer(id: string | Guid): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot deleteLayer without linking to WWTInstance');
@@ -940,6 +1593,11 @@ export const engineStore = defineStore('wwt-engine', {
 
     // Imageset layers, including FITS layers
 
+    /** Request the creation of a image layer. Either a single FITS or an image set.
+     *
+     * The action resolves to a new [ImageSetLayer](../../engine/classes/ImageSetLayer.html) instance.
+     * It’s asynchronous because the requested url has to be downloaded.
+     */
     async addImageSetLayer(
       options: AddImageSetLayerOptions
     ): Promise<ImageSetLayer> {
@@ -955,6 +1613,12 @@ export const engineStore = defineStore('wwt-engine', {
       return wwtLayer;
     },
 
+    /** Deprecated. Use addImageSetLayer instead.
+     * Request the creation of a FITS image layer.
+     *
+     * The action resolves to a new [ImageSetLayer](../../engine/classes/ImageSetLayer.html) instance.
+     * It’s asynchronous because the requested FITS file has to be downloaded.
+     */
     async loadFitsLayer(
       options: LoadFitsLayerOptions
     ): Promise<ImageSetLayer> {
@@ -971,6 +1635,9 @@ export const engineStore = defineStore('wwt-engine', {
       return this.$wwt.inst.addImageSetLayer(addImageSetLayerOptions);
     },
 
+    /** Change the [ImageSetLayer](../../engine/classes/ImageSetLayer.html)
+     * position in the draw cycle.
+     */
     setImageSetLayerOrder(options: SetLayerOrderOptions): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot setImageSetLayerOrder without linking to WWTInstance');
@@ -979,6 +1646,9 @@ export const engineStore = defineStore('wwt-engine', {
       this.activeLayers = activeLayersList(this.$wwt);
     },
 
+    /** Alter the "stretch" of a FITS image layer according to
+     * [the options](../../engine-helpers/interfaces/StretchFitsLayerOptions.html).
+     */
     stretchFitsLayer(options: StretchFitsLayerOptions): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot stretchFitsLayer without linking to WWTInstance');
@@ -994,6 +1664,9 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
+    /** Set the colormap used for a FITS image layer according to
+     * [the options](../../engine-helpers/interfaces/SetFitsLayerColormapOptions.html).
+     */
     setFitsLayerColormap(options: SetFitsLayerColormapOptions): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot setFitsLayerColormap without linking to WWTInstance');
@@ -1007,6 +1680,9 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
+    /** Alter one or more settings of the specified FITS image layer as specified
+     * in [the options](../../engine-helpers/interfaces/ApplyFitsLayerSettingsOptions.html).
+     */
     applyFitsLayerSettings(options: ApplyFitsLayerSettingsOptions): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot applyFitsLayerSettings without linking to WWTInstance');
@@ -1024,6 +1700,10 @@ export const engineStore = defineStore('wwt-engine', {
 
     // Spreadsheet layers
 
+    /** Request the creation of a tabular data layer.
+     *
+     * The action resolves to a new [SpreadSheetLayer](../../engine/classes/SpreadSheetLayer.html) instance.
+     */
     async createTableLayer(
       options: CreateTableLayerParams
     ): Promise<SpreadSheetLayer> {
@@ -1069,6 +1749,9 @@ export const engineStore = defineStore('wwt-engine', {
       return wwtLayer;
     },
 
+    /** Alter one or more settings of the specified tabular data layers as specified
+     * in [the options](../../engine-helpers/interfaces/ApplyTableLayerSettingsOptions.html).
+     */
     applyTableLayerSettings(options: ApplyTableLayerSettingsOptions): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot applyTableLayerSettings without linking to WWTInstance');
@@ -1085,6 +1768,9 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
+    /** Update the contents of a tabular data layer according to
+     * [the options](../../engine-helpers/interfaces/UpdateTableLayerOptions.html).
+     */
     updateTableLayer(options: UpdateTableLayerOptions): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot updateTableLayer without linking to WWTInstance');
@@ -1098,6 +1784,10 @@ export const engineStore = defineStore('wwt-engine', {
     // These have some characteristics of imagesets, and some characteristics
     // of spreadsheet layers.
 
+    /** Add a "catalog HiPS" dataset to the current view, by name.
+     *
+     * If the catalog name is not in the engine's registry, the promise rejects.
+     */
     async addCatalogHipsByName(options: AddCatalogHipsByNameOptions): Promise<Imageset> {
       if (this.$wwt.inst == null)
         throw new Error('cannot addCatalogHipsByName without linking to WWTInstance');
@@ -1122,12 +1812,14 @@ export const engineStore = defineStore('wwt-engine', {
       return imgset;
     },
 
+    /** Request an export of the catalog HiPS data within the current viewport. */
     getCatalogHipsDataInView(options: GetCatalogHipsDataInViewOptions): Promise<InViewReturnMessage> {
       if (this.$wwt.inst == null)
         throw new Error('cannot getCatalogHipsDataInView without linking to WWTInstance');
       return this.$wwt.inst.getCatalogHipsDataInView(options);
     },
 
+    /** Remove a "catalog HiPS" dataset to the current view, by name. */
     removeCatalogHipsByName(name: string): void {
       if (this.$wwt.inst == null)
         throw new Error('cannot removeCatalogHipsByName without linking to WWTInstance');
@@ -1142,18 +1834,21 @@ export const engineStore = defineStore('wwt-engine', {
 
     // Annotations
 
+    /** Add an [Annotation](../../engine/classes/Annotation.html) to the view. */
     addAnnotation(ann: Annotation): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot addAnnotation without linking to WWTInstance');
       this.$wwt.inst.si.addAnnotation(ann);
     },
 
+    /** Remove the specified [Annotation](../../engine/classes/Annotation.html) from the view. */
     removeAnnotation(ann: Annotation): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot removeAnnotation without linking to WWTInstance');
       this.$wwt.inst.si.removeAnnotation(ann);
     },
 
+    /** Clear all [Annotations](../../engine/classes/Annotation.html) from the view. */
     clearAnnotations(): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot clearAnnotations without linking to WWTInstance');
@@ -1162,12 +1857,16 @@ export const engineStore = defineStore('wwt-engine', {
 
     // Capturing the current display
 
+    /** Capture the current frame as an image `Blob` with the desired width, height, and format.
+     * The first argument is a callback function to execute on the created `Blob`. */
     captureFrame(options: CaptureFrameOptions): Promise<Blob | null> {
       if (this.$wwt.inst === null)
         throw new Error('cannot captureThumbnail without linking to WWTInstance');
       return this.$wwt.inst.captureFrame(options);
     },
 
+    /** Capture a video as a stream of image `Blob`s with the desired width, height and format.
+     * The number of frames per second and total frame count are specified as well. */
     captureVideo(options: CaptureVideoOptions): ReadableStream<Blob | null> {
       if (this.$wwt.inst === null)
         throw new Error("cannot captureVideo without linking to WWTInstance");

--- a/engine-pinia/src/wwtaware.ts
+++ b/engine-pinia/src/wwtaware.ts
@@ -15,9 +15,12 @@ import { engineStore } from "./store";
  *
  * This class doesn’t implement any special functionality itself. All it does is
  * provide a set of state variables and methods that are pre-connected to [the
- * WWT Pinia interface](#md:the-wwt-pinia-interface). A component inheriting from
- * this class can use whichever ones it needs without having to set up that
- * integration itself.
+ * WWT Pinia
+ * interface](../functions/engineStore.html#md:the-wwt-pinia-interface). A
+ * component inheriting from this class can use whichever ones it needs without
+ * having to set up that integration itself. For that reason, **the detailed API
+ * associated with this class is intentionally undocumented**, so that the
+ * in-depth documentation can be centralized in one place.
  *
  * # Example
  *
@@ -60,792 +63,110 @@ import { engineStore } from "./store";
  * {@link engineStore} directly instead.
  *
  * [1]: https://vuejs.org/api/options-composition.html#extends
- *
- * # The WWT Pinia Interface
- *
- * A component deriving from {@link WWTAwareComponent}, or any other piece of
- * code that has access to the WWT Pinia store, can monitor or manipulate the
- * state of the WWT renderer.
- *
- * Here we document all of the available interfaces, grouping them by category.
- * As a reminder, in the Pinia paradigm, state is expressed in [state variables]
- * and [getters], and modified either directly or through [actions] (which can
- * be asynchronous).
- *
- * [state variables]: https://pinia.vuejs.org/core-concepts/state.html
- *
- * [getters]: https://pinia.vuejs.org/core-concepts/getters.html
- *
- * [actions]: https://pinia.vuejs.org/core-concepts/actions.html
- *
- * ## Initialization
- *
- * Actions:
- *
- * - {@link waitForReady}
- * - {@link setupForImageset}
- *
- * ## Basic View Information
- *
- * State:
- *
- * - {@link wwtCurrentTime}
- * - {@link wwtClockDiscontinuities}
- * - {@link wwtClockRate}
- * - {@link wwtDecRad}
- * - {@link wwtRARad}
- * - {@link wwtZoomDeg}
- * - {@link wwtRollRad}
- *
- * Getters:
- *
- * - {@link findRADecForScreenPoint}
- * - {@link findScreenPointForRADec}
- *
- * Actions:
- *
- * - {@link gotoRADecZoom}
- * - {@link timeToRADecZoom}
- * - {@link gotoTarget}
- * - {@link setClockRate}
- * - {@link setClockSync}
- * - {@link setTime}
- * - {@link setTrackedObject}
- * - {@link zoom}
- * - {@link move}
- * - {@link tilt}
- *
- * ## Image Sets
- *
- * State:
- *
- * - {@link wwtAvailableImagesets}
- * - {@link wwtBackgroundImageset}
- * - {@link wwtForegroundImageset}
- * - {@link wwtForegroundOpacity}
- * - {@link wwtRenderType}
- *
- * Getters:
- *
- * - {@link lookupImageset}
- *
- * Actions:
- *
- * - {@link loadImageCollection}
- * - {@link addImagesetToRepository}
- * - {@link setBackgroundImageByName}
- * - {@link setForegroundImageByName}
- * - {@link setForegroundOpacity}
- * - {@link setupForImageset}
- *
- *
- * ## General Layer Management
- *
- * State:
- *
- * - {@link wwtActiveLayers}
- *
- * Getters:
- *
- * - {@link layerById}
- *
- * Actions:
- *
- * - {@link deleteLayer}
- *
- * ## Imageset Layers (including FITS imagery)
- *
- * State:
- *
- * - {@link wwtActiveLayers}
- * - {@link wwtImagesetLayers}
- *
- * Getters:
- *
- * - {@link activeImagesetLayerStates}
- * - {@link imagesetForLayer}
- * - {@link imagesetStateForLayer}
- * - {@link imagesetLayerById}
- *
- * Actions:
- *
- * - {@link addImageSetLayer}
- * - {@link loadFitsLayer} (deprecated)
- * - {@link applyFitsLayerSettings}
- * - {@link setFitsLayerColormap}
- * - {@link stretchFitsLayer}
- * - {@link setImageSetLayerOrder}
- * - {@link deleteLayer}
- *
- * ## Tabular (“Spreadsheet”) Data Layers
- *
- * State:
- *
- * - {@link wwtActiveLayers}
- * - {@link wwtSpreadSheetLayers}
- *
- * Getters:
- *
- * - {@link spreadSheetLayer}
- * - {@link spreadsheetState}
- * - {@link spreadSheetLayerById}
- * - {@link spreadsheetStateById}
- *
- * Actions:
- *
- * - {@link createTableLayer}
- * - {@link applyTableLayerSettings}
- * - {@link updateTableLayer}
- * - {@link deleteLayer}
- *
- * ## Annotations
- *
- * Actions:
- *
- * - {@link addAnnotation}
- * - {@link clearAnnotations}
- * - {@link removeAnnotation}
- *
- * ## Progressive HiPS Catalogs
- *
- * These have some characteristics of both imagesets and tabular ("spreadsheet")
- * data layers.
- *
- * Getters:
- *
- * - {@link layerForHipsCatalog}
- * - {@link spreadsheetStateForHipsCatalog}
- *
- * Actions:
- *
- * - {@link addCatalogHipsByName}
- * - {@link applyTableLayerSettings}
- * - {@link getCatalogHipsDataInView}
- * - {@link removeCatalogHipsByName}
- *
- * ## Tours
- *
- * State:
- *
- * - {@link wwtIsTourPlayerActive}
- * - {@link wwtIsTourPlaying}
- * - {@link wwtTourCompletions}
- * - {@link wwtTourRunTime}
- * - {@link wwtTourStopStartTimes}
- * - {@link wwtTourTimecode}
- *
- * Actions:
- *
- * - {@link loadTour}
- * - {@link seekToTourTimecode}
- * - {@link setTourPlayerLeaveSettingsWhenStopped}
- * - {@link startTour}
- * - {@link toggleTourPlayPauseState}
- *
- * ## Miscellaneous
- *
- * State:
- *
- * - {@link wwtShowWebGl2Warning}
- *
- * Actions:
- *
- * - {@link applySetting}
- * - {@link viewAsTourXml}
- * - {@link captureFrame}
- * - {@link captureVideo}
  **/
 export const WWTAwareComponent = defineComponent({
   props: {
-    /** The namespace of the Pinia module used to track the WWT component’s state.
-     * This prop should have the same value in all components in the app that
-     * reference WWT.
+    /** This property is unused. It is retained for API compatibility from the
+     * days of Vuex.
      */
     wwtNamespace: { type: String, default: "wwt", required: false },
+
+    /** @hidden this was a mistake; keep it just in case */
     wwtFreestandingAssetBaseurl: String,
   },
 
   computed: {
-    // Renamed getters:
+    // Renamed getters/properties:
     ...mapState(engineStore, {
-
-      /** The GUIDs of all rendered layers, in their draw order.
-       *
-       * This list gives the GUIDs of the layers that are currently candidates for
-       * rendering. This list is determined by the hierarchy of "layer maps"
-       * registered with the engine and its current rendering mode. Layers in this
-       * list might not be actually rendered if their `enabled` flag is false, if
-       * they are fully transparent, and so on.
-       **/
       wwtActiveLayers: 'activeLayers',
-
-      /** Information about the imagesets that are available to be used as a background.
-         *
-         * The info includes the name, which can then be used to set the background image
-         * via the {@link setBackgroundImageByName} mutation.
-         */
       wwtAvailableImagesets: 'availableImagesets',
-
-      /** The current background [Imageset](../../engine/classes/Imageset-1.html), or
-       * null if it is undefined.
-       *
-       * You can cause this state variable to change using the
-       * {@link setBackgroundImageByName} mutation.
-       * **/
       wwtBackgroundImageset: 'backgroundImageset',
-
-      /** The current time of WWT internal clock. In normal operation this variable
-       * will change with every rendered WWT frame, or every 30 ms or so.
-       */
       wwtCurrentTime: 'currentTime',
-
-      /** The number of times that the progression of the WWT internal clock has
-       * been changed discontinuously.
-       *
-       * The main use of this state variable is that you can
-       * [watch](https://vuejs.org/api/reactivity-core.html#watch) for changes to it and be alerted
-       * when the clock has been altered. */
       wwtClockDiscontinuities: 'clockDiscontinuities',
-
-      /** The rate at which the WWT internal clock progresses compared to real time.
-       * If the WWT clock is paused, this will be zero. Negative and fractional
-       * values are both possible. */
       wwtClockRate: 'clockRate',
-
-      /** The current declination of the center of the WWT view, in radians.
-       *
-       * TODO: define the meaning here for view modes other than "sky."
-       */
       wwtDecRad: 'decRad',
-
-      /** The current foreground [Imageset](../../engine/classes/Imageset-1.html), or
-       * null if it is undefined.
-       *
-       * You can cause this state variable to change using the
-       * {@link setForegroundImageByName} mutation.
-       * **/
       wwtForegroundImageset: 'foregroundImageset',
-
-      /** The opacity of the foreground imageset. Values range between 0 (invisible)
-        * and 100 (fully opaque). */
       wwtForegroundOpacity: 'foregroundOpacity',
-
-      /** A table of activated imageset layers.
-       *
-       * Use {@link imagesetStateForLayer} to access information about a particular
-       * layer.
-       */
       wwtImagesetLayers: 'imagesetLayers',
-
-      /** Whether a tour has been loaded up and is available for playback. */
       wwtIsTourPlayerActive: 'isTourPlayerActive',
-
-      /** Whether a tour is actively playing back right now. This can spontaneously become
-        * false if the tour completes playing. */
       wwtIsTourPlaying: 'isTourPlaying',
-
-      /** The current right ascension of the center of the WWT view, in radians.
-       *
-       * TODO: define the meaning here for view modes other than "sky."
-       */
       wwtRARad: 'raRad',
-
-      /** The current mode of the WWT renderer.
-       *
-       * This is derived from the "type" of the active background imageset. To
-       * change the mode, change the background imageset with
-       * {@link setBackgroundImageByName}.
-       */
       wwtRenderType: 'renderType',
-
-      /** The current roll of the view camera, in radians */
       wwtRollRad: 'rollRad',
-
-      /** Whether or not to show a warning about recommending WebGL 2 */
       wwtShowWebGl2Warning: 'showWebGl2Warning',
-
-      /** A table of activated imageset layers.
-       *
-       * Use {@link imagesetStateForLayer} to access information about a particular
-       * layer.
-       */
       wwtSpreadSheetLayers: 'spreadSheetLayers',
-
-      /** The number of times that a WWT tour has completed playing.
-       *
-       * The main use of this state variable is that you can
-       * [watch](https://vuejs.org/api/reactivity-core.html#watch) for changes to it and be alerted
-       * when a tour finishes. Watching {@link wwtIsTourPlaying} doesn't suffice because
-       * that will trigger when a tour is paused. */
       wwtTourCompletions: 'tourCompletions',
-
-      /** The total runtime of the current tour, in seconds, if there is one. */
       wwtTourRunTime: 'tourRunTime',
-
-      /** The timecodes at which the current tour’s "stops" begin, in seconds.
-       *
-       * Each WWT tour is composed of one or more "stops", each of which has a fixed
-       * wall-clock duration. This variable gives the start times of the stops under
-       * the assumption that they all follow one another in sequence. It is possible
-       * to have nonlinear flow from one stop to the next.
-       *
-       * If no tour is loaded, this is an empty array.
-       */
       wwtTourStopStartTimes: 'tourStopStartTimes',
-
-      /** The "timecode" of the current tour playback progression.
-       *
-       * The "timecode" is approximately the number of seconds elapsed since tour
-       * playback began. More precisely, however, it is the start time of the
-       * current tour stop, plus however much wall-clock time has elapsed while at
-       * that stop. Because it is possible for stops to link to each other
-       * non-linearly, it is also possible for the timecode to progress non-linearly
-       * even when the tour plays back without user interaction.
-       *
-       * In combination with {@link wwtTourStopStartTimes}, you can use this value to
-       * determine the index number of the currently active tour stop.
-       *
-       * If no tour is loaded, this is zero.
-       */
       wwtTourTimecode: 'tourTimecode',
-
-      /** The WWT zoom level, in degrees.
-       *
-       * TODO: define the semantics here in 3D and other modes.
-       *
-       * In 2D sky mode, the zoom level is the angular height of the viewport,
-       * *times six*.
-       */
       wwtZoomDeg: 'zoomDeg',
     }),
 
-    // Getters re-exported without renaming:
+    // Properties/getters re-exported without renaming:
     ...mapState(engineStore, [
-      /** Get the reactive state for the active imageset layers
-       *
-       * These layers are created using the {@link addImageSetLayer} action. The state
-       * structures returned by this function are part of the reactive store, so
-       * you can wire them up to your UI and they will update correctly. The list is
-       * returned in the engine's render order.
-       *
-       * @returns The layer states
-       */
       "activeImagesetLayerStates",
-
-      /** Get the right ascension and declination, in degrees, for x, y coordinates on the screen */
       "findRADecForScreenPoint",
-
-      /** Given an RA and Dec position, return the x, y coordinates of the screen point */
       "findScreenPointForRADec",
-
-      /** Get the actual WWT `Layer` for the layer with the given ID.
-       *
-       * Do not use this function for UI purposes -- the WWT layer object is not
-       * integrated into the reactive state system, and so if you use it as a
-       * basis for UI elements, those elements will not be updated properly
-       * if/when the layer's settings change. If you know the specific type of
-       * your layer, you can use functions like {@link imagesetStateForLayer} or
-       * {@link spreadSheetStateById} to get reactive data structures.
-       *
-       * @param id The layer's identifier.
-       */
       "layerById",
-
-      /** Look up the WWT engine object for an active imageset layer.
-       *
-       * This getter gets the WWT `Imageset` object associated with an imageset
-       * layer. The returned object is *not* part of the Vue(x) reactivity system,
-       * so you shouldn't use it to set up UI elements, but you can obtain more
-       * detailed information about the imageset than is stored in the state
-       * management system. For UI purposes, use {@link imagesetStateForLayer}.
-       *
-       * @param guidtext The GUID of the layer to query, as a string
-       * @returns The layer's underlying imageset, or null if the GUID is
-       * unrecognized
-       */
       "imagesetForLayer",
-
-      /** Get the actual WWT `ImageSetLayer` for the imageset layer with the given ID.
-       *
-       * Do not use this function for UI purposes -- the WWT layer object is not
-       * integrated into the reactive state system, and so if you use it as a basis
-       * for UI elements, those elements will not be updated properly if/when the
-       * layer's settings change. Use {@link imagesetStateForLayer} instead.
-       *
-       * @param id The imageset layer's identifier.
-       */
       "imagesetLayerById",
-
-      /** Look up the reactive state for an active imageset layer.
-       *
-       * These layers are created using the {@link addImageSetLayer} action. The state
-       * returned by this function is part of the reactive store, so you can
-       * wire it up to your UI and it will update as the layer settings are changed.
-       * If you need "runtime" state not captured in the reactivity system, you may
-       * need to use {@link imagesetForLayer} instead.
-       *
-       * @param guidtext The GUID of the layer to query, as a string
-       * @returns The layer state, or null if the GUID is unrecognized
-       */
       "imagesetStateForLayer",
-
-      /** Get the actual WWT `SpreadSheetLayer` for the named HiPS catalog.
-       *
-       * Do not use this function for UI purposes -- the WWT layer object is not
-       * integrated into the reactive state system, and so if you use it as a basis
-       * for UI elements, those elements will not be updated properly if/when the
-       * layer's settings change. Use {@link spreadsheetStateForHipsCatalog} instead.
-       *
-       * @param name The `datasetName` of the HiPS catalog
-       */
       "layerForHipsCatalog",
-
-      /** Look up an [Imageset](../../engine/classes/Imageset-1.html) in the engine’s
-       * table of ones with registered names.
-       *
-       * This delegates to
-       * [WWTControl.getImagesetByName()](../../engine/classes/WWTControl-1.html#getimagesetbyname),
-       * which has very eager name-matching rules. But if nothing matches, null is
-       * returned.
-       *
-       * Imagesets are not added to the engine’s list of names automatically. In
-       * order for an imageset to be findable by this function, its containing
-       * folder must have been loaded using the {@link loadImageCollection} action.
-       */
       "lookupImageset",
-
-      /** Get the actual WWT `SpreadSheetLayer` for the table layer with the given ID.
-       *
-       * Do not use this function for UI purposes -- the WWT layer object is not
-       * integrated into the reactive state system, and so if you use it as a basis
-       * for UI elements, those elements will not be updated properly if/when the
-       * layer's settings change. Use {@link spreadsheetState} instead.
-       *
-       * @param id The table layer's identifier.
-       */
       "spreadSheetLayerById",
-
-      /** Get the actual WWT `SpreadSheetLayer` for the table layer corresponding
-       * to the given CatalogLayerInfo.
-       *
-       * Do not use this function for UI purposes -- the WWT layer object is not
-       * integrated into the reactive state system, and so if you use it as a basis
-       * for UI elements, those elements will not be updated properly if/when the
-       * layer's settings change. Use {@link spreadsheetState} instead.
-       *
-       * @param id The table layer's identifier.
-       */
       "spreadSheetLayer",
-
-      /** Get reactive `SpreadSheetLayer` settings for the table layer corresponding to
-       * the given CatalogLayerInfo.
-       *
-       * The returned data structure is a component of the app's reactive state. You can
-       * therefore use the settings to construct UI elements, and they will update
-       * reactively as the state evolves. The actual data structures used by WWT are
-       * separate, but the two mirror each other.
-       *
-       * @param catalog A CatalogLayerInfo object corresponding to the layer.
-       */
       "spreadsheetState",
-
-      /** Get reactive `SpreadSheetLayer` settings for the table layer with the given ID.
-       *
-       * The returned data structure is a component of the app's reactive state. You can
-       * therefore use the settings to construct UI elements, and they will update
-       * reactively as the state evolves. The actual data structures used by WWT are
-       * separate, but the two mirror each other.
-       *
-       * @param id The identifier of the table layer.
-       */
       "spreadsheetStateById",
-
-      /** Get reactive `SpreadSheetLayer` settings for the named HiPS catalog.
-       *
-       * The returned data structure is a component of the app's reactive state. You can
-       * therefore use the settings to construct UI elements, and they will update
-       * reactively as the state evolves. The actual data structures used by WWT are
-       * separate, but the two mirror each other.
-       *
-       * @param name The `datasetName` of the HiPS catalog
-       */
       "spreadsheetStateForHipsCatalog",
     ]),
   },
 
   methods: {
     ...mapActions(engineStore, [
-
-      /** Add a "catalog HiPS" dataset to the current view, by name.
-       *
-       * If the catalog name is not in the engine's registry, the promise rejects.
-       */
       "addCatalogHipsByName",
-
-      /** Request the creation of a tabular data layer.
-       *
-       * The action resolves to a new [SpreadSheetLayer](../../engine/classes/SpreadSheetLayer.html) instance.
-       */
       "createTableLayer",
-
-      /** Request an export of the catalog HiPS data within the current viewport. */
       "getCatalogHipsDataInView",
-
-      /** Command the view to steer to a specific configuration.
-       *
-       * The async action completes when the view arrives, or when
-       * a subsequent view command overrides this one.
-       *
-       * TODO: document semantics when not in 2D sky mode!
-       */
       "gotoRADecZoom",
-
-      /** Returns the time it would take, in seconds, to navigate to the given target. */
       "timeToRADecZoom",
-
-      /** Command the view to steer as specified in
-       * [the options](../../engine-helpers/interfaces/GotoTargetOptions.html).
-       *
-       * The async action completes when the view arrives, or when
-       * a subsequent view command overrides this one.
-       */
       "gotoTarget",
-
-      /** Request the engine to load the specified image collection.
-       *
-       * The image collection is a [WTML file](https://docs.worldwidetelescope.org/data-guide/1/data-file-formats/collections/)
-       * Images in collections loaded this way become usable for name-based lookup
-       * by interfaces such as {@link setForegroundImageByName}.
-       *
-       * The action resolves to a [Folder](../../engine/classes/Folder.html) instance.
-       * It’s asynchronous because the specified WTML file has to be downloaded.
-       */
       "loadImageCollection",
-
-      /** Add an imageset directly into the engine's database.
-       *
-       * If an imageset with the same URL has already been loaded, this is a
-       * no-op.
-       *
-       * This returns the imageset that ultimately resides in the engine's
-       * database. It could either be the input argument, if it was newly added,
-       * or a pre-existing imageset in the no-op condition.
-       */
       "addImagesetToRepository",
-
-      /** Deprecated. Use addImageSetLayer instead.
-       * Request the creation of a FITS image layer.
-       *
-       * The action resolves to a new [ImageSetLayer](../../engine/classes/ImageSetLayer.html) instance.
-       * It’s asynchronous because the requested FITS file has to be downloaded.
-       */
       "loadFitsLayer",
-
-      /** Request the creation of a image layer. Either a single FITS or an image set.
-       *
-       * The action resolves to a new [ImageSetLayer](../../engine/classes/ImageSetLayer.html) instance.
-       * It’s asynchronous because the requested url has to be downloaded.
-       */
       "addImageSetLayer",
-
-      /** Request the engine to load a tour file.
-       *
-       * The action resolves when the load is complete. It’s asynchronous because
-       * the full WTT tour file has to be downloaded.
-      */
       "loadTour",
-
-      /** Get the current view as a one-slide tour, serialized to XML */
       "viewAsTourXml",
-
-      /** Wait for the WWT engine to become ready for usage.
-       *
-       * You should invoke this action and wait for is completion before trying to
-       * do anything else with a WWT-aware component. The action resolves when the
-       * WWT engine has completed its initialization, which involes the download of
-       * some supporting data files.
-       */
       "waitForReady",
-
       // Formerly mutations
-      // TODO: Alphabetize this into one big list
-
-      /** Add an [Annotation](../../engine/classes/Annotation.html) to the view. */
       "addAnnotation",
-
-      /** Alter one or more settings of the specified FITS image layer as specified
-       * in [the options](../../engine-helpers/interfaces/ApplyFitsLayerSettingsOptions.html).
-       */
       "applyFitsLayerSettings",
-
-      /** Alter one or more settings of the specified tabular data layers as specified
-       * in [the options](../../engine-helpers/interfaces/ApplyTableLayerSettingsOptions.html).
-       */
       "applyTableLayerSettings",
-
-      /** Alter one [WWT engine setting](../../engine/modules.html#enginesetting). */
       "applySetting",
-
-      /** Capture the current frame as an image `Blob` with the desired width, height, and format.
-       * The first argument is a callback function to execute on the created `Blob`. */
       'captureFrame',
-
-      /** Capture a video as a stream of image `Blob`s with the desired width, height and format.
-       * The number of frames per second and total frame count are specified as well. */
       'captureVideo',
-
-      /** Clear all [Annotations](../../engine/classes/Annotation.html) from the view. */
       "clearAnnotations",
-
-      /** Delete the specified layer from the layer manager.
-       *
-       * A layer may be identified by either its name or its [id](../../engine/classes/Layer.html#id).
-       */
       "deleteLayer",
-
-      /** Remove the specified [Annotation](../../engine/classes/Annotation.html) from the view. */
       "removeAnnotation",
-
-      /** Remove a "catalog HiPS" dataset to the current view, by name. */
       "removeCatalogHipsByName",
-
-      /** Seek tour playback to the specified timecode.
-       *
-       * See {@link wwtTourTimecode} for a definition of the tour timecode.
-       *
-       * An important limitation is that the engine can only seek to the very
-       * beginning of a tour stop. If you request a timecode in the middle of a
-       * slide, the seek will actually occur to the start time of that slide.
-       */
       "seekToTourTimecode",
-
-      /** Set the current background [Imageset](../../engine/classes/Imageset-1.html)
-       * based on its name.
-       *
-       * The name lookup here is effectively done using {@link lookupImageset}. If
-       * the name is not found, the current background imageset remains unchanged.
-       *
-       * Changing the background imageset may change the value of {@link wwtRenderType},
-       * and the overall "mode" of the WWT renderer.
-       */
       "setBackgroundImageByName",
-
-      /** Set the rate at which the WWT clock progresses compared to wall-clock time.
-       *
-       * A value of 10 means that the WWT clock progresses ten times faster than
-       * real time. A value of -0.1 means that the WWT clock moves backwards, ten
-       * times slower than real time.
-       *
-       * Altering this causes an increment in {@link wwtClockDiscontinuities}.
-       */
       "setClockRate",
-
-      /** Set whether the WWT clock should progress with real time.
-       *
-       * See
-       * [SpaceTimeController.set_syncToClock()](../../engine/modules/SpaceTimeController.html#set_synctoclock).
-       * This interface effectively allows you to pause the WWT clock.
-       *
-       * Altering this causes an increment in {@link wwtClockDiscontinuities}.
-       */
       "setClockSync",
-
-      /** Set the colormap used for a FITS image layer according to
-       * [the options](../../engine-helpers/interfaces/SetFitsLayerColormapOptions.html).
-       */
       "setFitsLayerColormap",
-
-      /** Set the current foreground [Imageset](../../engine/classes/Imageset-1.html)
-       * based on its name.
-       *
-       * The name lookup here is effectively done using {@link lookupImageset}. If
-       * the name is not found, the current foreground imageset remains unchanged.
-       */
       "setForegroundImageByName",
-
-      /** Set the opacity of the foreground imageset.
-       *
-       * Valid values are between 0 (invisible) and 100 (fully opaque).
-       */
       "setForegroundOpacity",
-
-      /** Change the [ImageSetLayer](../../engine/classes/ImageSetLayer.html)
-       * position in the draw cycle.
-       */
       "setImageSetLayerOrder",
-
-      /** Set whether the renderer settings of tours should remain applied after
-       * those tours finish playing back.
-       *
-       * This specialized option helps avoid jarring visual effects when tours
-       * finish playing. If a tour activates a renderer option like "local horizon
-       * mode", by default that option will turn off when the tour finishes, causing
-       * the view to suddenly change. If this option is set to True, that setting
-       * will remain active, preventing the sudden change.
-       */
       "setTourPlayerLeaveSettingsWhenStopped",
-
-      /** Set the current time of WWT's internal clock.
-       *
-       * Altering this causes an increment in {@link wwtClockDiscontinuities}.
-       */
       "setTime",
-
-      /** Set the "tracked object" in the 3D solar system view.
-       *
-       * Allowed values are
-       * [defined in @wwtelescope/engine-types](../../engine-types/enums/SolarSystemObjects.html).
-       */
       "setTrackedObject",
-
-      /** Set up the background and foreground imagesets according to
-       * [the options](../../engine-helpers/interfaces/SetupForImagesetOptions.html)
-       *
-       * The main use of this interface is that it provides a mechanism to guess
-       * the appropriate background imageset given a foreground imageset that you
-       * want to show.
-       */
       "setupForImageset",
-
-      /** Start playback of the currently loaded tour.
-       *
-       * Nothing happens if no tour is loaded.
-       */
       "startTour",
-
-      /** Alter the "stretch" of a FITS image layer according to
-       * [the options](../../engine-helpers/interfaces/StretchFitsLayerOptions.html).
-       */
       "stretchFitsLayer",
-
-      /** Toggle the play/pause state of the current tour.
-       *
-       * Nothing happens if no tour is loaded.
-       */
       "toggleTourPlayPauseState",
-
-      /** Update the contents of a tabular data layer according to
-       * [the options](../../engine-helpers/interfaces/UpdateTableLayerOptions.html).
-       */
       "updateTableLayer",
-
       //"updateAvailableImagesets",
-
-      /** Set the zoom level of the view.
-       *
-       * This action may result in an action that takes a perceptible amount of
-       * time to resolve, if the "smooth pan" renderer option is enabled. To have
-       * proper asynchronous feedback about when the zoom operation completes, use
-       * {@link gotoRADecZoom}.
-       */
       "zoom",
-
-      /** Moves the position of the view */
       "move",
-
-      /** Tilts the position of the view */
       "tilt",
     ]),
   }
-
 });

--- a/engine-pinia/src/wwtaware.ts
+++ b/engine-pinia/src/wwtaware.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the .NET Foundation
+// Copyright 2020-2023 the .NET Foundation
 // Licensed under the MIT License
 
 import { defineComponent } from "vue";
@@ -15,7 +15,7 @@ import { engineStore } from "./store";
  *
  * This class doesn’t implement any special functionality itself. All it does is
  * provide a set of state variables and methods that are pre-connected to [the
- * WWT Pinia interface](#the-wwt-pinia-interface). A component inheriting from
+ * WWT Pinia interface](#md:the-wwt-pinia-interface). A component inheriting from
  * this class can use whichever ones it needs without having to set up that
  * integration itself.
  *

--- a/research-app-messages/src/tours.ts
+++ b/research-app-messages/src/tours.ts
@@ -10,7 +10,7 @@
  * parameters are all correct.
  *
  * The underlying implementation maps to
- * [WWTAwareComponent.viewAsTourXml](../../engine-pinia/classes/WWTAwareComponent.html#viewAsTourXml).
+ * [engineStore.viewAsTourXml](../../engine-pinia/functions/engineStore.html#viewAsTourXml).
  */
 export interface GetViewAsTourMessage {
   /** The tag identifying this message type. */


### PR DESCRIPTION
I realized that the Pinia store methods weren't actually getting documented — while docstrings in `wwtaware.ts` worked for properties, they weren't coming through for methods. It is probably better to center the docs on the engineStore anyway, since Vue is pushing people towards the composition API, so here we bite the bullet and shift everything over. It is now looking like the docs are all there.