### PR TITLE
Fix transformations between world and screen coordinates when roll is nonzero

### DIFF
--- a/engine/esm/coordinates.js
+++ b/engine/esm/coordinates.js
@@ -199,7 +199,7 @@ Coordinates.cartesianToSpherical2 = function (vector) {
 Coordinates.cartesianToSphericalSky = function (vector) {
     var rho = Math.sqrt(vector.x * vector.x + vector.y * vector.y + vector.z * vector.z);
     var ra = Math.atan2(vector.z, vector.x);
-    var dec = Math.asin(-vector.y / rho);
+    var dec = Math.asin(vector.y / rho);
     return Vector2d.create(ra / Math.PI * 12, dec / Math.PI * 180);
 };
 
@@ -207,7 +207,7 @@ Coordinates.sphericalSkyToCartesian = function (vector) {
     var ra = vector.x * (Math.PI / 12);
     var dec = vector.y * (Math.PI / 180);
     var x = Math.cos(ra) * Math.cos(dec);
-    var y = -Math.sin(dec);
+    var y = Math.sin(dec);
     var z = Math.sin(ra) * Math.cos(dec);
     return Vector3d.create(x, y, z);
 };


### PR DESCRIPTION
This PR resolves #273 by making some changes to the transformations between world and screen coordinates. Note that the `Coordinates` functions that are modified here are only used in the `transformPickPointToWorldSpace` and `transformWorldPointToPickSpace` functions.

The reason that this worked before is because when the roll is zero, the view matrix is almost the identity - that fact combined with the minus sign that had been in the coordinate transformations made things work out okay.

This should be easy to test - open up the research app, load up a HiPS catalog, roll the view, and check that the point selection is still working.