### PR TITLE
engine/esm/url_helpers.js: fix HTTPS rewriting corner case

### DIFF
--- a/engine/esm/url_helpers.js
+++ b/engine/esm/url_helpers.js
@@ -237,17 +237,31 @@ var URLHelpers$ = {
             case DomainHandling.tryNoProxy:
             default:
                 if (this._force_https && lcproto !== 'https:') {
-                    // Force HTTPS and we'll see what happens. If
-                    // downloading fails, we'll set a flag and use our
-                    // proxy to launder the security.
+                    // Force HTTPS and we'll see what happens. If downloading
+                    // fails, we'll set a flag and use our proxy to launder the
+                    // security.
+                    //
+                    // As a quasi-hack to work around some stuff emited by the
+                    // Azure backend, make sure to strip off an `:80` port
+                    // specification if we're upgrading. If there's a port
+                    // specification that's anything else, don't try HTTPS - it
+                    // won't work.
                     //
                     // NOTE: it is important that we use `domain` and not
                     // `lcdomain`, even though domain names are
                     // case-insensitive, because we might be processing a
                     // template URL containing text like `{S}`, and WWT's
-                    // replacements *are* case-sensitive. Yes, I did learn
-                    // this the hard way.
-                    return 'https://' + domain + rest;
+                    // replacements *are* case-sensitive. Yes, I did learn this
+                    // the hard way.
+                    var rewrite_domain = domain;
+
+                    if (ss.endsWith(domain, ":80")) {
+                        rewrite_domain = domain.substring(0, domain.length - 3);
+                    } else if (domain.indexOf(':') >= 0) {
+                        return url;
+                    }
+
+                    return 'https://' + rewrite_domain + rest;
                 }
                 return url;
 


### PR DESCRIPTION
If we were given a URL like `http://mydomain.com:80/` to rewrite in force-HTTPS mode, we'd change it to `https://mydomain.com:80/`, which obviously isn't going to work.

In that one case, it makes sense to rewrite to `https://mydomain.com/` and see what happens. In cases with non-standard port specifications, that's definitely *not* going to work, so in those cases, we just have to keep the URL as insecure HTTP and hope the browser doesn't ding us.

This change motivated by an issue in `ShowImage.aspx`, which seems to have started including the `:80` in the URLs it emits in its redirects, breaking the Astrometry.Net workflow. I'm not sure why that changed, and we could try to change it back, but this modification here makes the rewriting code more correct, and should fully solve the problem. I hope.

@Carifio24 Would you mind giving this a quick read-over and seeing if this seems sensible to you? I want to get this fixed quickly, but don't want to rush a dumb mistake into a release either.