### PR TITLE
engine: build the UMD module with a `globalObject` of `this`

### DIFF
--- a/engine/webpack.config.js
+++ b/engine/webpack.config.js
@@ -4,6 +4,7 @@ var config = {
     entry: "./esm/index.js",
     output: {
         path: path.resolve(__dirname, "src"),
+        globalObject: "this",
         library: {
             name: "wwtlib",
             type: "umd"


### PR DESCRIPTION
The Webpack default is `self` but as far as I can tell, `this` is preferable:

https://webpack.js.org/configuration/output/#outputglobalobject
https://stackoverflow.com/questions/64639839/typescript-webpack-library-generates-referenceerror-self-is-not-defined

This fixes a problem with testing/running the Constellations frontend with the latest version of the engine.