### PR TITLE
Adjust double-touch logic for better usability

### DIFF
--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -1157,12 +1157,14 @@ var WWTControl$ = {
 
     onTouchMove: function (e) {
         var ev = e;
+
         if (this._hasTwoTouches) {
             var t0 = ev.touches[0];
             var t1 = ev.touches[1];
             var newRect = new Array(2);
             newRect[0] = Vector2d.create(t0.pageX, t0.pageY);
             newRect[1] = Vector2d.create(t1.pageX, t1.pageY);
+
             if (!this._dragging && this._pinchingZoomRect[0] != null && this._pinchingZoomRect[1] != null) {
                 var centerPoint = Vector2d.create(this.renderContext.width / 2, this.renderContext.height / 2);
                 var delta1 = Vector2d.subtract(newRect[0], this._pinchingZoomRect[0]);
@@ -1179,14 +1181,14 @@ var WWTControl$ = {
                 var angularComponent2 = Vector2d.subtract(delta2, radialComponent2);
                 var radialMagnitude = radialComponent1.get_length() + radialComponent2.get_length();
                 var angularMagnitude = angularComponent1.get_length() + angularComponent2.get_length();
-                if (radialMagnitude >= angularMagnitude && !this._rotating) {
+
+                if (radialMagnitude >= 0.5 * angularMagnitude && !this._rotating) {
                     var oldDist = this.getDistance(this._pinchingZoomRect[0], this._pinchingZoomRect[1]);
                     var newDist = this.getDistance(newRect[0], newRect[1]);
                     var ratio = oldDist / newDist;
                     this.zoom(ratio);
                     this._zooming = true;
-                }
-                else if (!this._zooming) {
+                } else if (!this._zooming) {
                     var oldCenterDelta1 = Vector2d.subtract(this._pinchingZoomRect[0], centerPoint);
                     var oldCenterDelta2 = Vector2d.subtract(this._pinchingZoomRect[1], centerPoint);
                     var newCenterDelta1 = Vector2d.subtract(newRect[0], centerPoint);
@@ -1195,6 +1197,7 @@ var WWTControl$ = {
                     var cross2 = this.crossProductZ(oldCenterDelta2, newCenterDelta2);
                     var angle1 = Math.asin(cross1 / (oldCenterDelta1.get_length() * newCenterDelta1.get_length()));
                     var angle2 = Math.asin(cross2 / (oldCenterDelta2.get_length() * newCenterDelta2.get_length()));
+
                     if (angle1 * angle2 >= 0) {
                         var angle = angle1 + angle2;
                         if (this.get_planetLike() || this.get_solarSystemMode()) {
@@ -1205,13 +1208,16 @@ var WWTControl$ = {
                     }
                 }
             }
+
             this._pinchingZoomRect = newRect;
             ev.stopPropagation();
             ev.preventDefault();
             return;
         }
+
         ev.preventDefault();
         ev.stopPropagation();
+
         if (this._mouseDown && !(this._rotating || this._zooming)) {
             var curX = ev.targetTouches[0].pageX - this._lastX;
             var curY = ev.targetTouches[0].pageY - this._lastY;

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -115,6 +115,9 @@ export function WWTControl() {
     this._pointerIds = new Array(2);
     this._pinchingZoomRect = new Array(2);
     this._moved = false;
+    this._zooming = false;
+    this._rotating = false;
+    this._dragThreshold = 4;
 
     this._foregroundCanvas = null;
     this._fgDevice = null;
@@ -1160,7 +1163,7 @@ var WWTControl$ = {
             var newRect = new Array(2);
             newRect[0] = Vector2d.create(t0.pageX, t0.pageY);
             newRect[1] = Vector2d.create(t1.pageX, t1.pageY);
-            if (this._pinchingZoomRect[0] != null && this._pinchingZoomRect[1] != null) {
+            if (!this._dragging && this._pinchingZoomRect[0] != null && this._pinchingZoomRect[1] != null) {
                 var centerPoint = Vector2d.create(this.renderContext.width / 2, this.renderContext.height / 2);
                 var delta1 = Vector2d.subtract(newRect[0], this._pinchingZoomRect[0]);
                 var delta2 = Vector2d.subtract(newRect[1], this._pinchingZoomRect[1]);
@@ -1176,13 +1179,14 @@ var WWTControl$ = {
                 var angularComponent2 = Vector2d.subtract(delta2, radialComponent2);
                 var radialMagnitude = radialComponent1.get_length() + radialComponent2.get_length();
                 var angularMagnitude = angularComponent1.get_length() + angularComponent2.get_length();
-                if (radialMagnitude >= angularMagnitude) {
+                if (radialMagnitude >= angularMagnitude && !this._rotating) {
                     var oldDist = this.getDistance(this._pinchingZoomRect[0], this._pinchingZoomRect[1]);
                     var newDist = this.getDistance(newRect[0], newRect[1]);
                     var ratio = oldDist / newDist;
                     this.zoom(ratio);
+                    this._zooming = true;
                 }
-                else {
+                else if (!this._zooming) {
                     var oldCenterDelta1 = Vector2d.subtract(this._pinchingZoomRect[0], centerPoint);
                     var oldCenterDelta2 = Vector2d.subtract(this._pinchingZoomRect[1], centerPoint);
                     var newCenterDelta1 = Vector2d.subtract(newRect[0], centerPoint);
@@ -1197,6 +1201,7 @@ var WWTControl$ = {
                             angle *= -1;
                         }
                         this.roll(angle);
+                        this._rotating = true;
                     }
                 }
             }
@@ -1207,10 +1212,10 @@ var WWTControl$ = {
         }
         ev.preventDefault();
         ev.stopPropagation();
-        if (this._mouseDown) {
-            this._dragging = true;
+        if (this._mouseDown && !(this._rotating || this._zooming)) {
             var curX = ev.targetTouches[0].pageX - this._lastX;
             var curY = ev.targetTouches[0].pageY - this._lastY;
+            this._dragging = this._dragging || (Math.sqrt(curX * curX + curY * curY) > this._dragThreshold);
             this.move(curX, curY);
             this._lastX = ev.targetTouches[0].pageX;
             this._lastY = ev.targetTouches[0].pageY;
@@ -1248,6 +1253,8 @@ var WWTControl$ = {
         }
         this._mouseDown = false;
         this._dragging = false;
+        this._zooming = false;
+        this._rotating = false;
     },
 
     // Pointer events


### PR DESCRIPTION
This PR aims to solve some usability issues with the two-touch handling. There are two main changes here:

* If a user has either zoomed or rotated during the current touch sequence, dragging isn't possible until they remove both fingers and start a new touch sequence. This removes the issue that we currently see where it's easy to not pick up both fingers at exactly the same time and get unintended movement after zooming or rotating.
* Allow only one of either zooming or rotating during the same touch sequence. This prevents unintended zooming when rotating, and vice versa. This is a bit more restrictive, so I'm open to other suggestions here. We could always set some sort of timeout (e.g. if you haven't rotated in N milliseconds, unset the rotation flag, and similar for zoom), but I decided to go with keeping things simple.

Since it's also easy to put one finger down and move some epsilon amount before the other one touches, I've also added a  threshold (in pixels) that can be moved before we say that dragging has started to occur.