### PR TITLE
Use midpoint of touches for zoom/rotate calculations

### DIFF
--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -119,6 +119,8 @@ export function WWTControl() {
     this._rotating = false;
     this._dragThreshold = 8;
     this._twoTouchCenter = null;
+    this._twoTouchFrames = 0;
+    this._twoTouchFrameThreshold = 10;
 
     this._foregroundCanvas = null;
     this._fgDevice = null;
@@ -1168,8 +1170,10 @@ var WWTControl$ = {
             var newRect = new Array(2);
             newRect[0] = Vector2d.create(t0.pageX, t0.pageY);
             newRect[1] = Vector2d.create(t1.pageX, t1.pageY);
+            this._twoTouchFrames += 1;
 
-            if (!this._dragging && this._pinchingZoomRect[0] != null && this._pinchingZoomRect[1] != null && this._twoTouchCenter != null) {
+            if (!this._dragging && this._pinchingZoomRect[0] != null && this._pinchingZoomRect[1] != null &&
+                this._twoTouchCenter != null && this._twoTouchFrames > this._twoTouchFrameThreshold) {
                 this._twoTouchCenter = Vector2d.create(0.5 * (t0.pageX + t1.pageX), 0.5 * (t0.pageY + t1.pageY));
                 var delta1 = Vector2d.subtract(newRect[0], this._pinchingZoomRect[0]);
                 var delta2 = Vector2d.subtract(newRect[1], this._pinchingZoomRect[1]);
@@ -1186,7 +1190,7 @@ var WWTControl$ = {
                 var radialMagnitude = radialComponent1.get_length() + radialComponent2.get_length();
                 var angularMagnitude = angularComponent1.get_length() + angularComponent2.get_length();
 
-                if (radialMagnitude > 1.25 * angularMagnitude && !this._rotating) {
+                if (radialMagnitude > angularMagnitude && !this._rotating) {
                     var oldDist = this.getDistance(this._pinchingZoomRect[0], this._pinchingZoomRect[1]);
                     var newDist = this.getDistance(newRect[0], newRect[1]);
                     var ratio = oldDist / newDist;
@@ -1251,6 +1255,7 @@ var WWTControl$ = {
             if (ev.touches.length < 2) {
                 this._hasTwoTouches = false;
                 this._twoTouchCenter = null;
+                this._twoTouchFrames = 0;
             }
             return;
         }

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -1170,6 +1170,7 @@ var WWTControl$ = {
             newRect[1] = Vector2d.create(t1.pageX, t1.pageY);
 
             if (!this._dragging && this._pinchingZoomRect[0] != null && this._pinchingZoomRect[1] != null && this._twoTouchCenter != null) {
+                this._twoTouchCenter = Vector2d.create(0.5 * (t0.pageX + t1.pageX), 0.5 * (t0.pageY + t1.pageY));
                 var delta1 = Vector2d.subtract(newRect[0], this._pinchingZoomRect[0]);
                 var delta2 = Vector2d.subtract(newRect[1], this._pinchingZoomRect[1]);
                 var radialDirection1 = Vector2d.subtract(this._pinchingZoomRect[0], this._twoTouchCenter);
@@ -1185,7 +1186,7 @@ var WWTControl$ = {
                 var radialMagnitude = radialComponent1.get_length() + radialComponent2.get_length();
                 var angularMagnitude = angularComponent1.get_length() + angularComponent2.get_length();
 
-                if (radialMagnitude >= 0.5 * angularMagnitude && !this._rotating) {
+                if (radialMagnitude >= 0.75 * angularMagnitude && !this._rotating) {
                     var oldDist = this.getDistance(this._pinchingZoomRect[0], this._pinchingZoomRect[1]);
                     var newDist = this.getDistance(newRect[0], newRect[1]);
                     var ratio = oldDist / newDist;

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -1186,13 +1186,13 @@ var WWTControl$ = {
                 var radialMagnitude = radialComponent1.get_length() + radialComponent2.get_length();
                 var angularMagnitude = angularComponent1.get_length() + angularComponent2.get_length();
 
-                if (radialMagnitude >= 0.75 * angularMagnitude && !this._rotating) {
+                if (radialMagnitude > 1.25 * angularMagnitude && !this._rotating) {
                     var oldDist = this.getDistance(this._pinchingZoomRect[0], this._pinchingZoomRect[1]);
                     var newDist = this.getDistance(newRect[0], newRect[1]);
                     var ratio = oldDist / newDist;
                     this.zoom(ratio);
                     this._zooming = true;
-                } else if (!this._zooming) {
+                } else if (!this._zooming && radialMagnitude > 0) {
                     var oldCenterDelta1 = Vector2d.subtract(this._pinchingZoomRect[0], this._twoTouchCenter);
                     var oldCenterDelta2 = Vector2d.subtract(this._pinchingZoomRect[1], this._twoTouchCenter);
                     var newCenterDelta1 = Vector2d.subtract(newRect[0], this._twoTouchCenter);

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -120,8 +120,8 @@ export function WWTControl() {
     this._dragThreshold = 8;
     this._twoTouchCenter = null;
     this._lastTouchRect = new Array(2);
-    this._twoTouchFrames = 0;
-    this._twoTouchFrameThreshold = 10;
+    this._twoTouchEvents = 0;
+    this._twoTouchEventThreshold = 10;
 
     this._foregroundCanvas = null;
     this._fgDevice = null;
@@ -1173,10 +1173,10 @@ var WWTControl$ = {
             var newRect = new Array(2);
             newRect[0] = Vector2d.create(t0.pageX, t0.pageY);
             newRect[1] = Vector2d.create(t1.pageX, t1.pageY);
-            this._twoTouchFrames += 1;
+            this._twoTouchEvents += 1;
 
             if (!this._dragging && this._lastTouchRect[0] != null && this._lastTouchRect[1] != null &&
-                this._twoTouchCenter != null && this._twoTouchFrames > this._twoTouchFrameThreshold) {
+                this._twoTouchCenter != null && this._twoTouchEvents > this._twoTouchEventThreshold) {
 
                 var delta1 = Vector2d.subtract(newRect[0], this._lastTouchRect[0]);
                 var delta2 = Vector2d.subtract(newRect[1], this._lastTouchRect[1]);
@@ -1263,7 +1263,7 @@ var WWTControl$ = {
                 this._lastTouchRect[0] = null;
                 this._lastTouchRect[1] = null;
                 this._twoTouchCenter = null;
-                this._twoTouchFrames = 0;
+                this._twoTouchEvents = 0;
             }
             return;
         }

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -118,6 +118,7 @@ export function WWTControl() {
     this._zooming = false;
     this._rotating = false;
     this._dragThreshold = 4;
+    this._twoTouchCenter = null;
 
     this._foregroundCanvas = null;
     this._fgDevice = null;
@@ -1142,6 +1143,9 @@ var WWTControl$ = {
         this._lastY = ev.targetTouches[0].pageY;
         if (ev.targetTouches.length === 2) {
             this._hasTwoTouches = true;
+            var t0 = ev.touches[0];
+            var t1 = ev.touches[1];
+            this._twoTouchCenter = Vector2d.create(0.5 * (t0.pageX + t1.pageX), 0.5 * (t0.pageY + t1.pageY));
             return;
         }
         if (this.uiController != null) {
@@ -1165,12 +1169,11 @@ var WWTControl$ = {
             newRect[0] = Vector2d.create(t0.pageX, t0.pageY);
             newRect[1] = Vector2d.create(t1.pageX, t1.pageY);
 
-            if (!this._dragging && this._pinchingZoomRect[0] != null && this._pinchingZoomRect[1] != null) {
-                var centerPoint = Vector2d.create(this.renderContext.width / 2, this.renderContext.height / 2);
+            if (!this._dragging && this._pinchingZoomRect[0] != null && this._pinchingZoomRect[1] != null && this._twoTouchCenter != null) {
                 var delta1 = Vector2d.subtract(newRect[0], this._pinchingZoomRect[0]);
                 var delta2 = Vector2d.subtract(newRect[1], this._pinchingZoomRect[1]);
-                var radialDirection1 = Vector2d.subtract(this._pinchingZoomRect[0], centerPoint);
-                var radialDirection2 = Vector2d.subtract(this._pinchingZoomRect[1], centerPoint);
+                var radialDirection1 = Vector2d.subtract(this._pinchingZoomRect[0], this._twoTouchCenter);
+                var radialDirection2 = Vector2d.subtract(this._pinchingZoomRect[1], this._twoTouchCenter);
                 radialDirection1.normalize();
                 radialDirection2.normalize();
                 var radialDot1 = delta1.x * radialDirection1.x + delta1.y * radialDirection1.y;
@@ -1189,10 +1192,10 @@ var WWTControl$ = {
                     this.zoom(ratio);
                     this._zooming = true;
                 } else if (!this._zooming) {
-                    var oldCenterDelta1 = Vector2d.subtract(this._pinchingZoomRect[0], centerPoint);
-                    var oldCenterDelta2 = Vector2d.subtract(this._pinchingZoomRect[1], centerPoint);
-                    var newCenterDelta1 = Vector2d.subtract(newRect[0], centerPoint);
-                    var newCenterDelta2 = Vector2d.subtract(newRect[1], centerPoint);
+                    var oldCenterDelta1 = Vector2d.subtract(this._pinchingZoomRect[0], this._twoTouchCenter);
+                    var oldCenterDelta2 = Vector2d.subtract(this._pinchingZoomRect[1], this._twoTouchCenter);
+                    var newCenterDelta1 = Vector2d.subtract(newRect[0], this._twoTouchCenter);
+                    var newCenterDelta2 = Vector2d.subtract(newRect[1], this._twoTouchCenter);
                     var cross1 = this.crossProductZ(oldCenterDelta1, newCenterDelta1);
                     var cross2 = this.crossProductZ(oldCenterDelta2, newCenterDelta2);
                     var angle1 = Math.asin(cross1 / (oldCenterDelta1.get_length() * newCenterDelta1.get_length()));
@@ -1246,6 +1249,7 @@ var WWTControl$ = {
         if (this._hasTwoTouches) {
             if (ev.touches.length < 2) {
                 this._hasTwoTouches = false;
+                this._twoTouchCenter = null;
             }
             return;
         }

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -117,7 +117,7 @@ export function WWTControl() {
     this._moved = false;
     this._zooming = false;
     this._rotating = false;
-    this._dragThreshold = 4;
+    this._dragThreshold = 8;
     this._twoTouchCenter = null;
 
     this._foregroundCanvas = null;


### PR DESCRIPTION
This PR provides an implementation of the idea discussed in https://github.com/WorldWideTelescope/wwt-webgl-engine/pull/283#issuecomment-1804981457 and the following comment, where the midpoint of the two touch locations is used as the "center point" for calculations, rather than the viewport center.

As discussed there, this allows zooming and rotating from different areas of the screen, although of course the center of these motions is still the viewport center. The implementation here is simple - when a second touch is reported, we calculate the center of the two touches and save that as `_twoCenterTouch`, then use that in the zoom/rotate calculations. When we go down to < 2 touches, we reset that to `null`.

@pkgw Would be curious to know what you think. With this, I think the only major difference between our touch controls and what one usually sees (e.g. Google Maps) is that we don't allow rotating and zooming simultaneously.