### PR TITLE
Allow refreshing tile cache

### DIFF
--- a/docs/engine/research-app-messages-index.md
+++ b/docs/engine/research-app-messages-index.md
@@ -53,3 +53,8 @@ The {@link PingPongMessage} interface is also special. If you send this message 
 app, it will reply with an identical message. This is useful for checking
 whether the app has started up, because usually there is no alternative to
 polling it.
+
+The {@link ClearTileCacheMessage} interface describes a message that, when received by
+the app, will cause it to refresh its current cache of tiles. The primary use case
+for this should be if a network error has caused a necessary tile to fail to load. This
+should be used only when necessary, as it clears all previously downloaded tiles.

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -24,6 +24,7 @@ import {
   LayerMap,
   SpreadSheetLayer,
   SpreadSheetLayerSettingsInterfaceRO,
+  TileCache,
   WWTControl,
 } from "@wwtelescope/engine";
 
@@ -1871,6 +1872,11 @@ export const engineStore = defineStore('wwt-engine', {
       if (this.$wwt.inst === null)
         throw new Error("cannot captureVideo without linking to WWTInstance");
       return this.$wwt.inst.captureVideo(options);
+    },
+
+    /** Clear the current cache of tiles */
+    clearTileCache(): void {
+      TileCache.clearCache();
     }
   },
 });

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -814,7 +814,7 @@ function availableImagesets(): ImagesetInfo[] {
  * - {@link viewAsTourXml}
  * - {@link captureFrame}
  * - {@link captureVideo}
- * - @{link clearTileCache}
+ * - {@link clearTileCache}
  */
 export const engineStore = defineStore('wwt-engine', {
   // NOTE: We were originally alphabetizing these all, but now I think it will

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -814,6 +814,7 @@ function availableImagesets(): ImagesetInfo[] {
  * - {@link viewAsTourXml}
  * - {@link captureFrame}
  * - {@link captureVideo}
+ * - @{link clearTileCache}
  */
 export const engineStore = defineStore('wwt-engine', {
   // NOTE: We were originally alphabetizing these all, but now I think it will
@@ -1874,7 +1875,11 @@ export const engineStore = defineStore('wwt-engine', {
       return this.$wwt.inst.captureVideo(options);
     },
 
-    /** Clear the current cache of tiles */
+    /** Clear the current cache of tiles.
+      * The intended use case here is if a network issue caused a necessary tile to not load.
+      * This should only be used when necessary, as any previously downloaded tiles will need
+      * to be re-fetched.
+      * */
     clearTileCache(): void {
       TileCache.clearCache();
     }

--- a/engine-pinia/src/wwtaware.ts
+++ b/engine-pinia/src/wwtaware.ts
@@ -169,6 +169,7 @@ export const WWTAwareComponent = defineComponent({
       "zoom",
       "move",
       "tilt",
+      "clearTileCache",
     ]),
   }
 });

--- a/engine/esm/index.js
+++ b/engine/esm/index.js
@@ -201,6 +201,7 @@ export {
 export { FitsImageTile } from "./layers/fits_image_tile.js";
 
 export { Tile } from "./tile.js";
+export { TileCache } from "./tile_cache.js";
 export { RenderTriangle } from "./render_triangle.js";
 export { EquirectangularTile } from "./equirectangular_tile.js";
 export { HealpixTile, Xyf } from "./healpix_tile.js";

--- a/engine/esm/tile_cache.js
+++ b/engine/esm/tile_cache.js
@@ -74,6 +74,16 @@ TileCache.getCachedTile = function (level, x, y, dataset, parent) {
 
 set_tileCacheGetCachedTile(TileCache.getCachedTile);
 
+TileCache.clearCache = function() {
+  for (const tile of Object.values(TileCache._tiles)) {
+    try {
+      tile.cleanUp(true);
+    } catch (e) {
+      continue;
+    }
+  }
+}
+
 TileCache.getReadyToRenderTileCount = function () {
     var notReadyCullList = [];
     var readyCullList = [];

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -1923,6 +1923,12 @@ export class SpreadSheetLayer extends Layer implements SpreadSheetLayerSettingsI
  */
 export type SpreadSheetLayerSetting = LayerSetting | BaseSpreadSheetLayerSetting;
 
+/** A class that represents the current cache of loaded tiles. */
+export class TileCache {
+  /** Clear the current cache of tiles */
+  static clearCache(): void;
+}
+
 /** A WWT tour. */
 export class TourDocument {
   /** Get this tour's "attributes and credits" text.

--- a/research-app-messages/src/index.ts
+++ b/research-app-messages/src/index.ts
@@ -361,3 +361,13 @@ export function isPointerUpMessage(o: any): o is PointerUpMessage {  // eslint-d
     typeof o.clientY === "number" &&
     (o.sessionId === undefined || typeof o.sessionId === "string");
 }
+
+export interface ClearTileCacheMessage {
+  /** The tag identifying this message type */
+    event: "clear_tile_cache";
+}
+
+/** Type guard function for {@link ClearTileCacheMessage} */
+export function isClearTileCacheMessage(obj: any): obj is ClearTileCacheMessage {  // eslint-disable-line @typescript-eslint/no-explicit-any
+  return typeof obj.event === "string" && obj.event === "clear_tile_cache";
+}

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -414,6 +414,7 @@ import {
 import {
   classicPywwt,
   isPingPongMessage,
+  isClearTileCacheMessage,
   layers,
   selections,
   settings,
@@ -1892,6 +1893,8 @@ const App = defineComponent({
         this.handleModifyAllSelectability
       );
 
+      this.messageHandlers.set("clear_tile_cache", this.handleClearTileCache);
+
       // Ignore incoming view_state messages. When testing the app, you might want
       // to launch it as (e.g.)
       // `http://localhost:8080/?origin=http://localhost:8080/` so that you can
@@ -2022,6 +2025,13 @@ const App = defineComponent({
       }
 
       return false;
+    },
+
+    handleClearTileCache(msg: any): boolean {
+      if (!isClearTileCacheMessage(msg)) return false;
+
+      this.clearTileCache();
+      return true;
     },
 
     wwtOnPointerMove(event: PointerEvent) {


### PR DESCRIPTION
This PR resolves #290 by adding functionality to allow refreshing the tile cache. The engine-level implementation is based on the existing functionality from the Windows client [here](https://github.com/WorldWideTelescope/wwt-windows-client/blob/master/WWTExplorer3d/TileCache.cs#L42). I've retained the `try`-`catch` nature of the cache clearing in case some particular tile type's `cleanUp` can throw. This new functionality is also exposed to the Pinia layers and the research app messaging so that it can be used in downstream clients (e.g. `pywwt`).

Since the tile cache isn't really something that clients should be manipulating directly, the only function that I've exposed to the Pinia layer is this new method here. Obviously this doesn't place any restriction at the engine JS level, though.