### PR TITLE
keep track of zoomMin

### DIFF
--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -1105,6 +1105,9 @@ var WWTControl$ = {
         if (this.renderContext.targetCamera.zoom > this.get_zoomMax()) {
             this.renderContext.targetCamera.zoom = this.get_zoomMax();
         }
+        if (this.renderContext.targetCamera.zoom < this.get_zoomMin()) {
+            this.renderContext.targetCamera.zoom = this.get_zoomMin();
+        }
         if (!Settings.get_globalSettings().get_smoothPan()) {
             this.renderContext.viewCamera = this.renderContext.targetCamera.copy();
         }


### PR DESCRIPTION
The current version does not check the value of zoomMin when zooming, so nothing changes when it gets set. This just duplicates the logic used for the maximum zoom and uses it for the minimum zoom. 