### PR TITLE
ci: use ubuntu-latest for all images, rather than fixing 20.04

### DIFF
--- a/ci/azure-deployment.yml
+++ b/ci/azure-deployment.yml
@@ -328,7 +328,7 @@ jobs:
 - ${{ if parameters.isRelease }}:
   - job: branch_and_tag
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-latest
     variables:
     - group: Deployment Credentials
     steps:
@@ -346,7 +346,7 @@ jobs:
   - job: github_releases
     dependsOn: branch_and_tag # otherwise, GitHub creates the tags itself!
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-latest
     variables:
     - group: Deployment Credentials
     steps:
@@ -362,7 +362,7 @@ jobs:
 
   - job: yarn_publish
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-latest
     variables:
     - group: Deployment Credentials
     steps:

--- a/ci/azure-main-build.yml
+++ b/ci/azure-main-build.yml
@@ -11,7 +11,7 @@ parameters:
 jobs:
 - job: build_linux
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-latest
   steps:
   - template: azure-job-setup.yml
     parameters:
@@ -122,7 +122,7 @@ jobs:
 
 - job: browserstack
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-latest
   steps:
   - template: azure-job-setup.yml
     parameters:
@@ -167,7 +167,7 @@ jobs:
 
 - job: lint
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-latest
   steps:
   - template: azure-job-setup.yml
     parameters:
@@ -182,7 +182,7 @@ jobs:
 
 - job: docs_engine
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-latest
   steps:
   - template: azure-job-setup.yml
     parameters:
@@ -224,7 +224,7 @@ jobs:
 
 - job: docs_research
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-latest
   steps:
   - template: azure-job-setup.yml
     parameters:


### PR DESCRIPTION
We're not building binary artifacts, so it's not important to have precise control over the OS version here.

Doing this since the release automation failed with a missing `libssl.so.3` just now.