### PR TITLE
Fix issue with time offset at non-unit clock rates

### DIFF
--- a/engine/esm/space_time_controller.js
+++ b/engine/esm/space_time_controller.js
@@ -30,7 +30,7 @@ SpaceTimeController.updateClock = function () {
         var justNow = SpaceTimeController.get_metaNow();
         if (SpaceTimeController._timeRate !== 1) {
             var ts = justNow.getTime() - SpaceTimeController.last.getTime();
-            var ticks = (ts * SpaceTimeController._timeRate);
+            var ticks = (ts * (SpaceTimeController._timeRate - 1));
             SpaceTimeController._offset += ticks;
         }
         SpaceTimeController.last = justNow;


### PR DESCRIPTION
This PR fixes the issue with the WWT clock described in #301. The approach taken here is to make the controller offset be incremented by `Δreal * (rate - 1)` on each update, rather than `Δreal * rate`. The reason for this is that if my clock is running at, say, 3x real speed, I'm becoming more off by 2 additional seconds every second, not 3. Basically, the current offset formula is ignoring the fact that real time is moving forward too.