### PR TITLE
Use mode-dependent bounds in gesture handler

### DIFF
--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -1131,11 +1131,10 @@ var WWTControl$ = {
     onGestureChange: function (e) {
         var g = e;
         this._mouseDown = false;
-        this.renderContext.targetCamera.zoom = this.renderContext.viewCamera.zoom = Math.min(360, this._beginZoom * (1 / g.scale));
+        this.renderContext.targetCamera.zoom = this.renderContext.viewCamera.zoom = Math.max(this.get_zoomMin(), Math.min(this.get_zoomMax(), this._beginZoom * (1 / g.scale)));
     },
 
     onGestureEnd: function (e) {
-        var g = e;
         this._mouseDown = false;
     },
 


### PR DESCRIPTION
This PR resolves #303. The change here is to use `get_zoomMax()` to find the context-dependent max zoom (including accounting for user-specified zoom bounds). Additionally, I also added some logic to make sure that the zoom is greater than the relevant minimum zoom as well.