### PR TITLE
Fix a couple of Zola Markdown links

### DIFF
--- a/docs/engine/content/apiref/_index.md
+++ b/docs/engine/content/apiref/_index.md
@@ -22,12 +22,12 @@ If you’re interested in writing code to control a WWT display, you might want 
 check out the following sections of the documentation:
 
 - For pure JavaScript without any frameworks (the [hosted JavaScript
-  model](../getting-started/hosted-javascript-model.md)) see
+  model](@/getting-started/hosted-javascript-model.md)) see
   [@wwtelescope/engine](./engine/).
 - To control an embedded instance of the research app (the [embedded app
-  model](../getting-started/embedded-app-model.md)) see
+  model](@/getting-started/embedded-app-model.md)) see
   [@wwtelescope/research-app-messages](./research-app-messages/).
 - For a custom component-based web app built with Vue (the [Vue component
-  model](../getting-started/vue-component-model.md)) see [the WWT Pinia
+  model](@/getting-started/vue-component-model.md)) see [the WWT Pinia
   interface](engine-pinia/functions/engineStore.html#md:the-wwt-pinia-interface)
   in [@wwtelescope/engine-pinia](./engine-pinia/).

--- a/docs/engine/content/freestanding-mode/_index.md
+++ b/docs/engine/content/freestanding-mode/_index.md
@@ -58,7 +58,7 @@ following ways:
 
 ## Activating Freestanding Mode
 
-If you are using WWT in [the Vue/Pinia component model](../getting-started/vue-component-model.md),
+If you are using WWT in [the Vue/Pinia component model](@/getting-started/vue-component-model.md),
 activate freestanding mode by specifying the [Vue prop] `wwt-freestanding-asset-baseurl`:
 
 ```xml
@@ -81,14 +81,14 @@ used by the engine. The default value used in the production version of WWT is
 you don’t mind depending on `wwtassets.org`.
 
 If you're using the [bundled TypeScript
-model](../getting-started/bundled-typescript-model.md), you can activate the
+model](@/getting-started/bundled-typescript-model.md), you can activate the
 mode with an analogous parameter,
 {{helpersapi(p="interfaces/InitControlSettings.html#freestandingAssetBaseurl",t="InitControlSettings#freestandingAssetBaseurl")}},
 when calling {{helpersapi(p="classes/WWTInstance.html#constructor",t="the WWTInstance constructor")}}
 provided in the {{helpersapi(p="index.html",t="@wwtelescope/engine-helpers")}} package.
 
 Finally, at the lowest levels of abstraction, such as what you would have in the
-[hosted JavaScript model](../getting-started/hosted-javascript-model.md), you
+[hosted JavaScript model](@/getting-started/hosted-javascript-model.md), you
 can call the {{engineapi(p="classes/WWTControlBuilder.html#freestandingMode",
 t="freestandingMode() method")}} on the
 {{engineapi(p="classes/WWTControlBuilder.html", t="WWTControlBuilder class")}}


### PR DESCRIPTION
I happened to notice that a few of the documentation links are currently broken because they use a relative path syntax instead of Zola's internal link format, which results in the `.md` file extension not being removed and thus the URL being wrong. This PR fixes those.