### PR TITLE
Expose tour-stopping functions to Pinia layer

### DIFF
--- a/ci/azure-main-build.yml
+++ b/ci/azure-main-build.yml
@@ -100,7 +100,7 @@ jobs:
 
 - job: build_macos
   pool:
-    vmImage: macos-11
+    vmImage: macos-latest
   steps:
   - template: azure-job-setup.yml
     parameters:

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -1349,6 +1349,37 @@ export const engineStore = defineStore('wwt-engine', {
       player.play();
     },
 
+    /** Stop playing the currently loaded tour.
+      *
+      * Nothing happens if no tour is currently playing.
+      */
+    stopTour(): void {
+      if (this.$wwt.inst === null)
+        throw new Error('cannot stop tour without linking to WWTInstance');
+
+      const player = this.$wwt.inst.getActiveTourPlayer();
+      if (player === null)
+        throw new Error('no tour to stop');
+
+      // The argument here is currently unused in the engine
+      player.stop(false);
+    },
+
+    /** Close the active tour player, if there is one active.
+      *
+      * Any tour that is currently playing will be stopped.
+      */
+    closeTourPlayer(): void {
+      if (this.$wwt.inst === null)
+        throw new Error('cannot close tour player without linking to WWTInstance');
+
+      const player = this.$wwt.inst.getActiveTourPlayer();
+      if (player !== null) {
+        player.close();
+        this.$wwt.inst.ctl.uiController = null;
+      }
+    },
+
     /** Toggle the play/pause state of the current tour.
      *
      * Nothing happens if no tour is loaded.

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -1378,6 +1378,10 @@ export const engineStore = defineStore('wwt-engine', {
         player.close();
         this.$wwt.inst.ctl.uiController = null;
       }
+
+      this.tourRunTime = null;
+      this.tourStopStartTimes = [];
+      this.tourTimecode = 0;
     },
 
     /** Toggle the play/pause state of the current tour.

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -800,6 +800,8 @@ function availableImagesets(): ImagesetInfo[] {
  * - {@link seekToTourTimecode}
  * - {@link setTourPlayerLeaveSettingsWhenStopped}
  * - {@link startTour}
+ * - {@link stopTour}
+ * - {@link closeTourPlayer}
  * - {@link toggleTourPlayPauseState}
  *
  * ## Miscellaneous

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -1345,10 +1345,7 @@ export const engineStore = defineStore('wwt-engine', {
         throw new Error('cannot start tour without linking to WWTInstance');
 
       const player = this.$wwt.inst.getActiveTourPlayer();
-      if (player === null)
-        throw new Error('no tour to start');
-
-      player.play();
+      player?.play();
     },
 
     /** Stop playing the currently loaded tour.
@@ -1360,11 +1357,9 @@ export const engineStore = defineStore('wwt-engine', {
         throw new Error('cannot stop tour without linking to WWTInstance');
 
       const player = this.$wwt.inst.getActiveTourPlayer();
-      if (player === null)
-        throw new Error('no tour to stop');
 
       // The argument here is currently unused in the engine
-      player.stop(false);
+      player?.stop(false);
     },
 
     /** Close the active tour player, if there is one active.
@@ -1395,11 +1390,9 @@ export const engineStore = defineStore('wwt-engine', {
         throw new Error('cannot play/pause tour without linking to WWTInstance');
 
       const player = this.$wwt.inst.getActiveTourPlayer();
-      if (player === null)
-        throw new Error('no tour to play/pause');
 
       // Despite the unclear name, this function does toggle play/pause state.
-      player.pauseTour();
+      player?.pauseTour();
     },
 
     /** Set whether the renderer settings of tours should remain applied after

--- a/engine-pinia/src/wwtaware.ts
+++ b/engine-pinia/src/wwtaware.ts
@@ -136,6 +136,8 @@ export const WWTAwareComponent = defineComponent({
       "loadFitsLayer",
       "addImageSetLayer",
       "loadTour",
+      "stopTour",
+      "closeTourPlayer",
       "viewAsTourXml",
       "waitForReady",
       // Formerly mutations


### PR DESCRIPTION
While working on our newest WWT-based Cosmic Data Story, I noticed that the Pinia layer currently doesn't expose any way to stop a currently playing tour. This PR looks to remedy that by adding two new methods to the Pinia store; one for stopping a currently playing tour, and another to close the currently active tour player. These largely wrap the tour player methods. `closeTourPlayer` also updates some store-level data regarding the current tour state and sets the `uiController` of the `WWTControl` to be null (which moves the main control back to its default rendering mode).

I noticed that there are existing methods inside of the `WWTControl` to play and pause the current tour, but that our store methods instead use the tour player directly; for consistency I followed the same pattern here.