### PR TITLE
Allow specifying duration of movement time

### DIFF
--- a/engine-helpers/src/index.ts
+++ b/engine-helpers/src/index.ts
@@ -171,6 +171,9 @@ export interface GotoTargetOptions {
   /** If true, the camera will continue tracking the view target as it moves
    * with the progression of the WWT internal clock. */
   trackObject: boolean;
+
+  /** Optional: The desired duration of the movement */
+  duration?: number;
 }
 
 
@@ -503,15 +506,17 @@ export class WWTInstance {
    * @param zoomDeg The zoom setting, in *degrees*
    * @param instant Whether to snap the camera instantly, or pan it
    * @param rollRad If specified, the roll of the target camera position, in radians
+   * @param duration If specified, the duration of the motion (in seconds)
    * @returns A void promise that resolves when the camera arrives at the target position.
    */
-  async gotoRADecZoom(raRad: number, decRad: number, zoomDeg: number, instant: boolean, rollRad?: number): Promise<void> {
+  async gotoRADecZoom(raRad: number, decRad: number, zoomDeg: number, instant: boolean, rollRad?: number, duration?: number): Promise<void> {
     this.ctl.gotoRADecZoom(
       raRad * R2H,
       decRad * R2D,
       zoomDeg,
       instant,
-      rollRad
+      rollRad,
+      duration,
     );
     return this.makeArrivePromise(instant);
   }

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -499,6 +499,9 @@ export interface GotoRADecZoomParams {
 
   /** Optional: The target roll of the camera, in radians. */
   rollRad?: number;
+
+  /** Optional: The desired duration of the movement */
+  duration?: number;
 }
 
 /** The parameters for the {{@link engineStore.loadTour} action. */
@@ -1485,11 +1488,11 @@ export const engineStore = defineStore('wwt-engine', {
      * TODO: document semantics when not in 2D sky mode!
      */
     async gotoRADecZoom(
-      { raRad, decRad, zoomDeg, instant, rollRad }: GotoRADecZoomParams
+      { raRad, decRad, zoomDeg, instant, rollRad, duration }: GotoRADecZoomParams
     ): Promise<void> {
       if (this.$wwt.inst === null)
         throw new Error('cannot gotoRADecZoom without linking to WWTInstance');
-      return this.$wwt.inst.gotoRADecZoom(raRad, decRad, zoomDeg, instant, rollRad);
+      return this.$wwt.inst.gotoRADecZoom(raRad, decRad, zoomDeg, instant, rollRad, duration);
     },
 
     /** Returns the time it would take, in seconds, to navigate to the given target. */

--- a/engine/esm/script_interface.js
+++ b/engine/esm/script_interface.js
@@ -461,9 +461,9 @@ var ScriptInterface$ = {
         }
     },
 
-    gotoRaDecZoom: function (ra, dec, zoom, instant, roll) {
+    gotoRaDecZoom: function (ra, dec, zoom, instant, roll, duration) {
         if (globalWWTControl != null) {
-            globalWWTControl.gotoRADecZoom(ra / 15, dec, zoom * 6, instant, roll);
+            globalWWTControl.gotoRADecZoom(ra / 15, dec, zoom * 6, instant, roll, duration);
         }
     },
 

--- a/engine/esm/view_mover.js
+++ b/engine/esm/view_mover.js
@@ -112,9 +112,17 @@ export function ViewMoverSlew() {
     this._complete = false;
 }
 
-ViewMoverSlew.create = function (from, to) {
+ViewMoverSlew.create = function (from, to, duration) {
     var temp = new ViewMoverSlew();
     temp.init(from, to);
+    if (duration) {
+      const originalTargetTime = temp._toTargetTime;
+      const upFraction = temp._upTargetTime / originalTargetTime;
+      const downFraction = temp._downTargetTime / originalTargetTime;
+      temp._upTargetTime = duration * upFraction;
+      temp._downTargetTime = duration * downFraction;
+      temp._toTargetTime = duration; 
+    }
     return temp;
 };
 
@@ -123,18 +131,6 @@ ViewMoverSlew.createUpDown = function (from, to, upDowFactor) {
     temp._upTimeFactor = temp._downTimeFactor = upDowFactor;
     temp.init(from.copy(), to.copy());
     return temp;
-};
-
-ViewMoverSlew.createWithDuration = function (from, to, duration) {
-  var temp = new ViewMoverSlew();
-  temp.init(from.copy(), to.copy());
-  const originalTargetTime = temp._toTargetTime;
-  const upFraction = temp._upTargetTime / originalTargetTime;
-  const downFraction = temp._downTargetTime / originalTargetTime;
-  temp._upTargetTime = duration * upFraction;
-  temp._downTargetTime = duration * downFraction;
-  temp._toTargetTime = duration; 
-  return temp;
 };
 
 var ViewMoverSlew$ = {

--- a/engine/esm/view_mover.js
+++ b/engine/esm/view_mover.js
@@ -125,6 +125,18 @@ ViewMoverSlew.createUpDown = function (from, to, upDowFactor) {
     return temp;
 };
 
+ViewMoverSlew.createWithDuration = function (from, to, duration) {
+  var temp = new ViewMoverSlew();
+  temp.init(from.copy(), to.copy());
+  const originalTargetTime = temp._toTargetTime;
+  const upFraction = temp._upTargetTime / originalTargetTime;
+  const downFraction = temp._downTargetTime / originalTargetTime;
+  temp._upTargetTime = duration * upFraction;
+  temp._downTargetTime = duration * downFraction;
+  temp._toTargetTime = duration; 
+  return temp;
+};
+
 var ViewMoverSlew$ = {
     init: function (from, to) {
         if (Math.abs(from.lng - to.lng) > 180) {

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -2549,16 +2549,18 @@ export class WWTControl {
    * @param zoom The target zoom level (see below)
    * @param instant Whether to snap the view instantly or move gradually.
    * @param roll_deg Optional, The roll of the camera, in degrees.
+   * @param duration Optional, The duration of the motion, in seconds.
    *
    * If `instant` is true or the commanded camera position is extremely close to the
    * current camera position, the view will update instantly. Otherwise it will
-   * scroll there smoothly, taking an unpredictable amount of time to arrive.
+   * scroll there smoothly. If no duration is specified, it will take an unpredictable
+   * amount of time to arrive.
    *
    * The zoom level is the height of the viewport in degrees, times six.
    *
    * Navigating the view in this way ends any "tracking" status of the current view.
    */
-  gotoRADecZoom(ra_hours: number, dec_deg: number, zoom: number, instant: boolean, roll_deg?: number): void;
+  gotoRADecZoom(ra_hours: number, dec_deg: number, zoom: number, instant: boolean, roll_deg?: number, duration?: number): void;
 
   /** Returns how long moving to the given position will take, in seconds.
  *
@@ -2579,10 +2581,11 @@ export class WWTControl {
    * @param instant If true, the view camera will immediately snap to the
    * destination position. Otherwise, it will gradually move.
    * @param trackObject If true, the camera will continue tracking the view
+   * @param duration If specified, the duration of the motion (in seconds)
    * target as it moves with the progression of the WWT internal clock.
    *
    */
-  gotoTarget(place: Place, noZoom: boolean, instant: boolean, trackObject: boolean): void;
+  gotoTarget(place: Place, noZoom: boolean, instant: boolean, trackObject: boolean, duration?: number): void;
 
   /** Change the zoom of the current view. The change is not necessarily
    * instantaneous, depending on whether the "smooth pan" setting is activated.


### PR DESCRIPTION
This PR implements something that we want in CosmicDS, which is the ability to specify the duration of a movement between two locations.

As for how I implemented this:
* Add a new optional `duration` parameter to our parameters that control goto movements. This represents the desired duration of the move, in seconds.
* We have two view mover classes: `ViewMoverKenBurnsStyle` and `ViewMoverSlew`. The Ken Burns-style mover already has a parameter for the time to target, so almost all of the work here is for the slew mover. We generally create the slew mover via its `create` function (in fact, I think that's the only way that we do in the codebase), so I've updated that function to take in a `duration` parameter. If the caller doesn't pass anything in, this will be undefined, and the behavior is left unchanged from what it is currently
    - My original plan had been to do something like `createUpDown`, and set appropriate values for the various factors to give the desired duration. However, this isn't possible due to the second term in [this line](https://github.com/Carifio24/wwt-webgl-engine/blob/27bffda195389d0752e8bcf0d6e2c95939607265/engine/esm/view_mover.js#L173), which doesn't have a prefactor that we can adjust. Thus, the approach taken here is a simpler one: create the view mover and let it figure out its times, then adjust the up/down/total times to have the same relative sizes, just scaled to fit the desired duration. This works because only the target time variables are used for the interpolation - the up/down/travel factors are only used in `init`. If not for how they're used in `createUpDown` (whose API I assume we don't want to change), they could just be scoped to that function.
* The rest of the PR is then just plumbing this new functionality through the various layers of the codebase

If anyone wants to test this out, I've set up a demo [here](https://carifio24.github.io/testing/wwt-move-time/) that allows specifying the various parameters. Similar to the time functionality exposed in #222, the actual time for the movement will within a few milliseconds of the requested duration.