### PR TITLE
Allow getting roll angle from script interface

### DIFF
--- a/engine/esm/script_interface.js
+++ b/engine/esm/script_interface.js
@@ -710,7 +710,14 @@ var ScriptInterface$ = {
             return globalRenderContext.viewCamera.zoom / 6;
         }
         return 60;
-    }
+    },
+
+    get_roll: function() {
+        if (globalRenderContext != null) {
+            return globalRenderContext.viewCamera.rotation;
+        }
+      return 0;
+    },
 };
 
 registerType("ScriptInterface", [ScriptInterface, ScriptInterface$, null]);


### PR DESCRIPTION
This PR adds a method to allow getting the roll angle from the script interface. This is the easiest way I can think of to allow fixing https://github.com/WorldWideTelescope/wwt-web-client/issues/367. We already allow getting RA/Dec/FoV, may as well expose the roll angle too.