### PR TITLE
Fix issues with research app finder scope

### DIFF
--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -3111,6 +3111,12 @@ const App = defineComponent({
       }
     },
 
+    showFinderScope(show: boolean) {
+      if (!show) {
+        this.finderScopeActive = false;
+      }
+    },
+
     sources: {
       handler(sources: Source[]) {
         // Notify clients when the list of selected sources is changed

--- a/ui-components/src/FinderScope.vue
+++ b/ui-components/src/FinderScope.vue
@@ -121,6 +121,10 @@ export default defineComponent({
     "place": (_place: Place | null) => true,
   },
 
+  unmounted() {
+    this.clearCircle();
+  },
+
   methods: {
     ...mapActions(engineStore, [
       "addAnnotation",
@@ -425,7 +429,6 @@ export default defineComponent({
       if (!value) {
         this.place = null;
       }
-
       this.$nextTick(() => {
         if (value && !this.crosshairsDrawn) {
           this.drawCrosshairs();


### PR DESCRIPTION
This PR fixes two issues with the finder scope and its embedding into the research app
* Fix an issue where the research app's finder scope could fail to draw the crosshairs. This could only happen after enabling the finder scope setting, opening the finder scope, and then disabling and re-enabling the finder scope setting.
* Fix an issue where the finder scope could fail to clear its circle annotation when removed.