### PR TITLE
Allow drawing ecliptic circle

### DIFF
--- a/engine-types/src/index.ts
+++ b/engine-types/src/index.ts
@@ -289,6 +289,7 @@ export type BaseEngineSetting =
   ["showCrosshairs", boolean] |
   ["showEarthSky", boolean] |
   ["showEcliptic", boolean] |
+  ["showEclipticCircle", boolean] |
   ["showEclipticGrid", boolean] |
   ["showEclipticGridText", boolean] |
   ["showEclipticOverviewText", boolean] |
@@ -355,6 +356,7 @@ const baseEngineSettingTypeInfo = {
   "showCrosshairs/boolean": true,
   "showEarthSky/boolean": true,
   "showEcliptic/boolean": true,
+  "showEclipticCircle/boolean": true,
   "showEclipticGrid/boolean": true,
   "showEclipticGridText/boolean": true,
   "showEclipticOverviewText/boolean": true,

--- a/engine/esm/grids.js
+++ b/engine/esm/grids.js
@@ -421,8 +421,7 @@ Grids._makeEquitorialGridText = function () {
     }
 };
 
-Grids.drawEcliptic = function (renderContext, opacity, drawColor) {
-    var col = drawColor;
+Grids.drawEcliptic = function (renderContext, opacity, drawColor, drawCircle) {
     var year = SpaceTimeController.get_now().getUTCFullYear();
     if (Grids._eclipticOverviewLineList == null || year !== Grids._eclipticYear) {
         if (Grids._eclipticOverviewLineList != null) {
@@ -440,11 +439,12 @@ Grids.drawEcliptic = function (renderContext, opacity, drawColor) {
             Grids._monthDays[1] = 28;
             daysPerYear = 365;
         }
-        var count = 2 * ss.truncate(daysPerYear);
         Grids._eclipticCount = ss.truncate(daysPerYear);
         var jYear = SpaceTimeController.utcToJulian(new Date(year, 0, 1, 12, 0, 0));
         var index = 0;
         var d = 0;
+        var dPrev = 0;
+        var dStart = 0;
         Grids._eclipticOverviewLineList = new SimpleLineList();
         Grids._eclipticOverviewLineList.set_depthBuffered(false);
         for (var m = 0; m < 12; m++) {
@@ -453,16 +453,26 @@ Grids.drawEcliptic = function (renderContext, opacity, drawColor) {
                 var sunRaDec = Planets.getPlanetLocationJD('Sun', jYear);
                 var sunEcliptic = CT.eq2Ec(sunRaDec.RA, sunRaDec.dec, obliquity);
                 d = sunEcliptic.x;
+                if (i == 0 && m == 0) {
+                    dStart = d;
+                }
                 var width = 0.005;
                 if (!i) {
                     width = 0.01;
                 }
                 var dd = d;
                 Grids._eclipticOverviewLineList.addLine(Vector3d._transformCoordinate(Vector3d.create(Math.cos((dd * Math.PI * 2) / 360), width, Math.sin((dd * Math.PI * 2) / 360)), mat), Vector3d._transformCoordinate(Vector3d.create(Math.cos((dd * Math.PI * 2) / 360), -width, Math.sin((dd * Math.PI * 2) / 360)), mat));
+                if (drawCircle && !(i == 0 && m == 0)) {
+                    Grids._eclipticOverviewLineList.addLine(Vector3d._transformCoordinate(Vector3d.create(Math.cos((dd * Math.PI * 2) / 360), 0, Math.sin((dd * Math.PI * 2) / 360)), mat), Vector3d._transformCoordinate(Vector3d.create(Math.cos((dPrev * Math.PI * 2) / 360), 0, Math.sin((dPrev * Math.PI * 2) / 360)), mat));
+                }
                 index++;
                 jYear += 1;
+                dPrev = d;
             }
             d += Grids._monthDays[m];
+        }
+        if (drawCircle) {
+            Grids._eclipticOverviewLineList.addLine(Vector3d._transformCoordinate(Vector3d.create(Math.cos((dStart * Math.PI * 2) / 360), 0, Math.sin((dStart * Math.PI * 2) / 360)), mat), Vector3d._transformCoordinate(Vector3d.create(Math.cos((dd * Math.PI * 2) / 360), 0, Math.sin((dd * Math.PI * 2) / 360)), mat));
         }
     }
     Grids._eclipticOverviewLineList.drawLines(renderContext, opacity, drawColor);

--- a/engine/esm/settings.js
+++ b/engine/esm/settings.js
@@ -105,6 +105,7 @@ export function Settings() {
     this._showCrosshairs = true;
     this._crosshairsColor = 'white';
     this._showEcliptic = false;
+    this._showEclipticCircle = false;
     this._locationLat = 47.717;
     this._locationLng = -122.0858;
     this._locationAltitude = 100;
@@ -337,6 +338,15 @@ var Settings$ = {
 
     set_showEcliptic: function (value) {
         this._showEcliptic = value;
+        return value;
+    },
+
+    get_showEclipticCircle: function () {
+        return this._showEclipticCircle;
+    },
+
+    set_showEclipticCircle: function (value) {
+        this._showEclipticCircle = value;
         return value;
     },
 

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -930,7 +930,7 @@ var WWTControl$ = {
             Grids.drawPrecessionChart(this.renderContext, 1, Settings.get_active().get_precessionChartColor());
         }
         if (Settings.get_active().get_showEcliptic()) {
-            Grids.drawEcliptic(this.renderContext, 1, Settings.get_active().get_eclipticColor());
+            Grids.drawEcliptic(this.renderContext, 1, Settings.get_active().get_eclipticColor(), Settings.get_active().get_showEclipticCircle());
             if (Settings.get_active().get_showEclipticOverviewText()) {
                 Grids.drawEclipticText(this.renderContext, 1, Settings.get_active().get_eclipticColor());
             }

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -1621,6 +1621,8 @@ export class Settings implements EngineSettingsInterface {
   set_showConstellationSelection(v: boolean): boolean;
   get_showEcliptic(): boolean;
   set_showEcliptic(v: boolean): boolean;
+  get_showEclipticCircle(): boolean;
+  set_showEclipticCircle(v: boolean): boolean;
   get_showElevationModel(): boolean;
   set_showElevationModel(v: boolean): boolean;
   get_showFieldOfView(): boolean;


### PR DESCRIPTION
This PR adds the ability to connect the ecliptic ticks via a circle. This is something that we want for CosmicDS (see our [Planet Parade](https://github.com/cosmicds/planet-parade) story), so I figured that this might as well be made available for WWT users in general.

This is controlled via a new engine setting, `showEclipticCircle`. This is set to false by default, and only has an effect if `showEcliptic` is turned on. This setup ensures backwards compatibility - existing clients won't be adjusting this previously nonexisting setting, so they'll get the standard non-circle ecliptic.