### PR TITLE
Replace broken link in documentation

### DIFF
--- a/docs/engine/content/tutorial/add-image/index.md
+++ b/docs/engine/content/tutorial/add-image/index.md
@@ -122,8 +122,9 @@ See also the [WWT Data Guide].
 
 You might note that we’re piling up a lot of callbacks here. We sure are!
 There’s a reason that web developers talk about [callback
-hell](http://callbackhell.com) — this style of programming rapidly becomes very
-hard to scale and maintain. **This is why we strongly recommend avoiding plain
+hell](https://www.geeksforgeeks.org/javascript/what-to-understand-callback-and-callback-hell-in-javascript/)
+— this style of programming rapidly becomes very hard to scale and maintain.
+**This is why we strongly recommend avoiding plain
 JavaScript when building complex WWT apps.** More sophisticated models like the
 [Vue component model](@/getting-started/vue-component-model.md), or even the
 [TypeScript model](@/getting-started/bundled-typescript-model.md) with `async`


### PR DESCRIPTION
`zola check` very nicely pointed out to us in CI that http://callbackhell.com is now broken - indeed, it seems that the site is totally down/no longer exists. Thus this PR updates this link to point [here](https://www.geeksforgeeks.org/javascript/what-to-understand-callback-and-callback-hell-in-javascript/), another description of callback hell that isn't broken. If the callbackhell website comes back online at some point, we can always re-point to that instead.