### PR TITLE
Screen <---> world conversions in 3D mode

### DIFF
--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -25,6 +25,7 @@ import {
   SpreadSheetLayer,
   SpreadSheetLayerSettingsInterfaceRO,
   TileCache,
+  Vector3d,
   WWTControl,
 } from "@wwtelescope/engine";
 
@@ -664,6 +665,9 @@ function availableImagesets(): ImagesetInfo[] {
  *
  * - {@link findRADecForScreenPoint}
  * - {@link findScreenPointForRADec}
+ * - {@link findCoordinatesForScreenPoint}
+ * - {@link findScreenPointForCoordinates}
+ * - {@link findRayForScreenPoint}
  *
  * Actions:
  *
@@ -914,15 +918,31 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
-    /** Given a lon/lat or RA/Dec position in degrees, return the x, y coordinates of the screen point */
+    /** Given world space coordinates, return the x and y coordinates of the corresponding screen point
+     *
+     * In Sky mode, (x, y) means (RA, Dec)
+     * In planet-like modes (Earth and Planet), (x, y) means (lon, lat)
+     * In Solar System mode, this is the (x, y, z) coordinates
+     */
     findScreenPointForCoordinates(_state) {
-      return (pt: { lng: number; lat: number }): { x: number; y: number; } => {
+      return (pt: { x: number; y: number; z?: number }): { x: number; y: number; } => {
         if (this.$wwt.inst === null)
           throw new Error('cannot findScreenPointForCoordinates without linking to WWTInstance');
-        let lng = pt.lng;
+        let x = pt.x;
         if (this.backgroundImageset?.get_dataSetType() === ImageSetType.sky)
-          lng /= 15;
-        return this.$wwt.inst.ctl.getScreenPointForCoordinates(lng, pt.lat);
+          x /= 15;
+        return this.$wwt.inst.ctl.getScreenPointForCoordinates(x, pt.y, pt.z ?? 0);
+      }
+    },
+
+    /**
+     *
+     */
+    findRayForScreenPoint(_state) {
+      return (pt: { x: number; y: number; near?: number; far?: number; }): [Vector3d, Vector3d] => {
+        if (this.$wwt.inst === null)
+          throw new Error('cannot findRayForScreenPoint without linking to WWTInstance');
+        return this.$wwt.inst.ctl.getRayForScreenPoint(pt.x, pt.y, pt.near ?? -1, pt.far ?? 1); 
       }
     },
 

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -949,13 +949,20 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
-    /**
+    /** This method is for 3D mode only. If used outside of 3D mode, an error is thrown.
+     * It returns a list of two vectors that correspond to the given screen point.
+     * Optionally one can specific z-values for the near and far planes
      *
+     * The first vector n corresponds to the point on the near plane that corresponds to the screen point.
+     * The second vector v gives the direction of the 3d world space ray defined by the point,
+     * so points along the ray n + v * t with t > 0 will lie at the given screen point.
      */
     findRayForScreenPoint(_state) {
       return (pt: { x: number; y: number; near?: number; far?: number; }): [Vector3d, Vector3d] => {
         if (this.$wwt.inst === null)
           throw new Error('cannot findRayForScreenPoint without linking to WWTInstance');
+        if (this.backgroundImageset?.get_dataSetType() !== ImageSetType.solarSystem)
+          throw new Error('can only find ray for screen point in Solar System mode');
         return this.$wwt.inst.ctl.getRayForScreenPoint(pt.x, pt.y, pt.near ?? -1, pt.far ?? 1); 
       }
     },

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -901,20 +901,34 @@ export const engineStore = defineStore('wwt-engine', {
       }
     },
 
-    /** Get the coordinates, in degrees, for x, y coordinates on the screen */
+    /** Get the coordinates, in degrees, for x, y coordinates on the screen
+     *
+     * In Sky mode, (x, y) means (RA, Dec)
+     * In planet-like modes (Earth and Planet), (x, y) means (lon, lat)
+     * In Solar System mode, this is the (x, y, z) coordinates
+     */
     findCoordinatesForScreenPoint(_state) {
-      return (pt: { x: number; y: number; }): { lng: number; lat: number } | null => {
+      return (pt: { x: number; y: number; }): { x: number; y: number, z?: number } | null => {
         if (this.$wwt.inst === null)
           throw new Error('cannot findCoordinatesForScreenPoint without linking to WWTInstance');
         const coords = this.$wwt.inst.ctl.getCoordinatesForScreenPoint(pt.x, pt.y);
-        if (coords === null) {
+        const background = this.backgroundImageset;
+        if (coords === null || background === null) {
           return null;
         }
-        if (this.backgroundImageset?.get_dataSetType() === ImageSetType.sky) {
-          return { lng: (15 * coords.x + 720) % 360, lat: coords.y };
-        } else {
-          return { lng: coords.x, lat: coords.y };
+
+        switch (background.get_dataSetType()) {
+          case ImageSetType.sky:
+            return { x: (15 * coords.x + 720) % 360, y: coords.y };
+          case ImageSetType.earth:
+          case ImageSetType.planet:
+            return { x: coords.x, y: coords.y };
+          case ImageSetType.solarSystem:
+            return { x: coords.x, y: coords.y, z: coords.z };
+          default:
+            return null;
         }
+
       }
     },
 

--- a/engine-pinia/src/wwtaware.ts
+++ b/engine-pinia/src/wwtaware.ts
@@ -111,6 +111,7 @@ export const WWTAwareComponent = defineComponent({
       "findScreenPointForRADec",
       "findCoordinatesForScreenPoint",
       "findScreenPointForCoordinates",
+      "findRayForScreenPoint",
       "layerById",
       "imagesetForLayer",
       "imagesetLayerById",

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -1523,7 +1523,8 @@ var WWTControl$ = {
         var planetMode = this.get_planetLike();
 
         if (planetMode) {
-          var [pointNear, diff] = this.getRayForScreenPoint(x, y);
+          const near = planetMode ? -1 : this.renderContext.nearPlane;
+          var [pointNear, diff] = this.getRayForScreenPoint(x, y, near);
           diff.normalize();
 
           var planetRadius = 1;
@@ -1555,10 +1556,8 @@ var WWTControl$ = {
         }
     },
 
-    getRayForScreenPoint: function (x, y) {
+    getRayForScreenPoint: function (x, y, near=-1, far=1) {
       var pt = Vector2d.create(x, y);
-      var near = -1;
-      var far = 1;
       var pointFar = this.transformPickPointToWorldSpace(pt, this.renderContext.width, this.renderContext.height, false, far);
       var pointNear = this.transformPickPointToWorldSpace(pt, this.renderContext.width, this.renderContext.height, false, near);
       var diff = Vector3d.create(pointFar.x - pointNear.x, pointFar.y - pointNear.y, pointFar.z - pointNear.z);

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -1292,13 +1292,6 @@ var WWTControl$ = {
         var index = 0;
         var evt = arguments[0], cnv = arguments[0].target; if (cnv.setPointerCapture) { cnv.setPointerCapture(evt.pointerId); } else if (cnv.msSetPointerCapture) { cnv.msSetPointerCapture(evt.pointerId); }
 
-        console.log("------------");
-        console.log(this.getScreenPointForCoordinates(0, 0, 0));
-        const mars = Planets._planet3dLocations[3];
-        console.log(mars);
-        console.log(this.getScreenPointForCoordinates(mars.x, mars.y, mars.z));
-        console.log("------------");
-
         // Check for this pointer already being in the list because as of July
         // 2020, Chrome/Mac sometimes fails to deliver the pointerUp event.
 

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -1625,6 +1625,9 @@ var WWTControl$ = {
         var planetMode = this.get_planetLike();
         var cartesian;
         if (planetMode) {
+          // We (human users) measure longitude from 180 W -> 180 E, or in (-180, 180)
+          // But the internal spherical coordinate system runs from (0, 360)
+          // so we bump (-180, 180) -> (0, 360) by adding 180
           x += 180;
           cartesian = Coordinates.geoTo3d(y, x);
         } else if (this.get_solarSystemMode()) {

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -1523,8 +1523,7 @@ var WWTControl$ = {
         var planetMode = this.get_planetLike();
 
         if (planetMode) {
-          const near = planetMode ? -1 : this.renderContext.nearPlane;
-          var [pointNear, diff] = this.getRayForScreenPoint(x, y, near);
+          var [pointNear, diff] = this.getRayForScreenPoint(x, y);
           diff.normalize();
 
           var planetRadius = 1;

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -1292,6 +1292,13 @@ var WWTControl$ = {
         var index = 0;
         var evt = arguments[0], cnv = arguments[0].target; if (cnv.setPointerCapture) { cnv.setPointerCapture(evt.pointerId); } else if (cnv.msSetPointerCapture) { cnv.msSetPointerCapture(evt.pointerId); }
 
+        console.log("------------");
+        console.log(this.getScreenPointForCoordinates(0, 0, 0));
+        const mars = Planets._planet3dLocations[3];
+        console.log(mars);
+        console.log(this.getScreenPointForCoordinates(mars.x, mars.y, mars.z));
+        console.log("------------");
+
         // Check for this pointer already being in the list because as of July
         // 2020, Chrome/Mac sometimes fails to deliver the pointerUp event.
 
@@ -1516,15 +1523,10 @@ var WWTControl$ = {
         var planetMode = this.get_planetLike();
 
         if (planetMode) {
-          var planetRadius = 1;
-
-          var near = -1;
-          var far = 1;
-          var pointFar = this.transformPickPointToWorldSpace(pt, this.renderContext.width, this.renderContext.height, false, far);
-          var pointNear = this.transformPickPointToWorldSpace(pt, this.renderContext.width, this.renderContext.height, false, near);
-          var diff = Vector3d.create(pointFar.x - pointNear.x, pointFar.y - pointNear.y, pointFar.z - pointNear.z);
+          var [pointNear, diff] = this.getRayForScreenPoint(x, y);
           diff.normalize();
 
+          var planetRadius = 1;
           var b = 2 * Vector3d.dot(pointNear, diff);
           var pointNearLenSq = Vector3d.getLengthSq(pointNear);
           var c = pointNearLenSq - planetRadius * planetRadius;
@@ -1551,6 +1553,17 @@ var WWTControl$ = {
           var PickRayDir = this.transformPickPointToWorldSpace(pt, this.renderContext.width, this.renderContext.height);
           return Coordinates.cartesianToSphericalSky(PickRayDir);
         }
+    },
+
+    getRayForScreenPoint: function (x, y) {
+      var pt = Vector2d.create(x, y);
+      var near = -1;
+      var far = 1;
+      var pointFar = this.transformPickPointToWorldSpace(pt, this.renderContext.width, this.renderContext.height, false, far);
+      var pointNear = this.transformPickPointToWorldSpace(pt, this.renderContext.width, this.renderContext.height, false, near);
+      var diff = Vector3d.create(pointFar.x - pointNear.x, pointFar.y - pointNear.y, pointFar.z - pointNear.z);
+      
+      return [pointNear, diff];
     },
 
     transformPickPointToWorldSpace: function (ptCursor, backBufferWidth, backBufferHeight, normalize=true, z=-1) {
@@ -1606,15 +1619,18 @@ var WWTControl$ = {
         return p;
     },
 
-    // In Sky mode, (lon, lat) means (ra, dec)
-    getScreenPointForCoordinates: function (lon, lat) {
+    // In Sky mode, (x, y) means (ra, dec)
+    // In planet-like modes, (x, y) means (lon, lat)
+    getScreenPointForCoordinates: function (x, y, z=0) {
         var planetMode = this.get_planetLike();
         var cartesian;
         if (planetMode) {
-          lon += 180;
-          cartesian = Coordinates.geoTo3d(lat, lon);
+          x += 180;
+          cartesian = Coordinates.geoTo3d(y, x);
+        } else if (this.get_solarSystemMode()) {
+          cartesian = Vector3d.create(x, y, z); 
         } else {
-          var pt = Vector2d.create(lon, lat);
+          var pt = Vector2d.create(x, y);
           cartesian = Coordinates.sphericalSkyToCartesian(pt);
         }
         var result = this.transformWorldPointToPickSpace(cartesian, this.renderContext.width, this.renderContext.height);

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -2773,6 +2773,7 @@ export class WWTControl {
   getScreenPointForCoordinates(x: number, y: number, z?: number): { x: number; y: number };
 
   /** For 3D mode: Return a list of two vectors corresponding to the given screen point.
+   * Specific z-values for the near and far planes can optionally be specified.
    *
    * The first vector n corresponds to the point on the near plane that corresponds to the screen point.
    * The second vector v gives the direction of the 3d world space ray defined by the point,

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -2755,8 +2755,14 @@ export class WWTControl {
   /** Remove a previously loaded "catalog HiPS" dataset from the view. */
   removeCatalogHipsByName(name: string): void;
 
-  /** Given x and y coordinates on the screen, returns the RA and Dec */
-  getCoordinatesForScreenPoint(x: number, y: number): { x: number; y: number };
+  /**
+   * Given x and y coordinates on the screen, returns the RA and Dec
+   *
+   * In Sky mode, (x, y) means (RA, Dec)
+   * In planet-like modes (Earth and Planet), (x, y) means (lon, lat)
+   * In Solar System mode, this is the (x, y, z) coordinates
+   */
+  getCoordinatesForScreenPoint(x: number, y: number): { x: number; y: number; z?: number; };
 
   /** Given world space coordinates, return the x and y coordinates of the corresponding screen point
    *

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -2761,6 +2761,14 @@ export class WWTControl {
   /** Given RA and Dec, return the x and y coordinates of the corresponding screen point */
   getScreenPointForCoordinates(ra: number, dec: number): { x: number; y: number };
 
+  /** For 3D mode: Return a list of two vectors corresponding to the given screen point.
+   *
+   * The first vector n corresponds to the point on the near plane that corresponds to the screen point.
+   * The second vector v gives the direction of the 3d world space ray defined by the point,
+   * so points along the ray n + v * t with t > 0 will lie at the given screen point.
+   */
+  getRayForScreenPoint(x: number, y: number): [Vector3d, Vector3d];
+
   /** Start loading the tour stored at the specified URL.
    *
    * When loading is complete, a `tourReady` event will be issued, which you can

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -2758,8 +2758,13 @@ export class WWTControl {
   /** Given x and y coordinates on the screen, returns the RA and Dec */
   getCoordinatesForScreenPoint(x: number, y: number): { x: number; y: number };
 
-  /** Given RA and Dec, return the x and y coordinates of the corresponding screen point */
-  getScreenPointForCoordinates(ra: number, dec: number): { x: number; y: number };
+  /** Given world space coordinates, return the x and y coordinates of the corresponding screen point
+   *
+   * In Sky mode, (x, y) means (RA, Dec)
+   * In planet-like modes (Earth and Planet), (x, y) means (lon, lat)
+   * In Solar System mode, this is the (x, y, z) coordinates
+   */
+  getScreenPointForCoordinates(x: number, y: number, z?: number): { x: number; y: number };
 
   /** For 3D mode: Return a list of two vectors corresponding to the given screen point.
    *
@@ -2767,7 +2772,7 @@ export class WWTControl {
    * The second vector v gives the direction of the 3d world space ray defined by the point,
    * so points along the ray n + v * t with t > 0 will lie at the given screen point.
    */
-  getRayForScreenPoint(x: number, y: number): [Vector3d, Vector3d];
+  getRayForScreenPoint(x: number, y: number, near?: number, far?: number): [Vector3d, Vector3d];
 
   /** Start loading the tour stored at the specified URL.
    *

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -377,7 +377,7 @@ import { Source, researchAppStore } from "./store";
 import { wwtEngineNamespace } from "./namespaces";
 
 import { ImageSetType, SolarSystemObjects } from "@wwtelescope/engine-types";
-import { Place } from "@wwtelescope/engine";
+import { Place, WWTControl } from "@wwtelescope/engine";
 
 interface Message {
   event?: string;
@@ -2878,7 +2878,7 @@ const App = defineComponent({
       }
 
       if (closestPt !== null) {
-        const closestLngLatDeg = { lng: closestPt.lng * R2D, lat: closestPt.lat * R2D };
+        const closestLngLatDeg = { x: closestPt.lng * R2D, y: closestPt.lat * R2D };
         const closestScreenPoint = this.findScreenPointForCoordinates(closestLngLatDeg);
         const pixelDist = Math.sqrt((point.x - closestScreenPoint.x) ** 2 + (point.y - closestScreenPoint.y) ** 2);
         if (!threshold || pixelDist < threshold) {
@@ -2918,6 +2918,14 @@ const App = defineComponent({
       if (script !== null) {
         this.$options.statusMessageDestination = window;
       }
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      window.wwt = WWTControl.singleton;
+
+      const iset = "Solar System";
+      this.setBackgroundImageByName(iset);
+      this.setForegroundImageByName(iset);
 
       // This returns a promise but I don't think that we need to wait for that
       // to resolve before going ahead and starting to listen for messages.

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -377,7 +377,7 @@ import { Source, researchAppStore } from "./store";
 import { wwtEngineNamespace } from "./namespaces";
 
 import { ImageSetType, SolarSystemObjects } from "@wwtelescope/engine-types";
-import { Place, WWTControl } from "@wwtelescope/engine";
+import { Place } from "@wwtelescope/engine";
 
 interface Message {
   event?: string;
@@ -2840,7 +2840,7 @@ const App = defineComponent({
       if (!coordsDeg) {
         return null;
       }
-      const target = { lng: D2R * coordsDeg.lng, lat: D2R * coordsDeg.lat };
+      const target = { lng: D2R * coordsDeg.x, lat: D2R * coordsDeg.y };
 
       for (const layerInfo of this.selectableTableLayers()) {
         const layer = this.spreadSheetLayer(layerInfo);

--- a/research-app/src/App.vue
+++ b/research-app/src/App.vue
@@ -2919,14 +2919,6 @@ const App = defineComponent({
         this.$options.statusMessageDestination = window;
       }
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      window.wwt = WWTControl.singleton;
-
-      const iset = "Solar System";
-      this.setBackgroundImageByName(iset);
-      this.setForegroundImageByName(iset);
-
       // This returns a promise but I don't think that we need to wait for that
       // to resolve before going ahead and starting to listen for messages.
       this.loadImageCollection({


### PR DESCRIPTION
This PR builds off of the changes from #369 to allow converting (to some degree) between screen and world coordinates in 3D. This is mostly straightforward, but with the additional consideration that the image of a screen point in 3D is a ray rather than a point.

@astrodavid10 This is what would be needed to do e.g. the ping animation in 3D. Hover-over is a bit more complicated but I can build it out of the pieces here.