### PR TITLE
Distinguish "close" and "cancel" simple input elements

### DIFF
--- a/engine/esm/utilities/simple_input.js
+++ b/engine/esm/utilities/simple_input.js
@@ -49,8 +49,12 @@ var SimpleInput$ = {
         this._textElement.addEventListener('click', ss.bind('ignoreMe', this), true);
         var okButton = document.getElementById('simpleinputok');
         var cancelButton = document.getElementById('simpleinputcancel');
+        var closeButton = document.getElementById('simpleinputclose');
         okButton.addEventListener('click', ss.bind('okClicked', this), false);
         cancelButton.addEventListener('click', ss.bind('cancelClicked', this), false);
+        if (closeButton != null) {
+            closeButton.addEventListener('click', ss.bind('closeClicked', this), false);
+        }
         this._okCallback = callback;
     },
 
@@ -62,6 +66,10 @@ var SimpleInput$ = {
     },
 
     cancelClicked: function (e) {
+        this._close();
+    },
+
+    closeClicked: function (e) {
         this._close();
     },
 


### PR DESCRIPTION
Currently the "Cancel" button on the webclient "simple input" dialogs don't close because both the header "x" button and the cancel button have the same ID, so only one is picked up by `getElementById` and has the listener attached. This PR fixes things by adding a separate check for a "close" element, and attaching a different (but functionally identical) callback there as well. In the interest of backwards-safety, we check that the close element isn't null.

This feels like it really should be web client code, but it lives here, so we'll need to make this update and then fix the web client template.