### PR TITLE
Skip Khronos WebGL link check with Zola for now

### DIFF
--- a/docs/engine/config.toml
+++ b/docs/engine/config.toml
@@ -13,4 +13,4 @@ stylesheets = ["extras.css"]
 
 # This is temporary - see https://github.com/WorldWideTelescope/wwt-webgl-engine/issues/345
 [link_checker]
-skip_prefixes = ["https://npmjs.com"]
+skip_prefixes = ["https://npmjs.com", "https://www.khronos.org/webgl/"]

--- a/docs/research-app/config.toml
+++ b/docs/research-app/config.toml
@@ -13,4 +13,4 @@ stylesheets = ["extras.css"]
 
 # This is temporary - see https://github.com/WorldWideTelescope/wwt-webgl-engine/issues/345
 [link_checker]
-skip_prefixes = ["https://www.npmjs.com"]
+skip_prefixes = ["https://www.npmjs.com", "https://www.khronos.org/webgl/"]


### PR DESCRIPTION
We get a lot of transient errors from the Khronos WebGL site in the CI processes, which then necessitates a lot of check re-running. Similar to #346, this temporarily ignores those link checks until we have a more robust solution.