### PR TITLE
Account for coordinate system when finding 3D screen point

### DIFF
--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -1622,7 +1622,8 @@ var WWTControl$ = {
           x += 180;
           cartesian = Coordinates.geoTo3d(y, x);
         } else if (this.get_solarSystemMode()) {
-          cartesian = Vector3d.create(x, y, z); 
+          // In 3D mode, points are displayed with (X, Z, Y) coordinates
+          cartesian = Vector3d.create(x, z, y); 
         } else {
           var pt = Vector2d.create(x, y);
           cartesian = Coordinates.sphericalSkyToCartesian(pt);


### PR DESCRIPTION
When finding the screen point in #378, I forgot to account for the WWT coordinate system - it seems that XZ is the horizontal plane with Y pointing up. Layers then adjust their values to account for this - see e.g. [here](https://github.com/WorldWideTelescope/wwt-webgl-engine/blob/master/engine/esm/layers/spreadsheet_layer.js#L791). This PR updates the screen <--> world calculation to account for that.