### PR TITLE
Add functionality to display grid menu

### DIFF
--- a/engine/esm/layers/layer_manager.js
+++ b/engine/esm/layers/layer_manager.js
@@ -1196,6 +1196,17 @@ LayerManager.showLayerMenu = function (selected, x, y) {
     }
 };
 
+LayerManager.showGridMenu = function (gridName, x, y) {
+    var position = Vector2d.create(x, y);
+    LayerManager._lastMenuClick = position;
+    LayerManager._selectedGrid = gridName;
+    LayerManager._contextMenu = new ContextMenuStrip();
+    var colorMenu = ToolStripMenuItem.create(Language.getLocalizedText(458, 'Color/Opacity'));
+    colorMenu.click = LayerManager._gridColorMenu_Click;
+    LayerManager._contextMenu.items.push(colorMenu);
+    LayerManager._contextMenu._show(position);
+};
+
 LayerManager._publishMenu_Click = function (sender, e) { };
 
 LayerManager._addGirdLayer_Click = function (sender, e) {
@@ -1342,6 +1353,19 @@ LayerManager._colorMenu_Click = function (sender, e) {
     };
     picker.show(e);
 };
+
+LayerManager._gridColorMenu_Click = function (sender, e) {
+    var grid = LayerManager._selectedGrid;
+    var picker = new ColorPicker();
+    var currentColor = Settings.get_active()[`get_${grid}Color`]();
+    if (currentColor != null) {
+        picker.color = currentColor;
+    }
+    picker.callBack = function () {
+        Settings.get_active()[`set_${grid}Color`](picker.color);
+    };
+    picker.show(e);
+}
 
 LayerManager._addMenu_Click = function (sender, e) { };
 


### PR DESCRIPTION
This PR adds functionality to allow displaying a context menu for grids, similar to the one displayed for layers. The goal here is to allow users to manipulate grid colors inside the webclient. The setup here follows the same basic pattern as we use for the layers.

As I've mentioned before, it seems strange to me that the context menu functionality is web engine (rather than web client) code, but in the interest of internal consistency I'm adding this here as well.

I've already tested this with the corresponding web client changes (https://github.com/WorldWideTelescope/wwt-web-client/pull/381) and it seems to work as expected.