### PR TITLE
Respect orbits filter for planets

### DIFF
--- a/engine/esm/planets_3d.js
+++ b/engine/esm/planets_3d.js
@@ -92,6 +92,9 @@ Planets3d.drawPlanets3D = function (renderContext, opacity, centerPoint) {
             if (ii === 9) {
                 id = 19;
             }
+            if (!(Settings.get_active().get_planetOrbitsFilter() & id)) {
+              continue;
+            }
             var angle = Math.atan2(Planets._planet3dLocations[id].z, Planets._planet3dLocations[id].x);
             Planets3d._drawSingleOrbit(renderContext, Planets.planetColors[id], id, centerPoint, angle, Planets._planet3dLocations[id], fade);
         }

--- a/engine/esm/planets_3d.js
+++ b/engine/esm/planets_3d.js
@@ -86,13 +86,15 @@ Planets3d.drawPlanets3D = function (renderContext, opacity, centerPoint) {
     var fade = Math.min(1, Math.max(Util.log10(distss) - 8.6, 0));
 
     if (Settings.get_active().get_solarSystemOrbits() && fade > 0) {
+        var orbitsFilter = Settings.get_active().get_planetOrbitsFilter();
+
         // Mercury -> Pluto
         for (var ii = 1; ii < 10; ii++) {
             var id = ii;
             if (ii === 9) {
                 id = 19;
             }
-            if (!(Settings.get_active().get_planetOrbitsFilter() & id)) {
+            if (!(orbitsFilter & Math.pow(2, id))) {
               continue;
             }
             var angle = Math.atan2(Planets._planet3dLocations[id].z, Planets._planet3dLocations[id].x);
@@ -101,7 +103,9 @@ Planets3d.drawPlanets3D = function (renderContext, opacity, centerPoint) {
 
         // Moon is handled specially
         var mid = 9;
-        Planets3d._drawSingleOrbit(renderContext, Planets.planetColors[mid], mid, centerPoint, 0, Planets._planet3dLocations[mid], fade);
+        if (orbitsFilter & Math.pow(2, mid)) {
+          Planets3d._drawSingleOrbit(renderContext, Planets.planetColors[mid], mid, centerPoint, 0, Planets._planet3dLocations[mid], fade);
+        }
 
         // Galilean satellites. "Compute the positions of the Galilean
         // satellites at two times; we need the second in order to estimate the
@@ -134,7 +138,7 @@ Planets3d.drawPlanets3D = function (renderContext, opacity, centerPoint) {
             const id = galileans[i];
             const bit = Math.pow(2, id);
 
-            if (!(Settings.get_active().get_planetOrbitsFilter() & bit)) {
+            if (!(orbitsFilter & bit)) {
                 continue;
             }
 


### PR DESCRIPTION
After looking into https://github.com/WorldWideTelescope/wwt-web-client/issues/383, the UI elements in the webclient are correctly modifying the orbits filter from the settings - the issue is that the engine doesn't check the orbits filter when drawing the orbits for planets. Interestingly, it does check the filter for deciding which Galilean orbits to draw.

This PR resolves https://github.com/WorldWideTelescope/wwt-web-client/issues/383 by updating the relevant drawing method to use the orbits filter to decide which planetary orbits to draw. Note that the check done here has the same form as the existing check for the Galilean satellite orbits.