### PR TITLE
Allow changing text color

### DIFF
--- a/engine/esm/graphics/shaders.js
+++ b/engine/esm/graphics/shaders.js
@@ -2214,11 +2214,14 @@ TextShader.init = function (renderContext) {
         precision mediump float;
 
         varying vec2 vTextureCoord;
+        uniform vec4 uColor;
 
         uniform sampler2D uSampler;
 
         void main(void) {
-            gl_FragColor = texture2D(uSampler, vec2(vTextureCoord.s, vTextureCoord.t));
+           vec4 texColor;
+           texColor = texture2D(uSampler, vec2(vTextureCoord.s, vTextureCoord.t));
+           gl_FragColor = uColor * texColor;
         }
     `;
 
@@ -2256,6 +2259,7 @@ TextShader.init = function (renderContext) {
     TextShader.projMatLoc = gl.getUniformLocation(TextShader._prog, 'uPMatrix');
     TextShader.mvMatLoc = gl.getUniformLocation(TextShader._prog, 'uMVMatrix');
     TextShader.sampLoc = gl.getUniformLocation(TextShader._prog, 'uSampler');
+    TextShader.colorLoc = gl.getUniformLocation(TextShader._prog, 'uColor');
     set_tileUvMultiple(1);
     set_tileDemEnabled(true);
     gl.enable(WEBGL.BLEND);
@@ -2263,7 +2267,7 @@ TextShader.init = function (renderContext) {
     TextShader.initialized = true;
 };
 
-TextShader.use = function (renderContext, vertex, texture) {
+TextShader.use = function (renderContext, vertex, texture, color) {
     if (texture == null) {
         texture = Texture.getEmpty();
     }
@@ -2291,6 +2295,7 @@ TextShader.use = function (renderContext, vertex, texture) {
         gl.enableVertexAttribArray(TextShader.textureLoc);
         gl.vertexAttribPointer(TextShader.vertLoc, 3, WEBGL.FLOAT, false, 20, 0);
         gl.vertexAttribPointer(TextShader.textureLoc, 2, WEBGL.FLOAT, false, 20, 12);
+        gl.uniform4f(TextShader.colorLoc, color.r / 255, color.g / 255, color.b / 255, color.a / 255);
         gl.activeTexture(WEBGL.TEXTURE0);
         gl.bindTexture(WEBGL.TEXTURE_2D, texture);
         gl.enable(WEBGL.BLEND);

--- a/engine/esm/settings.js
+++ b/engine/esm/settings.js
@@ -99,6 +99,7 @@ export function Settings() {
     this._constellationBoundryColor = 'blue';
     this._constellationSelectionColor = 'yellow';
     this._constellationFigureColor = 'red';
+    this._constellationLabelsColor = 'white';
     this._showConstellationFigures = true;
     this._showConstellationBoundries = true;
     this._showConstellationSelection = true;
@@ -223,6 +224,15 @@ var Settings$ = {
 
     set_constellationSelectionColor: function (value) {
         this._constellationSelectionColor = value;
+        return value;
+    },
+
+    get_constellationLabelsColor: function () {
+        return this._constellationLabelsColor;
+    },
+
+    set_constellationLabelsColor: function (value) {
+        this._constellationLabelsColor = value;
         return value;
     },
 

--- a/engine/esm/sky_text.js
+++ b/engine/esm/sky_text.js
@@ -81,7 +81,7 @@ var Text3dBatch$ = {
             if (!this._glyphCache.ready) {
                 return;
             }
-            TextShader.use(renderContext, this._vertexBuffer.vertexBuffer, this._glyphCache.get_texture().texture2d);
+            TextShader.use(renderContext, this._vertexBuffer.vertexBuffer, this._glyphCache.get_texture().texture2d, color)
             renderContext.gl.drawArrays(WEBGL.TRIANGLES, 0, this._vertexBuffer.count);
         }
     },

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -956,7 +956,7 @@ var WWTControl$ = {
             WWTControl.constellationsBoundries.draw(this.renderContext, Settings.get_active().get_showConstellationSelection(), this.constellation, false);
         }
         if (Settings.get_active().get_showConstellationLabels()) {
-            Constellations.drawConstellationNames(this.renderContext, 1, Colors.get_yellow());
+            Constellations.drawConstellationNames(this.renderContext, 1, Color.load(Settings.get_active().get_constellationLabelsColor()));
         }
     },
 

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -1595,6 +1595,8 @@ export class Settings implements EngineSettingsInterface {
   set_constellationBoundryColor(v: string): string;
   get_constellationSelectionColor(): string;
   set_constellationSelectionColor(v: string): string;
+  get_constellationLabelsColor(): string;
+  set_constellationLabelsColor(v: string): string;
   get_showCrosshairs(): boolean;
   set_showCrosshairs(v: boolean): boolean;
   get_smoothPan(): boolean;


### PR DESCRIPTION
This PR updates the text shader to allow changing the text color. The computation in the shader is the same a what we do to set point colors for table layers. However, for points we need to make color an attribute as it can be different for each point (due to colormapping layers). This PR only allows making the text a solid color, so we can just pass in the color as a uniform (so we only need 4 numbers as opposed to 4 * N).

While hooking this up to `Text3dBatch`, I noticed that the text batches already have a color parameter. It looks like this parameter was used in the canvas-based implementation but hasn't previously been respected in WebGL. Interestingly enough, some of the existing overlay text batches (in particular, constellation names and grid text) already have colors other than white passed in.

@pkgw @patudom @astrodavid10 Did WWT ever look like the screenshot below? This is technically what the WWT control is asking for. I think changing the grid text color seems pretty reasonable, but the constellation name color seems like a much bigger change. So I added a settings item for constellation name color which is now what is asked for in the draw call, and set that to white by default.

<img width="1218" height="515" alt="Screenshot 2026-05-10 at 2 20 21 AM" src="https://github.com/user-attachments/assets/d9d3f969-235b-47a8-a446-1aae2f65696b" />
