### PR TITLE
Add fade in/out transition for various display settings

### DIFF
--- a/engine/esm/constellations.js
+++ b/engine/esm/constellations.js
@@ -159,7 +159,7 @@ Constellations.initializeConstellationNames = function () {
 // The WWTControl driver will not (and should not) call this function in
 // "freestanding mode", because the functionality depends on a
 // worldwidetelescope.org API.
-Constellations.drawArtwork = function (renderContext, opacity=100) {
+Constellations.drawArtwork = function (renderContext, opacity=1) {
     if (Constellations.artwork == null) {
         if (Constellations._artFile == null) {
             Constellations._artFile = makeNewFolder();
@@ -179,7 +179,7 @@ Constellations.drawArtwork = function (renderContext, opacity=100) {
             if (centroid != null) {
                 var pos = Coordinates.raDecTo3d((reverse) ? -centroid.get_RA() - 6 : centroid.get_RA(), (reverse) ? centroid.get_dec() : centroid.get_dec());
                 if (Vector3d.dot(renderContext.get_viewPoint(), pos) > Constellations._maxSeperation) {
-                    renderContext.drawImageSet(place.get_studyImageset(), opacity);
+                    renderContext.drawImageSet(place.get_studyImageset(), 100 * opacity);
                 }
             }
         }

--- a/engine/esm/constellations.js
+++ b/engine/esm/constellations.js
@@ -368,7 +368,7 @@ var Constellations$ = {
             if (Constellations._constToDraw === ls.get_name() && this._boundry) {
                 lsSelected = ls;
             }
-            else if (!showOnlySelected || !this._boundry) {
+            else if (!(showOnlySelected && this._boundry)) {
                 this._drawSingleConstellation(renderContext, ls, opacity);
             }
         }

--- a/engine/esm/constellations.js
+++ b/engine/esm/constellations.js
@@ -159,7 +159,7 @@ Constellations.initializeConstellationNames = function () {
 // The WWTControl driver will not (and should not) call this function in
 // "freestanding mode", because the functionality depends on a
 // worldwidetelescope.org API.
-Constellations.drawArtwork = function (renderContext) {
+Constellations.drawArtwork = function (renderContext, opacity=100) {
     if (Constellations.artwork == null) {
         if (Constellations._artFile == null) {
             Constellations._artFile = makeNewFolder();
@@ -179,7 +179,7 @@ Constellations.drawArtwork = function (renderContext) {
             if (centroid != null) {
                 var pos = Coordinates.raDecTo3d((reverse) ? -centroid.get_RA() - 6 : centroid.get_RA(), (reverse) ? centroid.get_dec() : centroid.get_dec());
                 if (Vector3d.dot(renderContext.get_viewPoint(), pos) > Constellations._maxSeperation) {
-                    renderContext.drawImageSet(place.get_studyImageset(), 100);
+                    renderContext.drawImageSet(place.get_studyImageset(), opacity);
                 }
             }
         }
@@ -354,7 +354,7 @@ var Constellations$ = {
         }
     },
 
-    draw: function (renderContext, showOnlySelected, focusConsteallation, clearExisting) {
+    draw: function (renderContext, showOnlySelected, focusConsteallation, clearExisting, opacity=1) {
         Constellations._maxSeperation = Math.max(0.6, Math.cos((renderContext.get_fovAngle() * 2) / 180 * Math.PI));
         this._drawCount = 0;
         var lsSelected = null;
@@ -369,11 +369,11 @@ var Constellations$ = {
                 lsSelected = ls;
             }
             else if (!showOnlySelected || !this._boundry) {
-                this._drawSingleConstellation(renderContext, ls, 1);
+                this._drawSingleConstellation(renderContext, ls, opacity);
             }
         }
         if (lsSelected != null) {
-            this._drawSingleConstellation(renderContext, lsSelected, 1);
+            this._drawSingleConstellation(renderContext, lsSelected, opacity);
         }
     },
 

--- a/engine/esm/graphics/primitives3d.js
+++ b/engine/esm/graphics/primitives3d.js
@@ -159,10 +159,10 @@ var SimpleLineList$ = {
             while ($enum1.moveNext()) {
                 var lineBuffer = $enum1.current;
                 if (this.pure2D) {
-                    SimpleLineShader2D.use(renderContext, lineBuffer.vertexBuffer, color, this._zBuffer);
+                    SimpleLineShader2D.use(renderContext, lineBuffer.vertexBuffer, color, this._zBuffer, opacity);
                 }
                 else {
-                    SimpleLineShader.use(renderContext, lineBuffer.vertexBuffer, color, this._zBuffer);
+                    SimpleLineShader.use(renderContext, lineBuffer.vertexBuffer, color, this._zBuffer, opacity);
                 }
                 renderContext.gl.drawArrays(WEBGL.LINES, 0, lineBuffer.count);
             }

--- a/engine/esm/graphics/shaders.js
+++ b/engine/esm/graphics/shaders.js
@@ -149,7 +149,7 @@ SimpleLineShader2D.init = function (renderContext) {
     SimpleLineShader2D.initialized = true;
 };
 
-SimpleLineShader2D.use = function (renderContext, vertex, lineColor, useDepth) {
+SimpleLineShader2D.use = function (renderContext, vertex, lineColor, useDepth, opacity=1) {
     var gl = renderContext.gl;
     if (gl != null) {
         if (!SimpleLineShader2D.initialized) {
@@ -157,7 +157,7 @@ SimpleLineShader2D.use = function (renderContext, vertex, lineColor, useDepth) {
         }
         gl.useProgram(SimpleLineShader2D._prog);
         var mvMat = Matrix3d.multiplyMatrix(renderContext.get_world(), renderContext.get_view());
-        gl.uniform4f(SimpleLineShader2D.lineColorLoc, lineColor.r / 255, lineColor.g / 255, lineColor.b / 255, 1);
+        gl.uniform4f(SimpleLineShader2D.lineColorLoc, lineColor.r / 255, lineColor.g / 255, lineColor.b / 255, lineColor.a * opacity / 255);
         if (renderContext.space || !useDepth) {
             gl.disable(WEBGL.DEPTH_TEST);
         } else {

--- a/engine/esm/graphics/shaders.js
+++ b/engine/esm/graphics/shaders.js
@@ -65,7 +65,7 @@ SimpleLineShader.init = function (renderContext) {
     SimpleLineShader.initialized = true;
 };
 
-SimpleLineShader.use = function (renderContext, vertex, lineColor, useDepth) {
+SimpleLineShader.use = function (renderContext, vertex, lineColor, useDepth, opacity=1) {
     var gl = renderContext.gl;
     if (gl != null) {
         if (!SimpleLineShader.initialized) {
@@ -75,7 +75,7 @@ SimpleLineShader.use = function (renderContext, vertex, lineColor, useDepth) {
         var mvMat = Matrix3d.multiplyMatrix(renderContext.get_world(), renderContext.get_view());
         gl.uniformMatrix4fv(SimpleLineShader.mvMatLoc, false, mvMat.floatArray());
         gl.uniformMatrix4fv(SimpleLineShader.projMatLoc, false, renderContext.get_projection().floatArray());
-        gl.uniform4f(SimpleLineShader.lineColorLoc, lineColor.r / 255, lineColor.g / 255, lineColor.b / 255, 1);
+        gl.uniform4f(SimpleLineShader.lineColorLoc, lineColor.r / 255, lineColor.g / 255, lineColor.b / 255, lineColor.a * opacity / 255);
         if (renderContext.space || !useDepth) {
             gl.disable(WEBGL.DEPTH_TEST);
         } else {

--- a/engine/esm/graphics/shaders.js
+++ b/engine/esm/graphics/shaders.js
@@ -2267,7 +2267,7 @@ TextShader.init = function (renderContext) {
     TextShader.initialized = true;
 };
 
-TextShader.use = function (renderContext, vertex, texture, color) {
+TextShader.use = function (renderContext, vertex, texture, color, opacity=1) {
     if (texture == null) {
         texture = Texture.getEmpty();
     }
@@ -2295,7 +2295,7 @@ TextShader.use = function (renderContext, vertex, texture, color) {
         gl.enableVertexAttribArray(TextShader.textureLoc);
         gl.vertexAttribPointer(TextShader.vertLoc, 3, WEBGL.FLOAT, false, 20, 0);
         gl.vertexAttribPointer(TextShader.textureLoc, 2, WEBGL.FLOAT, false, 20, 12);
-        gl.uniform4f(TextShader.colorLoc, color.r / 255, color.g / 255, color.b / 255, color.a / 255);
+        gl.uniform4f(TextShader.colorLoc, color.r / 255, color.g / 255, color.b / 255, color.a * opacity / 255);
         gl.activeTexture(WEBGL.TEXTURE0);
         gl.bindTexture(WEBGL.TEXTURE_2D, texture);
         gl.enable(WEBGL.BLEND);

--- a/engine/esm/sky_text.js
+++ b/engine/esm/sky_text.js
@@ -81,7 +81,7 @@ var Text3dBatch$ = {
             if (!this._glyphCache.ready) {
                 return;
             }
-            TextShader.use(renderContext, this._vertexBuffer.vertexBuffer, this._glyphCache.get_texture().texture2d, color)
+            TextShader.use(renderContext, this._vertexBuffer.vertexBuffer, this._glyphCache.get_texture().texture2d, color, opacity);
             renderContext.gl.drawArrays(WEBGL.TRIANGLES, 0, this._vertexBuffer.count);
         }
     },

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -138,10 +138,10 @@ export function WWTControl() {
     this.tourEdit = null;
     this._crossHairs = null;
   
-    this._fadeOpacities = {};
+    this._fadeInfo = {};
     for (var setting of WWTControl.fadeSettings) {
-      this._fadeOpacities[setting] = {
-        value: Number(Settings.get_active()[`get_${setting}`]()),
+      this._fadeInfo[setting] = {
+        opacity: Number(Settings.get_active()[`get_${setting}`]()),
         setting,
         start: null,
       };
@@ -637,9 +637,9 @@ var WWTControl$ = {
             this._crossHairs = null;
         }
 
-        for (var data of Object.values(this._fadeOpacities)) {
+        for (var data of Object.values(this._fadeInfo)) {
           var target = Number(Settings.get_active()[`get_${data.setting}`]());
-          if (data.value == target) {
+          if (data.opacity == target) {
             data.start = null;
           } else if (data.start == null) {
             data.start = Date.now();
@@ -648,7 +648,7 @@ var WWTControl$ = {
             // NB: This assumes that we are always going from 0 -> 1 or 1 -> 0
             // It will need slight tweaking if we eventually make this not the case
             var elapsed = Date.now() - data.start;
-            data.value = Math.min(1, Math.max(0, 1 - target + elapsed * Math.sign(target - data.value) / (data.duration || 400)));
+            data.opacity = Math.min(1, Math.max(0, 1 - target + elapsed * Math.sign(target - data.opacity) / (data.duration || 400)));
           }
         }
 
@@ -837,8 +837,8 @@ var WWTControl$ = {
         var worldSave = this.renderContext.get_world();
         var viewSave = this.renderContext.get_view();
         var projSave = this.renderContext.get_projection();
-        if (this._fadeOpacities.showCrosshairs.value > 0) {
-            this._drawCrosshairs(this.renderContext, this._fadeOpacities.showCrosshairs.value);
+        if (this._fadeInfo.showCrosshairs.opacity > 0) {
+            this._drawCrosshairs(this.renderContext, this._fadeInfo.showCrosshairs.opacity);
         }
         if (this.uiController != null) {
             this.uiController.render(this.renderContext);
@@ -946,10 +946,10 @@ var WWTControl$ = {
     },
 
     _drawSkyOverlays: function () {
-        if (this._fadeOpacities.showConstellationPictures.value > 0 && !this.freestandingMode) {
-            Constellations.drawArtwork(this.renderContext, 100 * this._fadeOpacities.showConstellationPictures.value);
+        if (this._fadeInfo.showConstellationPictures.opacity > 0 && !this.freestandingMode) {
+            Constellations.drawArtwork(this.renderContext, 100 * this._fadeInfo.showConstellationPictures.opacity);
         }
-        if (this._fadeOpacities.showConstellationFigures.value > 0) {
+        if (this._fadeInfo.showConstellationFigures.opacity > 0) {
             if (WWTControl.constellationsFigures == null) {
                 WWTControl.constellationsFigures = Constellations.create(
                     'Constellations',
@@ -959,42 +959,42 @@ var WWTControl$ = {
                     false,  // "resource"
                 );
             }
-            WWTControl.constellationsFigures.draw(this.renderContext, false, 'UMA', false, this._fadeOpacities.showConstellationFigures.value);
+            WWTControl.constellationsFigures.draw(this.renderContext, false, 'UMA', false, this._fadeInfo.showConstellationFigures.opacity);
         }
-        if (this._fadeOpacities.showEclipticGrid.value > 0) {
-            Grids.drawEclipticGrid(this.renderContext, this._fadeOpacities.showEclipticGrid.value, Settings.get_active().get_eclipticGridColor());
-            if (this._fadeOpacities.showEclipticGridText.value > 0) {
-                Grids.drawEclipticGridText(this.renderContext, this._fadeOpacities.showEclipticGridText.value, Settings.get_active().get_eclipticGridColor());
+        if (this._fadeInfo.showEclipticGrid.opacity > 0) {
+            Grids.drawEclipticGrid(this.renderContext, this._fadeInfo.showEclipticGrid.opacity, Settings.get_active().get_eclipticGridColor());
+            if (this._fadeInfo.showEclipticGridText.opacity > 0) {
+                Grids.drawEclipticGridText(this.renderContext, this._fadeInfo.showEclipticGridText.opacity, Settings.get_active().get_eclipticGridColor());
             }
         }
-        if (this._fadeOpacities.showGalacticGrid.value > 0) {
-            Grids.drawGalacticGrid(this.renderContext, this._fadeOpacities.showGalacticGrid.value, Settings.get_active().get_galacticGridColor());
-            if (this._fadeOpacities.showGalacticGridText.value > 0) {
-                Grids.drawGalacticGridText(this.renderContext, this._fadeOpacities.showGalacticGridText.value, Settings.get_active().get_galacticGridColor());
+        if (this._fadeInfo.showGalacticGrid.opacity > 0) {
+            Grids.drawGalacticGrid(this.renderContext, this._fadeInfo.showGalacticGrid.opacity, Settings.get_active().get_galacticGridColor());
+            if (this._fadeInfo.showGalacticGridText.opacity > 0) {
+                Grids.drawGalacticGridText(this.renderContext, this._fadeInfo.showGalacticGridText.opacity, Settings.get_active().get_galacticGridColor());
             }
         }
-        if (this._fadeOpacities.showAltAzGrid.value > 0) {
-            Grids.drawAltAzGrid(this.renderContext, this._fadeOpacities.showAltAzGrid.value, Settings.get_active().get_altAzGridColor());
-            if (this._fadeOpacities.showAltAzGridText.value > 0) {
-                Grids.drawAltAzGridText(this.renderContext, this._fadeOpacities.showAltAzGridText.value, Settings.get_active().get_altAzGridColor());
+        if (this._fadeInfo.showAltAzGrid.opacity > 0) {
+            Grids.drawAltAzGrid(this.renderContext, this._fadeInfo.showAltAzGrid.opacity, Settings.get_active().get_altAzGridColor());
+            if (this._fadeInfo.showAltAzGridText.opacity > 0) {
+                Grids.drawAltAzGridText(this.renderContext, this._fadeInfo.showAltAzGridText.opacity, Settings.get_active().get_altAzGridColor());
             }
         }
-        if (this._fadeOpacities.showPrecessionChart.value > 0) {
-            Grids.drawPrecessionChart(this.renderContext, this._fadeOpacities.showPrecessionChart.value, Settings.get_active().get_precessionChartColor());
+        if (this._fadeInfo.showPrecessionChart.opacity > 0) {
+            Grids.drawPrecessionChart(this.renderContext, this._fadeInfo.showPrecessionChart.opacity, Settings.get_active().get_precessionChartColor());
         }
-        if (this._fadeOpacities.showEcliptic.value > 0) {
-            Grids.drawEcliptic(this.renderContext, this._fadeOpacities.showEcliptic.value, Settings.get_active().get_eclipticColor(), Settings.get_active().get_showEclipticCircle());
-            if (this._fadeOpacities.showEclipticOverviewText.value > 0) {
-                Grids.drawEclipticText(this.renderContext, this._fadeOpacities.showEclipticOverviewText.value, Settings.get_active().get_eclipticColor());
+        if (this._fadeInfo.showEcliptic.opacity > 0) {
+            Grids.drawEcliptic(this.renderContext, this._fadeInfo.showEcliptic.opacity, Settings.get_active().get_eclipticColor(), Settings.get_active().get_showEclipticCircle());
+            if (this._fadeInfo.showEclipticOverviewText.opacity > 0) {
+                Grids.drawEclipticText(this.renderContext, this._fadeInfo.showEclipticOverviewText.opacity, Settings.get_active().get_eclipticColor());
             }
         }
-        if (this._fadeOpacities.showGrid.value > 0) {
-            Grids.drawEquitorialGrid(this.renderContext, this._fadeOpacities.showGrid.value, Settings.get_active().get_equatorialGridColor());
-            if (this._fadeOpacities.showEquatorialGridText.value > 0) {
-                Grids.drawEquitorialGridText(this.renderContext, this._fadeOpacities.showEquatorialGridText.value, Settings.get_active().get_equatorialGridColor());
+        if (this._fadeInfo.showGrid.opacity > 0) {
+            Grids.drawEquitorialGrid(this.renderContext, this._fadeInfo.showGrid.opacity, Settings.get_active().get_equatorialGridColor());
+            if (this._fadeInfo.showEquatorialGridText.opacity > 0) {
+                Grids.drawEquitorialGridText(this.renderContext, this._fadeInfo.showEquatorialGridText.opacity, Settings.get_active().get_equatorialGridColor());
             }
         }
-        if (this._fadeOpacities.showConstellationBoundries.value > 0) {
+        if (this._fadeInfo.showConstellationBoundries.opacity > 0) {
             if (WWTControl.constellationsBoundries == null) {
                 WWTControl.constellationsBoundries = Constellations.create(
                     'Constellations',
@@ -1004,10 +1004,10 @@ var WWTControl$ = {
                     false,  // "resource"
                 );
             }
-            WWTControl.constellationsBoundries.draw(this.renderContext, Settings.get_active().get_showConstellationSelection(), this.constellation, false, this._fadeOpacities.showConstellationBoundries.value);
+            WWTControl.constellationsBoundries.draw(this.renderContext, Settings.get_active().get_showConstellationSelection(), this.constellation, false, this._fadeInfo.showConstellationBoundries.opacity);
         }
-        if (this._fadeOpacities.showConstellationLabels.value > 0) {
-            Constellations.drawConstellationNames(this.renderContext, this._fadeOpacities.showConstellationLabels.value, Color.load(Settings.get_active().get_constellationLabelsColor()));
+        if (this._fadeInfo.showConstellationLabels.opacity > 0) {
+            Constellations.drawConstellationNames(this.renderContext, this._fadeInfo.showConstellationLabels.opacity, Color.load(Settings.get_active().get_constellationLabelsColor()));
         }
     },
 

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -957,7 +957,7 @@ var WWTControl$ = {
         var eclipticGridOpacity = this._fadeStates.showEclipticGrid.get_opacity();
         if (eclipticGridOpacity > 0) {
             Grids.drawEclipticGrid(this.renderContext, eclipticGridOpacity, Settings.get_active().get_eclipticGridColor());
-            var eclipticGridTextOpacity = this._fadeStates.showEclipticGridText.get_opacity();
+            var eclipticGridTextOpacity = this._fadeStates.showEclipticGridText.get_opacity() * eclipticGridOpacity;
             if (eclipticGridTextOpacity > 0) {
                 Grids.drawEclipticGridText(this.renderContext, eclipticGridTextOpacity, Settings.get_active().get_eclipticGridColor());
             }
@@ -965,7 +965,7 @@ var WWTControl$ = {
         var galacticGridOpacity = this._fadeStates.showGalacticGrid.get_opacity();
         if (galacticGridOpacity > 0) {
             Grids.drawGalacticGrid(this.renderContext, galacticGridOpacity, Settings.get_active().get_galacticGridColor());
-            var galacticGridTextOpacity = this._fadeStates.showGalacticGridText.get_opacity();
+            var galacticGridTextOpacity = this._fadeStates.showGalacticGridText.get_opacity() * galacticGridOpacity;
             if (galacticGridTextOpacity > 0) {
                 Grids.drawGalacticGridText(this.renderContext, galacticGridTextOpacity, Settings.get_active().get_galacticGridColor());
             }
@@ -973,7 +973,7 @@ var WWTControl$ = {
         var altAzGridOpacity = this._fadeStates.showAltAzGrid.get_opacity();
         if (altAzGridOpacity > 0) {
             Grids.drawAltAzGrid(this.renderContext, altAzGridOpacity, Settings.get_active().get_altAzGridColor());
-            var altAzGridTextOpacity = this._fadeStates.showAltAzGridText.get_opacity();
+            var altAzGridTextOpacity = this._fadeStates.showAltAzGridText.get_opacity() * altAzGridOpacity;
             if (altAzGridTextOpacity > 0) {
                 Grids.drawAltAzGridText(this.renderContext, altAzGridTextOpacity, Settings.get_active().get_altAzGridColor());
             }
@@ -985,7 +985,7 @@ var WWTControl$ = {
         var eclipticOpacity = this._fadeStates.showEcliptic.get_opacity();
         if (eclipticOpacity > 0) {
             Grids.drawEcliptic(this.renderContext, eclipticOpacity, Settings.get_active().get_eclipticColor(), Settings.get_active().get_showEclipticCircle());
-            var eclipticOverviewTextOpacity = this._fadeStates.showEclipticOverviewText.get_opacity();
+            var eclipticOverviewTextOpacity = this._fadeStates.showEclipticOverviewText.get_opacity() * eclipticOpacity;
             if (eclipticOverviewTextOpacity > 0) {
                 Grids.drawEclipticText(this.renderContext, eclipticOverviewTextOpacity, Settings.get_active().get_eclipticColor());
             }
@@ -993,7 +993,7 @@ var WWTControl$ = {
         var gridOpacity = this._fadeStates.showGrid.get_opacity();
         if (gridOpacity > 0) {
             Grids.drawEquitorialGrid(this.renderContext, gridOpacity, Settings.get_active().get_equatorialGridColor());
-            var equatorialGridTextOpacity = this._fadeStates.showEquatorialGridText.get_opacity();
+            var equatorialGridTextOpacity = this._fadeStates.showEquatorialGridText.get_opacity() * gridOpacity;
             if (equatorialGridTextOpacity > 0) {
                 Grids.drawEquitorialGridText(this.renderContext, equatorialGridTextOpacity, Settings.get_active().get_equatorialGridColor());
             }

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -949,7 +949,7 @@ var WWTControl$ = {
 
     _drawSkyOverlays: function () {
         if (this._fadeInfo.showConstellationPictures.opacity > 0 && !this.freestandingMode) {
-            Constellations.drawArtwork(this.renderContext, 100 * this._fadeInfo.showConstellationPictures.opacity);
+            Constellations.drawArtwork(this.renderContext, this._fadeInfo.showConstellationPictures.opacity);
         }
         if (this._fadeInfo.showConstellationFigures.opacity > 0) {
             if (WWTControl.constellationsFigures == null) {

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -139,7 +139,11 @@ export function WWTControl() {
     this._crossHairs = null;
 
     this._opacities = {
-      constellationFigures: { value: 1, getter: Settings.get_showConstellationFigures, start: null },
+      constellationFigures: {
+        value: Number(Settings.get_active().get_showConstellationFigures()),
+        setting: "showConstellationFigures",
+        start: null,
+      },
     };
 
 }
@@ -612,14 +616,17 @@ var WWTControl$ = {
         }
 
         for (var data of Object.values(this._opacities)) {
-          var target = Number(data.getter());
+          var target = Number(Settings.get_active()[`get_${data.setting}`]());
+          console.log(`Value: ${data.value}, target: ${target}`);
+          console.log(data.start);
           if (data.value == target) {
             data.start = null;
           } else if (data.start == null) {
             data.start = Date.now();
           } else {
             var elapsed = Date.now() - data.start;
-            data.value = Math.min(1, Math.max(0, elapsed * Math.sign(target - data.value) / (data.duration || 400)));
+            data.value = Math.min(1, Math.max(0, data.value + elapsed * Math.sign(target - data.value) / (data.duration || 1000)));
+            console.log(data.value);
           }
         }
 
@@ -918,9 +925,9 @@ var WWTControl$ = {
 
     _drawSkyOverlays: function () {
         if (Settings.get_active().get_showConstellationPictures() && !this.freestandingMode) {
-            Constellations.drawArtwork(this.renderContext, 100 * this._opacities.constellationFigures);
+            Constellations.drawArtwork(this.renderContext, 100 * this._opacities.constellationFigures.value);
         }
-        if (Settings.get_active().get_showConstellationFigures()) {
+        if (this._opacities.constellationFigures.value > 0) {
             if (WWTControl.constellationsFigures == null) {
                 WWTControl.constellationsFigures = Constellations.create(
                     'Constellations',
@@ -930,7 +937,7 @@ var WWTControl$ = {
                     false,  // "resource"
                 );
             }
-            WWTControl.constellationsFigures.draw(this.renderContext, false, 'UMA', false, this._opacities.constellationFigures);
+            WWTControl.constellationsFigures.draw(this.renderContext, false, 'UMA', false, this._opacities.constellationFigures.value);
         }
         if (Settings.get_active().get_showEclipticGrid()) {
             Grids.drawEclipticGrid(this.renderContext, 1, Settings.get_active().get_eclipticGridColor());
@@ -975,10 +982,10 @@ var WWTControl$ = {
                     false,  // "resource"
                 );
             }
-            WWTControl.constellationsBoundries.draw(this.renderContext, Settings.get_active().get_showConstellationSelection(), this.constellation, false, this._opacities.constellationFigures);
+            WWTControl.constellationsBoundries.draw(this.renderContext, Settings.get_active().get_showConstellationSelection(), this.constellation, false, this._opacities.constellationFigures.value);
         }
         if (Settings.get_active().get_showConstellationLabels()) {
-            Constellations.drawConstellationNames(this.renderContext, this._opacities.constellationFigures, Color.load(Settings.get_active().get_constellationLabelsColor()));
+            Constellations.drawConstellationNames(this.renderContext, this._opacities.constellationFigures.value, Color.load(Settings.get_active().get_constellationLabelsColor()));
         }
     },
 

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -944,8 +944,8 @@ var WWTControl$ = {
     },
 
     _drawSkyOverlays: function () {
-        if (this._fadeOpacities.showConstellationPictures > 0 && !this.freestandingMode) {
-            Constellations.drawArtwork(this.renderContext, 100 * this._fadeOpacities.constellationPictures.value);
+        if (this._fadeOpacities.showConstellationPictures.value > 0 && !this.freestandingMode) {
+            Constellations.drawArtwork(this.renderContext, 100 * this._fadeOpacities.showConstellationPictures.value);
         }
         if (this._fadeOpacities.showConstellationFigures.value > 0) {
             if (WWTControl.constellationsFigures == null) {

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -637,6 +637,8 @@ var WWTControl$ = {
             this._crossHairs = null;
         }
 
+        // We use `Date.now()` rather than `performance.now()` in what follows
+        // for compatibility with Internet Explorer
         for (var data of Object.values(this._fadeInfo)) {
           var target = Number(Settings.get_active()[`get_${data.setting}`]());
           if (data.opacity == target) {

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -175,6 +175,7 @@ WWTControl.fadeSettings = [
   "showEclipticCircle",
   "showEclipticOverviewText",
   "showPrecessionChart",
+  "showCrosshairs",
 ];
 
 
@@ -836,8 +837,8 @@ var WWTControl$ = {
         var worldSave = this.renderContext.get_world();
         var viewSave = this.renderContext.get_view();
         var projSave = this.renderContext.get_projection();
-        if (Settings.get_current().get_showCrosshairs()) {
-            this._drawCrosshairs(this.renderContext);
+        if (this._fadeOpacities.showCrosshairs.value > 0) {
+            this._drawCrosshairs(this.renderContext, this._fadeOpacities.showCrosshairs.value);
         }
         if (this.uiController != null) {
             this.uiController.render(this.renderContext);
@@ -2260,7 +2261,7 @@ var WWTControl$ = {
         }
     },
 
-    _drawCrosshairs: function (context) {
+    _drawCrosshairs: function (context, opacity=1) {
         if (context.gl == null) {
             var ctx = context.device;
             ctx.save();
@@ -2288,7 +2289,7 @@ var WWTControl$ = {
                 this._crossHairs.addLine(Vector3d.create(-halfWidth, 0, 0), Vector3d.create(halfWidth, 0, 0));
                 this._crossHairs.addLine(Vector3d.create(0, -halfHeight, 0), Vector3d.create(0, halfHeight, 0));
             }
-            this._crossHairs.drawLines(context, 1, Color.load(Settings.get_current().get_crosshairsColor()));
+            this._crossHairs.drawLines(context, opacity, Color.load(Settings.get_current().get_crosshairsColor()));
         }
     },
 

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -137,6 +137,11 @@ export function WWTControl() {
     this.tour = null;
     this.tourEdit = null;
     this._crossHairs = null;
+
+    this._opacities = {
+      constellationFigures: { value: 1, getter: Settings.get_showConstellationFigures, start: null },
+    };
+
 }
 
 // Note: these fields must remain public because there is JS code in the
@@ -606,6 +611,18 @@ var WWTControl$ = {
             this._crossHairs = null;
         }
 
+        for (var data of Object.values(this._opacities)) {
+          var target = Number(data.getter());
+          if (data.value == target) {
+            data.start = null;
+          } else if (data.start == null) {
+            data.start = Date.now();
+          } else {
+            var elapsed = Date.now() - data.start;
+            data.value = Math.min(1, Math.max(0, elapsed * Math.sign(target - data.value) / (data.duration || 400)));
+          }
+        }
+
         Tile.lastDeepestLevel = Tile.deepestLevel;
         RenderTriangle.width = this.renderContext.width = this.canvas.width;
         RenderTriangle.height = this.renderContext.height = this.canvas.height;
@@ -901,7 +918,7 @@ var WWTControl$ = {
 
     _drawSkyOverlays: function () {
         if (Settings.get_active().get_showConstellationPictures() && !this.freestandingMode) {
-            Constellations.drawArtwork(this.renderContext);
+            Constellations.drawArtwork(this.renderContext, 100 * this._opacities.constellationFigures);
         }
         if (Settings.get_active().get_showConstellationFigures()) {
             if (WWTControl.constellationsFigures == null) {
@@ -913,7 +930,7 @@ var WWTControl$ = {
                     false,  // "resource"
                 );
             }
-            WWTControl.constellationsFigures.draw(this.renderContext, false, 'UMA', false);
+            WWTControl.constellationsFigures.draw(this.renderContext, false, 'UMA', false, this._opacities.constellationFigures);
         }
         if (Settings.get_active().get_showEclipticGrid()) {
             Grids.drawEclipticGrid(this.renderContext, 1, Settings.get_active().get_eclipticGridColor());
@@ -958,10 +975,10 @@ var WWTControl$ = {
                     false,  // "resource"
                 );
             }
-            WWTControl.constellationsBoundries.draw(this.renderContext, Settings.get_active().get_showConstellationSelection(), this.constellation, false);
+            WWTControl.constellationsBoundries.draw(this.renderContext, Settings.get_active().get_showConstellationSelection(), this.constellation, false, this._opacities.constellationFigures);
         }
         if (Settings.get_active().get_showConstellationLabels()) {
-            Constellations.drawConstellationNames(this.renderContext, 1, Color.load(Settings.get_active().get_constellationLabelsColor()));
+            Constellations.drawConstellationNames(this.renderContext, this._opacities.constellationFigures, Color.load(Settings.get_active().get_constellationLabelsColor()));
         }
     },
 

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -138,13 +138,11 @@ export function WWTControl() {
     this.tourEdit = null;
     this._crossHairs = null;
   
-    this._fadeInfo = {};
-    for (var setting of WWTControl.fadeSettings) {
-      this._fadeInfo[setting] = {
-        opacity: Number(Settings.get_active()[`get_${setting}`]()),
-        setting,
-        start: null,
-      };
+    this._fadeStates = {};
+    for (var i = 0; i < WWTControl.fadeSettings.length; i++) {
+      var setting = WWTControl.fadeSettings[i];
+      var initialValue = Number(Settings.get_active()[`get_${setting}`]());
+      this._fadeStates[setting] = BlendState.create(initialValue, 400);
     }
 
 }
@@ -639,19 +637,10 @@ var WWTControl$ = {
 
         // We use `Date.now()` rather than `performance.now()` in what follows
         // for compatibility with Internet Explorer
-        for (var data of Object.values(this._fadeInfo)) {
-          var target = Number(Settings.get_active()[`get_${data.setting}`]());
-          if (data.opacity == target) {
-            data.start = null;
-          } else if (data.start == null) {
-            data.start = Date.now();
-          } else {
-
-            // NB: This assumes that we are always going from 0 -> 1 or 1 -> 0
-            // It will need slight tweaking if we eventually make this not the case
-            var elapsed = Date.now() - data.start;
-            data.opacity = Math.min(1, Math.max(0, 1 - target + elapsed * Math.sign(target - data.opacity) / (data.duration || 400)));
-          }
+        for (var setting in this._fadeStates) {
+          var state = this._fadeStates[setting];
+          var target = Number(Settings.get_active()[`get_${setting}`]());
+          state.set_targetState(target);
         }
 
         Tile.lastDeepestLevel = Tile.deepestLevel;
@@ -839,8 +828,8 @@ var WWTControl$ = {
         var worldSave = this.renderContext.get_world();
         var viewSave = this.renderContext.get_view();
         var projSave = this.renderContext.get_projection();
-        if (this._fadeInfo.showCrosshairs.opacity > 0) {
-            this._drawCrosshairs(this.renderContext, this._fadeInfo.showCrosshairs.opacity);
+        if (this._fadeStates.showCrosshairs.get_opacity() > 0) {
+            this._drawCrosshairs(this.renderContext, this._fadeStates.showCrosshairs.get_opacity());
         }
         if (this.uiController != null) {
             this.uiController.render(this.renderContext);
@@ -948,10 +937,12 @@ var WWTControl$ = {
     },
 
     _drawSkyOverlays: function () {
-        if (this._fadeInfo.showConstellationPictures.opacity > 0 && !this.freestandingMode) {
-            Constellations.drawArtwork(this.renderContext, this._fadeInfo.showConstellationPictures.opacity);
+        var constellationPicturesOpacity = this._fadeStates.showConstellationPictures.get_opacity();
+        if (constellationPicturesOpacity > 0 && !this.freestandingMode) {
+            Constellations.drawArtwork(this.renderContext, constellationPicturesOpacity);
         }
-        if (this._fadeInfo.showConstellationFigures.opacity > 0) {
+        var constellationFiguresOpacity = this._fadeStates.showConstellationFigures.get_opacity();
+        if (constellationFiguresOpacity > 0) {
             if (WWTControl.constellationsFigures == null) {
                 WWTControl.constellationsFigures = Constellations.create(
                     'Constellations',
@@ -961,42 +952,54 @@ var WWTControl$ = {
                     false,  // "resource"
                 );
             }
-            WWTControl.constellationsFigures.draw(this.renderContext, false, 'UMA', false, this._fadeInfo.showConstellationFigures.opacity);
+            WWTControl.constellationsFigures.draw(this.renderContext, false, 'UMA', false, constellationFiguresOpacity);
         }
-        if (this._fadeInfo.showEclipticGrid.opacity > 0) {
-            Grids.drawEclipticGrid(this.renderContext, this._fadeInfo.showEclipticGrid.opacity, Settings.get_active().get_eclipticGridColor());
-            if (this._fadeInfo.showEclipticGridText.opacity > 0) {
-                Grids.drawEclipticGridText(this.renderContext, this._fadeInfo.showEclipticGridText.opacity, Settings.get_active().get_eclipticGridColor());
+        var eclipticGridOpacity = this._fadeStates.showEclipticGrid.get_opacity();
+        if (eclipticGridOpacity > 0) {
+            Grids.drawEclipticGrid(this.renderContext, eclipticGridOpacity, Settings.get_active().get_eclipticGridColor());
+            var eclipticGridTextOpacity = this._fadeStates.showEclipticGridText.get_opacity();
+            if (eclipticGridTextOpacity > 0) {
+                Grids.drawEclipticGridText(this.renderContext, eclipticGridTextOpacity, Settings.get_active().get_eclipticGridColor());
             }
         }
-        if (this._fadeInfo.showGalacticGrid.opacity > 0) {
-            Grids.drawGalacticGrid(this.renderContext, this._fadeInfo.showGalacticGrid.opacity, Settings.get_active().get_galacticGridColor());
-            if (this._fadeInfo.showGalacticGridText.opacity > 0) {
-                Grids.drawGalacticGridText(this.renderContext, this._fadeInfo.showGalacticGridText.opacity, Settings.get_active().get_galacticGridColor());
+        var galacticGridOpacity = this._fadeStates.showGalacticGrid.get_opacity();
+        if (galacticGridOpacity > 0) {
+            Grids.drawGalacticGrid(this.renderContext, galacticGridOpacity, Settings.get_active().get_galacticGridColor());
+            var galacticGridTextOpacity = this._fadeStates.showGalacticGridText.get_opacity();
+            if (galacticGridTextOpacity > 0) {
+                Grids.drawGalacticGridText(this.renderContext, galacticGridTextOpacity, Settings.get_active().get_galacticGridColor());
             }
         }
-        if (this._fadeInfo.showAltAzGrid.opacity > 0) {
-            Grids.drawAltAzGrid(this.renderContext, this._fadeInfo.showAltAzGrid.opacity, Settings.get_active().get_altAzGridColor());
-            if (this._fadeInfo.showAltAzGridText.opacity > 0) {
-                Grids.drawAltAzGridText(this.renderContext, this._fadeInfo.showAltAzGridText.opacity, Settings.get_active().get_altAzGridColor());
+        var altAzGridOpacity = this._fadeStates.showAltAzGrid.get_opacity();
+        if (altAzGridOpacity > 0) {
+            Grids.drawAltAzGrid(this.renderContext, altAzGridOpacity, Settings.get_active().get_altAzGridColor());
+            var altAzGridTextOpacity = this._fadeStates.showAltAzGridText.get_opacity();
+            if (altAzGridTextOpacity > 0) {
+                Grids.drawAltAzGridText(this.renderContext, altAzGridTextOpacity, Settings.get_active().get_altAzGridColor());
             }
         }
-        if (this._fadeInfo.showPrecessionChart.opacity > 0) {
-            Grids.drawPrecessionChart(this.renderContext, this._fadeInfo.showPrecessionChart.opacity, Settings.get_active().get_precessionChartColor());
+        var precessionChartOpacity = this._fadeStates.showPrecessionChart.get_opacity();
+        if (precessionChartOpacity > 0) {
+            Grids.drawPrecessionChart(this.renderContext, precessionChartOpacity, Settings.get_active().get_precessionChartColor());
         }
-        if (this._fadeInfo.showEcliptic.opacity > 0) {
-            Grids.drawEcliptic(this.renderContext, this._fadeInfo.showEcliptic.opacity, Settings.get_active().get_eclipticColor(), Settings.get_active().get_showEclipticCircle());
-            if (this._fadeInfo.showEclipticOverviewText.opacity > 0) {
-                Grids.drawEclipticText(this.renderContext, this._fadeInfo.showEclipticOverviewText.opacity, Settings.get_active().get_eclipticColor());
+        var eclipticOpacity = this._fadeStates.showEcliptic.get_opacity();
+        if (eclipticOpacity > 0) {
+            Grids.drawEcliptic(this.renderContext, eclipticOpacity, Settings.get_active().get_eclipticColor(), Settings.get_active().get_showEclipticCircle());
+            var eclipticOverviewTextOpacity = this._fadeStates.showEclipticOverviewText.get_opacity();
+            if (eclipticOverviewTextOpacity > 0) {
+                Grids.drawEclipticText(this.renderContext, eclipticOverviewTextOpacity, Settings.get_active().get_eclipticColor());
             }
         }
-        if (this._fadeInfo.showGrid.opacity > 0) {
-            Grids.drawEquitorialGrid(this.renderContext, this._fadeInfo.showGrid.opacity, Settings.get_active().get_equatorialGridColor());
-            if (this._fadeInfo.showEquatorialGridText.opacity > 0) {
-                Grids.drawEquitorialGridText(this.renderContext, this._fadeInfo.showEquatorialGridText.opacity, Settings.get_active().get_equatorialGridColor());
+        var gridOpacity = this._fadeStates.showGrid.get_opacity();
+        if (gridOpacity > 0) {
+            Grids.drawEquitorialGrid(this.renderContext, gridOpacity, Settings.get_active().get_equatorialGridColor());
+            var equatorialGridTextOpacity = this._fadeStates.showEquatorialGridText.get_opacity();
+            if (equatorialGridTextOpacity > 0) {
+                Grids.drawEquitorialGridText(this.renderContext, equatorialGridTextOpacity, Settings.get_active().get_equatorialGridColor());
             }
         }
-        if (this._fadeInfo.showConstellationBoundries.opacity > 0) {
+        var constellationBoundriesOpacity = this._fadeStates.showConstellationBoundries.get_opacity();
+        if (constellationBoundriesOpacity > 0) {
             if (WWTControl.constellationsBoundries == null) {
                 WWTControl.constellationsBoundries = Constellations.create(
                     'Constellations',
@@ -1006,10 +1009,11 @@ var WWTControl$ = {
                     false,  // "resource"
                 );
             }
-            WWTControl.constellationsBoundries.draw(this.renderContext, Settings.get_active().get_showConstellationSelection(), this.constellation, false, this._fadeInfo.showConstellationBoundries.opacity);
+            WWTControl.constellationsBoundries.draw(this.renderContext, Settings.get_active().get_showConstellationSelection(), this.constellation, false, constellationBoundriesOpacity);
         }
-        if (this._fadeInfo.showConstellationLabels.opacity > 0) {
-            Constellations.drawConstellationNames(this.renderContext, this._fadeInfo.showConstellationLabels.opacity, Color.load(Settings.get_active().get_constellationLabelsColor()));
+        var constellationLabelsOpacity = this._fadeStates.showConstellationLabels.get_opacity();
+        if (constellationLabelsOpacity > 0) {
+            Constellations.drawConstellationNames(this.renderContext, constellationLabelsOpacity, Color.load(Settings.get_active().get_constellationLabelsColor()));
         }
     },
 

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -137,14 +137,34 @@ export function WWTControl() {
     this.tour = null;
     this.tourEdit = null;
     this._crossHairs = null;
+  
+    var fadeSettings = [
+      "showConstellationFigures",
+      "showConstellationBoundries",
+      "showConstellationPictures",
+      "showConstellationLabels",
+      "showEclipticGrid",
+      "showEclipticGridText",
+      "showGalacticGrid",
+      "showGalacticGridText",
+      "showAltAzGrid",
+      "showAltAzGridText",
+      "showGrid",
+      "showEquatorialGridText",
+      "showEcliptic",
+      "showEclipticCircle",
+      "showEclipticOverviewText",
+      "showPrecessionChart",
+    ];
 
-    this._opacities = {
-      constellationFigures: {
-        value: Number(Settings.get_active().get_showConstellationFigures()),
-        setting: "showConstellationFigures",
+    this._fadeOpacities = {};
+    for (var setting of fadeSettings) {
+      this._fadeOpacities[setting] = {
+        value: Number(Settings.get_active()[`get_${setting}`]()),
+        setting,
         start: null,
-      },
-    };
+      };
+    }
 
 }
 
@@ -615,7 +635,7 @@ var WWTControl$ = {
             this._crossHairs = null;
         }
 
-        for (var data of Object.values(this._opacities)) {
+        for (var data of Object.values(this._fadeOpacities)) {
           var target = Number(Settings.get_active()[`get_${data.setting}`]());
           if (data.value == target) {
             data.start = null;
@@ -924,10 +944,10 @@ var WWTControl$ = {
     },
 
     _drawSkyOverlays: function () {
-        if (Settings.get_active().get_showConstellationPictures() && !this.freestandingMode) {
-            Constellations.drawArtwork(this.renderContext, 100 * this._opacities.constellationFigures.value);
+        if (this._fadeOpacities.showConstellationPictures > 0 && !this.freestandingMode) {
+            Constellations.drawArtwork(this.renderContext, 100 * this._fadeOpacities.constellationPictures.value);
         }
-        if (this._opacities.constellationFigures.value > 0) {
+        if (this._fadeOpacities.showConstellationFigures.value > 0) {
             if (WWTControl.constellationsFigures == null) {
                 WWTControl.constellationsFigures = Constellations.create(
                     'Constellations',
@@ -937,42 +957,42 @@ var WWTControl$ = {
                     false,  // "resource"
                 );
             }
-            WWTControl.constellationsFigures.draw(this.renderContext, false, 'UMA', false, this._opacities.constellationFigures.value);
+            WWTControl.constellationsFigures.draw(this.renderContext, false, 'UMA', false, this._fadeOpacities.showConstellationFigures.value);
         }
-        if (Settings.get_active().get_showEclipticGrid()) {
-            Grids.drawEclipticGrid(this.renderContext, 1, Settings.get_active().get_eclipticGridColor());
-            if (Settings.get_active().get_showEclipticGridText()) {
-                Grids.drawEclipticGridText(this.renderContext, 1, Settings.get_active().get_eclipticGridColor());
+        if (this._fadeOpacities.showEclipticGrid.value > 0) {
+            Grids.drawEclipticGrid(this.renderContext, this._fadeOpacities.showEclipticGrid.value, Settings.get_active().get_eclipticGridColor());
+            if (this._fadeOpacities.showEclipticGridText.value > 0) {
+                Grids.drawEclipticGridText(this.renderContext, this._fadeOpacities.showEclipticGridText.value, Settings.get_active().get_eclipticGridColor());
             }
         }
-        if (Settings.get_active().get_showGalacticGrid()) {
-            Grids.drawGalacticGrid(this.renderContext, 1, Settings.get_active().get_galacticGridColor());
-            if (Settings.get_active().get_showGalacticGridText()) {
-                Grids.drawGalacticGridText(this.renderContext, 1, Settings.get_active().get_galacticGridColor());
+        if (this._fadeOpacities.showGalacticGrid.value > 0) {
+            Grids.drawGalacticGrid(this.renderContext, this._fadeOpacities.showGalacticGrid.value, Settings.get_active().get_galacticGridColor());
+            if (this._fadeOpacities.showGalacticGridText.value > 0) {
+                Grids.drawGalacticGridText(this.renderContext, this._fadeOpacities.showGalacticGridText.value, Settings.get_active().get_galacticGridColor());
             }
         }
-        if (Settings.get_active().get_showAltAzGrid()) {
-            Grids.drawAltAzGrid(this.renderContext, 1, Settings.get_active().get_altAzGridColor());
-            if (Settings.get_active().get_showAltAzGridText()) {
-                Grids.drawAltAzGridText(this.renderContext, 1, Settings.get_active().get_altAzGridColor());
+        if (this._fadeOpacities.showAltAzGrid.value > 0) {
+            Grids.drawAltAzGrid(this.renderContext, this._fadeOpacities.showAltAzGrid.value, Settings.get_active().get_altAzGridColor());
+            if (this._fadeOpacities.showAltAzGridText.value > 0) {
+                Grids.drawAltAzGridText(this.renderContext, this._fadeOpacities.showAltAzGridText.value, Settings.get_active().get_altAzGridColor());
             }
         }
-        if (Settings.get_active().get_showPrecessionChart()) {
-            Grids.drawPrecessionChart(this.renderContext, 1, Settings.get_active().get_precessionChartColor());
+        if (this._fadeOpacities.showPrecessionChart.value > 0) {
+            Grids.drawPrecessionChart(this.renderContext, this._fadeOpacities.showPrecessionChart.value, Settings.get_active().get_precessionChartColor());
         }
-        if (Settings.get_active().get_showEcliptic()) {
-            Grids.drawEcliptic(this.renderContext, 1, Settings.get_active().get_eclipticColor(), Settings.get_active().get_showEclipticCircle());
-            if (Settings.get_active().get_showEclipticOverviewText()) {
-                Grids.drawEclipticText(this.renderContext, 1, Settings.get_active().get_eclipticColor());
+        if (this._fadeOpacities.showPrecessionChart.value > 0) {
+            Grids.drawEcliptic(this.renderContext, this._fadeOpacities.showPrecessionChart.value, Settings.get_active().get_eclipticColor(), Settings.get_active().get_showEclipticCircle());
+            if (this._fadeOpacities.showEclipticOverviewText.value > 0) {
+                Grids.drawEclipticText(this.renderContext, this._fadeOpacities.showEclipticOverviewText.value, Settings.get_active().get_eclipticColor());
             }
         }
-        if (Settings.get_active().get_showGrid()) {
-            Grids.drawEquitorialGrid(this.renderContext, 1, Settings.get_active().get_equatorialGridColor());
-            if (Settings.get_active().get_showEquatorialGridText()) {
-                Grids.drawEquitorialGridText(this.renderContext, 1, Settings.get_active().get_equatorialGridColor());
+        if (this._fadeOpacities.showGrid.value > 0) {
+            Grids.drawEquitorialGrid(this.renderContext, this._fadeOpacities.showGrid.value, Settings.get_active().get_equatorialGridColor());
+            if (this._fadeOpacities.showEquatorialGridText.value > 0) {
+                Grids.drawEquitorialGridText(this.renderContext, this._fadeOpacities.showEquatorialGridText.value, Settings.get_active().get_equatorialGridColor());
             }
         }
-        if (Settings.get_active().get_showConstellationBoundries()) {
+        if (this._fadeOpacities.showConstellationBoundries.value > 0) {
             if (WWTControl.constellationsBoundries == null) {
                 WWTControl.constellationsBoundries = Constellations.create(
                     'Constellations',
@@ -982,10 +1002,10 @@ var WWTControl$ = {
                     false,  // "resource"
                 );
             }
-            WWTControl.constellationsBoundries.draw(this.renderContext, Settings.get_active().get_showConstellationSelection(), this.constellation, false, this._opacities.constellationFigures.value);
+            WWTControl.constellationsBoundries.draw(this.renderContext, Settings.get_active().get_showConstellationSelection(), this.constellation, false, this._fadeOpacities.showConstellationBoundries.value);
         }
-        if (Settings.get_active().get_showConstellationLabels()) {
-            Constellations.drawConstellationNames(this.renderContext, this._opacities.constellationFigures.value, Color.load(Settings.get_active().get_constellationLabelsColor()));
+        if (this._fadeOpacities.showConstellationLabels.value > 0) {
+            Constellations.drawConstellationNames(this.renderContext, this._fadeOpacities.showConstellationLabels.value, Color.load(Settings.get_active().get_constellationLabelsColor()));
         }
     },
 

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -617,16 +617,16 @@ var WWTControl$ = {
 
         for (var data of Object.values(this._opacities)) {
           var target = Number(Settings.get_active()[`get_${data.setting}`]());
-          console.log(`Value: ${data.value}, target: ${target}`);
-          console.log(data.start);
           if (data.value == target) {
             data.start = null;
           } else if (data.start == null) {
             data.start = Date.now();
           } else {
+
+            // NB: This assumes that we are always going from 0 -> 1 or 1 -> 0
+            // It will need slight tweaking if we eventually make this not the case
             var elapsed = Date.now() - data.start;
-            data.value = Math.min(1, Math.max(0, data.value + elapsed * Math.sign(target - data.value) / (data.duration || 1000)));
-            console.log(data.value);
+            data.value = Math.min(1, Math.max(0, 1 - target + elapsed * Math.sign(target - data.value) / (data.duration || 400)));
           }
         }
 

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -138,27 +138,8 @@ export function WWTControl() {
     this.tourEdit = null;
     this._crossHairs = null;
   
-    var fadeSettings = [
-      "showConstellationFigures",
-      "showConstellationBoundries",
-      "showConstellationPictures",
-      "showConstellationLabels",
-      "showEclipticGrid",
-      "showEclipticGridText",
-      "showGalacticGrid",
-      "showGalacticGridText",
-      "showAltAzGrid",
-      "showAltAzGridText",
-      "showGrid",
-      "showEquatorialGridText",
-      "showEcliptic",
-      "showEclipticCircle",
-      "showEclipticOverviewText",
-      "showPrecessionChart",
-    ];
-
     this._fadeOpacities = {};
-    for (var setting of fadeSettings) {
+    for (var setting of WWTControl.fadeSettings) {
       this._fadeOpacities[setting] = {
         value: Number(Settings.get_active()[`get_${setting}`]()),
         setting,
@@ -177,6 +158,26 @@ WWTControl._renderNeeded = false;
 WWTControl.constellationsFigures = null;
 WWTControl.constellationsBoundries = null;
 WWTControl.solarSystemObjectsNames = ['Sun', 'Mercury', 'Venus', 'Mars', 'Jupiter', 'Saturn', 'Uranus', 'Neptune', 'Pluto', 'Moon', 'Io', 'Europa', 'Ganymede', 'Callisto', 'IoShadow', 'EuropaShadow', 'GanymedeShadow', 'CallistoShadow', 'SunEclipsed', 'Earth', 'Custom', 'Undefined'];
+WWTControl.fadeSettings = [
+  "showConstellationFigures",
+  "showConstellationBoundries",
+  "showConstellationPictures",
+  "showConstellationLabels",
+  "showEclipticGrid",
+  "showEclipticGridText",
+  "showGalacticGrid",
+  "showGalacticGridText",
+  "showAltAzGrid",
+  "showAltAzGridText",
+  "showGrid",
+  "showEquatorialGridText",
+  "showEcliptic",
+  "showEclipticCircle",
+  "showEclipticOverviewText",
+  "showPrecessionChart",
+];
+
+
 
 WWTControl.addImageSetToRepository = function (imagesetToAdd) {
     var $enum1 = ss.enumerate(WWTControl.imageSets);
@@ -980,8 +981,8 @@ var WWTControl$ = {
         if (this._fadeOpacities.showPrecessionChart.value > 0) {
             Grids.drawPrecessionChart(this.renderContext, this._fadeOpacities.showPrecessionChart.value, Settings.get_active().get_precessionChartColor());
         }
-        if (this._fadeOpacities.showPrecessionChart.value > 0) {
-            Grids.drawEcliptic(this.renderContext, this._fadeOpacities.showPrecessionChart.value, Settings.get_active().get_eclipticColor(), Settings.get_active().get_showEclipticCircle());
+        if (this._fadeOpacities.showEcliptic.value > 0) {
+            Grids.drawEcliptic(this.renderContext, this._fadeOpacities.showEcliptic.value, Settings.get_active().get_eclipticColor(), Settings.get_active().get_showEclipticCircle());
             if (this._fadeOpacities.showEclipticOverviewText.value > 0) {
                 Grids.drawEclipticText(this.renderContext, this._fadeOpacities.showEclipticOverviewText.value, Settings.get_active().get_eclipticColor());
             }


### PR DESCRIPTION
Inspired by @astrodavid10 doing this for the constellations in a recent interactive, this PR updates the engine to fade certain items in/out. To do this, we check on each frame whether the relevant flag for each of these items has been changed, and if so we bring the opacity up/down by an amount proportional to the number of milliseconds since the transition has started. Once we arrive at the target opacity we unset the start time of the transition. Note that the transition process is handled by the preexisting `BlendState` class.

Along the way I updated the text and simple line shaders to take opacity arguments. If not specified, these are defaulted to 1 for backwards compatibility.

The values that can fade in/out are:
* Constellations (images, figures, boundaries, and names)
* Grids and their text
* Ecliptic and precession chart
* The reticle crosshairs

Below is a video that shows this in action (using a local webclient build)

https://github.com/user-attachments/assets/c7099bcd-6767-42ee-83a0-71f69b1f4d18

