### PR TITLE
Skip outerspace linkcheck

### DIFF
--- a/docs/engine/config.toml
+++ b/docs/engine/config.toml
@@ -13,4 +13,4 @@ stylesheets = ["extras.css"]
 
 # This is temporary - see https://github.com/WorldWideTelescope/wwt-webgl-engine/issues/345
 [link_checker]
-skip_prefixes = ["https://npmjs.com", "https://www.khronos.org/webgl/"]
+skip_prefixes = ["https://npmjs.com", "https://www.khronos.org/webgl/", "https://outerspace.stsci.edu/display/PANSTARRS/"]


### PR DESCRIPTION
Another link check to temporarily disable. This time the issue seems to be that Zola doesn't recognize the SSL certificate.

I will investigate whether this is an issue in Azure or something outside of our control, but I don't want this to hold up CI.