### PR TITLE
Allowing adding callbacks that run on each frame

### DIFF
--- a/engine-helpers/src/index.ts
+++ b/engine-helpers/src/index.ts
@@ -27,6 +27,7 @@ import {
   SpaceTimeController,
   SpreadSheetLayer,
   SpreadSheetLayerSetting,
+  FrameCallback,
 } from "@wwtelescope/engine";
 
 import {
@@ -468,6 +469,16 @@ export class WWTInstance {
         this.readyPromises.push(new SavedPromise(null, resolve, reject));
       }
     });
+  }
+
+  // Manage callbacks executed on each frame
+
+  addFrameCallback(callback: FrameCallback): void {
+    this.si.add_on_frame(callback);
+  }
+
+  removeFrameCallback(callback: FrameCallback): void {
+      this.si.remove_on_frame(callback);
   }
 
   // Arrival promises

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -16,6 +16,7 @@ import {
   Annotation,
   EngineSetting,
   Folder,
+  FrameCallback,
   Guid,
   Imageset,
   ImageSetLayer,
@@ -1552,6 +1553,20 @@ export const engineStore = defineStore('wwt-engine', {
           }
         });
       }
+    },
+
+    /** Add a callback that runs on each frame render */
+    addFrameCallback(callback: FrameCallback): void {
+      if (this.$wwt.inst === null)
+        throw new Error('cannot addFrameCallback without linking to WWTInstance');
+      this.$wwt.inst.addFrameCallback(callback);
+    },
+
+    /** Remove a callback that runs on each frame render */
+    removeFrameCallback(callback: FrameCallback): void {
+      if (this.$wwt.inst === null)
+        throw new Error('cannot removeFrameCallback without linking to WWTInstance');
+      this.$wwt.inst.removeFrameCallback(callback);
     },
 
     /** Command the view to steer to a specific configuration.

--- a/engine-pinia/src/wwtaware.ts
+++ b/engine-pinia/src/wwtaware.ts
@@ -143,6 +143,8 @@ export const WWTAwareComponent = defineComponent({
       "closeTourPlayer",
       "viewAsTourXml",
       "waitForReady",
+      "addFrameCallback",
+      "removeFrameCallback",
       // Formerly mutations
       "addAnnotation",
       "applyFitsLayerSettings",

--- a/engine/esm/script_interface.js
+++ b/engine/esm/script_interface.js
@@ -361,6 +361,14 @@ var ScriptInterface$ = {
         this.__timeScrubberHook = ss.bindSub(this.__timeScrubberHook, value);
     },
 
+    add_on_frame: function (value) {
+        globalWWTControl.addFrameCallback(value);
+    },
+
+    remove_on_frame: function (value) {
+        globalWWTControl.removeFrameCallback(value);
+    },
+
     setTimeScrubberPosition: function (posLeft) {
         LayerManager.setTimeSliderValue(posLeft);
     },

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -145,6 +145,7 @@ export function WWTControl() {
       this._fadeStates[setting] = BlendState.create(initialValue, 400);
     }
 
+    this._frameCallbacks = [];
 }
 
 // Note: these fields must remain public because there is JS code in the
@@ -886,6 +887,14 @@ var WWTControl$ = {
                 SpaceTimeController.frameDumping = false;
                 SpaceTimeController.cancelFrameDump = false;
                 this.capturingVideo = false;
+            }
+        }
+
+        for (var callback of this._frameCallbacks) {
+            try {
+                callback();
+            } catch (error) {
+                console.error("Error while running WWT callback:\n", error);
             }
         }
     },
@@ -2378,6 +2387,17 @@ var WWTControl$ = {
     clampZooms: function (rc) {
         rc.viewCamera.zoom = DoubleUtilities.clamp(rc.viewCamera.zoom, this.get_zoomMin(), this.get_zoomMax());
         rc.targetCamera.zoom = DoubleUtilities.clamp(rc.targetCamera.zoom, this.get_zoomMin(), this.get_zoomMax());
+    },
+
+    addFrameCallback(callback) {
+        this._frameCallbacks.push(callback);
+    },
+
+    removeFrameCallback(callback) {
+        var index = this._frameCallbacks.indexOf(callback);
+        if (index > -1) {
+            this._frameCallbacks.splice(index, 1);
+        }
     }
 };
 

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -892,7 +892,7 @@ var WWTControl$ = {
 
         for (var callback of this._frameCallbacks) {
             try {
-                callback();
+                callback(WWTControl.scriptInterface);
             } catch (error) {
                 console.error("Error while running WWT callback:\n", error);
             }

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -1324,7 +1324,7 @@ export interface ReadyEventCallback {
 
 export interface FrameCallback {
   /** A function that can be called on each frame */
-  (): void;
+  (si: ScriptInterface): void;
 }
 
 /** The core state of the WWT rendering engine.

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -1322,6 +1322,11 @@ export interface ReadyEventCallback {
   (si: ScriptInterface): void;
 }
 
+export interface FrameCallback {
+  /** A function that can be called on each frame */
+  (): void;
+}
+
 /** The core state of the WWT rendering engine.
  *
  * This class contains most of the information about the WWT camera, view
@@ -1483,6 +1488,12 @@ export class ScriptInterface {
 
   /** Deregister a "ready" callback. */
   remove_ready(callback: ReadyEventCallback): void;
+
+  /** Register a callback to be run on each frame */
+  add_on_frame(callback: FrameCallback): void;
+
+  /** Deregister a "frame" callback */
+  remove_on_frame(callback: FrameCallback): void;
 
   /** Register a callback to be called when {@link WWTControl.loadTour} or
    * {@link WWTControl.playTour} have finished loading a tour.


### PR DESCRIPTION
This PR adds the ability to attach callbacks that run after each frame render. This is something that we have to monkey patch into the lion's share of Cosmic Data Stories, and I think this is generally useful. We've used this sort of setup to add functionality that we don't want to put into the reactive framework (usually some sort of custom rendering), but if anything I think this could be more useful outside of a reactive framework where there aren't built-in hooks to look for updates. For this reason I made sure to expose this on the script interface so that it can be used in a hosted JavaScript setup.