### PR TITLE
Add functionality to display constellation setting menu

### DIFF
--- a/engine/esm/layers/layer_manager.js
+++ b/engine/esm/layers/layer_manager.js
@@ -1207,6 +1207,17 @@ LayerManager.showGridMenu = function (gridName, x, y) {
     LayerManager._contextMenu._show(position);
 };
 
+LayerManager.showConstellationSettingMenu = function (constellationSetting, x, y) {
+    var position = Vector2d.create(x, y);
+    LayerManager._lastMenuClick = position;
+    LayerManager._selectedConstellationSetting = constellationSetting;
+    LayerManager._contextMenu = new ContextMenuStrip();
+    var colorMenu = ToolStripMenuItem.create(Language.getLocalizedText(458, 'Color/Opacity'));
+    colorMenu.click = LayerManager._constellationSettingColorMenu_Click;
+    LayerManager._contextMenu.items.push(colorMenu);
+    LayerManager._contextMenu._show(position);
+};
+
 LayerManager._publishMenu_Click = function (sender, e) { };
 
 LayerManager._addGirdLayer_Click = function (sender, e) {
@@ -1366,6 +1377,20 @@ LayerManager._gridColorMenu_Click = function (sender, e) {
     };
     picker.show(e);
 }
+
+LayerManager._constellationSettingColorMenu_Click = function (sender, e) {
+    var constellationSetting = LayerManager._selectedConstellationSetting;
+    var picker = new ColorPicker();
+    var currentColor = Settings.get_active()[`get_${constellationSetting}Color`]();
+    if (currentColor != null) {
+        picker.color = currentColor;
+    }
+    picker.callBack = function () {
+        Settings.get_active()[`set_${constellationSetting}Color`](picker.color);
+    };
+    picker.show(e);
+}
+
 
 LayerManager._addMenu_Click = function (sender, e) { };
 

--- a/engine/esm/layers/layer_manager.js
+++ b/engine/esm/layers/layer_manager.js
@@ -1380,6 +1380,7 @@ LayerManager._gridColorMenu_Click = function (sender, e) {
 
 LayerManager._constellationSettingColorMenu_Click = function (sender, e) {
     var constellationSetting = LayerManager._selectedConstellationSetting;
+    constellationSetting = constellationSetting.replace("Boundries", "Boundry").replace("Figures", "Figure");
     var picker = new ColorPicker();
     var currentColor = Settings.get_active()[`get_${constellationSetting}Color`]();
     if (currentColor != null) {

--- a/engine/esm/layers/layer_manager.js
+++ b/engine/esm/layers/layer_manager.js
@@ -1384,10 +1384,10 @@ LayerManager._constellationSettingColorMenu_Click = function (sender, e) {
     var picker = new ColorPicker();
     var currentColor = Settings.get_active()[`get_${constellationSetting}Color`]();
     if (currentColor != null) {
-        picker.color = currentColor;
+        picker.color = Color.load(currentColor);
     }
     picker.callBack = function () {
-        Settings.get_active()[`set_${constellationSetting}Color`](picker.color);
+        Settings.get_active()[`set_${constellationSetting}Color`](picker.color.toString());
     };
     picker.show(e);
 }


### PR DESCRIPTION
Similar to #385, this allows displaying a context menu for some of the constellation settings. My comments from that PR about the location of this functionality apply here as well.

There are a few special concessions here to the way that these settings are named, as well as accounting for the fact that these are stored as strings rather than `Color` objects. I tested this out against a local webclient build.