### PR TITLE
Allow registering custom named colormaps; allow using opacity for colormaps

### DIFF
--- a/engine/esm/graphics/shaders.js
+++ b/engine/esm/graphics/shaders.js
@@ -1611,7 +1611,7 @@ FitsShader.init = function (renderContext) {
                         break;
                 }
                 vec4 colorFromColorMapper = texture(colorSampler, vec2(physicalValue, 0.5));
-                fragmentColor = vec4(colorFromColorMapper.rgb, opacity);
+                fragmentColor = vec4(colorFromColorMapper.rgb, colorFromColorMapper.a * opacity);
             }
         }
     `;

--- a/engine/esm/layers/color_map_container.js
+++ b/engine/esm/layers/color_map_container.js
@@ -109,7 +109,7 @@ ColorMapContainer._initColorTexture = function (gl, colorMapContainer) {
     gl.texParameteri(WEBGL.TEXTURE_2D, WEBGL.TEXTURE_WRAP_S, WEBGL.CLAMP_TO_EDGE);
     gl.texParameteri(WEBGL.TEXTURE_2D, WEBGL.TEXTURE_WRAP_T, WEBGL.CLAMP_TO_EDGE);
     var colorBuffer = ColorMapContainer._extractColorArray(colorMapContainer.colors);
-    gl.texImage2D(WEBGL.TEXTURE_2D, 0, WEBGL.RGB8, colorBuffer.length / 3, 1, 0, WEBGL.RGB, WEBGL.UNSIGNED_BYTE, colorBuffer);
+    gl.texImage2D(WEBGL.TEXTURE_2D, 0, WEBGL.RGB8, colorBuffer.length / 4, 1, 0, WEBGL.RGB, WEBGL.UNSIGNED_BYTE, colorBuffer);
     gl.texParameteri(WEBGL.TEXTURE_2D, WEBGL.TEXTURE_MIN_FILTER, WEBGL.NEAREST);
     gl.texParameteri(WEBGL.TEXTURE_2D, WEBGL.TEXTURE_MAG_FILTER, WEBGL.NEAREST);
     return colorTexture;
@@ -117,13 +117,14 @@ ColorMapContainer._initColorTexture = function (gl, colorMapContainer) {
 
 ColorMapContainer._extractColorArray = function (colors) {
     var index = 0;
-    var colorBuffer = new Uint8Array(colors.length * 3);
+    var colorBuffer = new Uint8Array(colors.length * 4);
     var $enum1 = ss.enumerate(colors);
     while ($enum1.moveNext()) {
         var color = $enum1.current;
         colorBuffer[index++] = color.r;
         colorBuffer[index++] = color.g;
         colorBuffer[index++] = color.b;
+        colorBuffer[index++] = color.a;
     }
     return colorBuffer;
 };

--- a/engine/esm/layers/color_map_container.js
+++ b/engine/esm/layers/color_map_container.js
@@ -84,7 +84,7 @@ ColorMapContainer._initColorTexture = function (gl, colorMapContainer) {
     gl.texParameteri(WEBGL.TEXTURE_2D, WEBGL.TEXTURE_WRAP_S, WEBGL.CLAMP_TO_EDGE);
     gl.texParameteri(WEBGL.TEXTURE_2D, WEBGL.TEXTURE_WRAP_T, WEBGL.CLAMP_TO_EDGE);
     var colorBuffer = ColorMapContainer._extractColorArray(colorMapContainer.colors);
-    gl.texImage2D(WEBGL.TEXTURE_2D, 0, WEBGL.RGB8, colorBuffer.length / 4, 1, 0, WEBGL.RGB, WEBGL.UNSIGNED_BYTE, colorBuffer);
+    gl.texImage2D(WEBGL.TEXTURE_2D, 0, WEBGL.RGBA8, colorBuffer.length / 4, 1, 0, WEBGL.RGBA, WEBGL.UNSIGNED_BYTE, colorBuffer);
     gl.texParameteri(WEBGL.TEXTURE_2D, WEBGL.TEXTURE_MIN_FILTER, WEBGL.NEAREST);
     gl.texParameteri(WEBGL.TEXTURE_2D, WEBGL.TEXTURE_MAG_FILTER, WEBGL.NEAREST);
     return colorTexture;

--- a/engine/esm/layers/color_map_container.js
+++ b/engine/esm/layers/color_map_container.js
@@ -44,42 +44,17 @@ ColorMapContainer.fromStringList = function (color_list) {
     return temp;
 };
 
-// Names are chosen to match matplotlib (which explains why some are
-// less-than-ideal).
 ColorMapContainer.fromNamedColormap = function (name) {
     if (name == null) {
         return null;
     }
-    switch (name.toLowerCase()) {
-        case 'viridis':
-            return ColorMapContainer.viridis;
-        case 'plasma':
-            return ColorMapContainer.plasma;
-        case 'inferno':
-            return ColorMapContainer.inferno;
-        case 'magma':
-            return ColorMapContainer.magma;
-        case 'cividis':
-            return ColorMapContainer.cividis;
-        case 'greys': // this is 0=>white, 1=>black
-            return ColorMapContainer.greys;
-        case 'gray': // this is 0=>black, 1=>white
-            return ColorMapContainer.gray;
-        case 'purples':
-            return ColorMapContainer.purples;
-        case 'blues':
-            return ColorMapContainer.blues;
-        case 'greens':
-            return ColorMapContainer.greens;
-        case 'oranges':
-            return ColorMapContainer.oranges;
-        case 'reds':
-            return ColorMapContainer.reds;
-        case 'rdylbu':
-            return ColorMapContainer.rdYlBu;
-    }
-    return null;
+    var cmap = ColorMapContainer._namedColormaps[name.toLowerCase()];
+    return cmap != null ? cmap : null;
 };
+
+ColorMapContainer.registerNamedColormap = function (name, colormap) {
+  ColorMapContainer._namedColormaps[name] = colormap;
+}
 
 ColorMapContainer._getTextureFromName = function (gl, name) {
     var texture = ColorMapContainer.colorTextures[name];
@@ -637,3 +612,21 @@ ColorMapContainer.rdYlBu = ColorMapContainer.fromStringList([
     '#3d5ba7', '#3c59a6', '#3b56a5', '#3a54a4', '#3a51a2', '#394fa1', '#384ca0', '#374a9f',
     '#36479e', '#36459c', '#35429b', '#34409a', '#333d99', '#333b97', '#323896', '#313695'
 ]);
+
+// Names are chosen to match matplotlib (which explains why some are
+// less-than-ideal).
+ColorMapContainer._namedColormaps = {
+  "viridis": ColorMapContainer.viridis,
+  "plasma": ColorMapContainer.plasma,
+  "inferno": ColorMapContainer.inferno,
+  "magma": ColorMapContainer.magma,
+  "cividis": ColorMapContainer.cividis,
+  "greys": ColorMapContainer.greys,  // this is 0=>white, 1=>black
+  "gray": ColorMapContainer.gray,  // this is 0=>black, 1=>white
+  "purples": ColorMapContainer.purples,
+  "blues": ColorMapContainer.blues,
+  "greens": ColorMapContainer.greens,
+  "oranges": ColorMapContainer.oranges,
+  "reds": ColorMapContainer.reds,
+  "rdylbu": ColorMapContainer.rdYlBu
+};

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -642,6 +642,12 @@ export namespace ColorMapContainer {
    */
   export function fromNamedColormap(name: string): ColorMapContainer;
 
+  /** Register a new named colormap. This colormap can then be retrieved from `fromNamedColormap`.
+   *
+   * Note that if you use an existing colormap name (including one of the defaults) as the
+   * value of `name`, this will overwrite that entry in the colormap registry (and it will
+   * no longer be accessible via `fromNamedColormap`).
+   */
   export function registerNamedColormap(name: string, colormap: ColorMapContainer): void;
 }
 

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -624,7 +624,7 @@ export namespace ColorMapContainer {
 
   /** Create a new ColorMapContainer from the named preset value.
    *
-   * The presets are extracted from Matplotlib. Accepted values include:
+   * The presets are extracted from Matplotlib. Accepted built-in values include:
    *
    * - viridis
    * - plasma
@@ -641,6 +641,8 @@ export namespace ColorMapContainer {
    * - rdylbu
    */
   export function fromNamedColormap(name: string): ColorMapContainer;
+
+  export function registerNamedColormap(name: string, colormap: ColorMapContainer): void;
 }
 
 /** A class describing rise/set/transit details */


### PR DESCRIPTION
The web engine has a built-in list of colormaps which can be obtained by name (taken from the set of matplotlib colormaps that we all know and love). And while the existing colormap functionality makes it straightforward to create a new colormap, there's currently no way to give a custom colormap a name to use it in places that want a named colormap (e.g. FITS properties). This PR aims to change that. The approach here is straightforward - currently named colormap retrieval is done via a switch statement in the function, but this is changed to an object keyed on the colormap name so that we can easily add named colormaps.

Additionally, currently colormaps only use RGB values. One can specify a colormap using RGBA values, but when the colormap gets used for rendering the engine creates an Nx1 texture using only the RGB values. This PR updates that process to include the alpha values as well, allowing for the creation of colormaps that vary in opacity. Note that this has no effect on the existing colormaps as they are all specified using only RGB colors with A = 255.

As an example of this, here's a [FITS image of the W5 region](https://docs.glueviz.org/en/stable/_downloads/4899eb8c5d0a367f6836af0219ff95ab/w5.tgz) rendered using a custom version of Viridis where the alpha value goes from 0 -> 1 through the colormap. You can make this colormap in e.g. the webclient using

```javascript
colors = wwtlib.ColorMapContainer.viridis.colors.map((color, index) => [index, color.r, color.g, color.b]);
cm=wwtlib.ColorMapContainer.fromArgbList(colors);
wwtlib.ColorMapContainer.registerNamedColormap("viridisalpha", cm);
layer.get_imageSet().get_fitsProperties().colorMapName = "viridisalpha"
```

<img width="898" height="515" alt="Screenshot 2026-05-27 at 3 16 43 PM" src="https://github.com/user-attachments/assets/1466b721-5f13-4558-9e70-8598cec4642d" />
