### PR TITLE
use more robust nan detection

### DIFF
--- a/engine/esm/graphics/shaders.js
+++ b/engine/esm/graphics/shaders.js
@@ -1581,7 +1581,7 @@ FitsShader.init = function (renderContext) {
             // See https://stackoverflow.com/questions/9446888/best-way-to-detect-nans-in-opengl-shaders
             // PKGW also finds that we need "value != value" on his Dell laptop running
             // Chrome on Linux.
-            return (value != value) || !(value < 0.0 || 0.0 < value || value == 0.0);
+            return (value != value) || !(value < 0.0 || 0.0 < value || value == 0.0) || isnan(value);
         }
 
         void main(void) {

--- a/engine/esm/graphics/shaders.js
+++ b/engine/esm/graphics/shaders.js
@@ -1581,11 +1581,11 @@ FitsShader.init = function (renderContext) {
             // See https://stackoverflow.com/questions/9446888/best-way-to-detect-nans-in-opengl-shaders
             // PKGW also finds that we need "value != value" on his Dell laptop running
             // Chrome on Linux.
-            // isnan has to be implement in WebGL but may return false on some systems.
+            // isnan is supposed to be implemented in WebGL but but apparently isn't always.
             // so then check the bit pattern to see if is nan. 
             // https://sakibsaikia.github.io/graphics/2022/01/04/Nan-Checks-In-HLSL.html
             highp uint bits = floatBitsToUint(value);
-            return (value != value) || !(value < 0.0 || 0.0 < value || value == 0.0) || isnan(value) || ((bits & 0x7fffffffu) > 0x7f800000u);
+            return (value != value) || !(value < 0.0 || 0.0 < value || value == 0.0) || ((bits & 0x7fffffffu) > 0x7f800000u);
         }
 
         void main(void) {

--- a/engine/esm/graphics/shaders.js
+++ b/engine/esm/graphics/shaders.js
@@ -1581,7 +1581,11 @@ FitsShader.init = function (renderContext) {
             // See https://stackoverflow.com/questions/9446888/best-way-to-detect-nans-in-opengl-shaders
             // PKGW also finds that we need "value != value" on his Dell laptop running
             // Chrome on Linux.
-            return (value != value) || !(value < 0.0 || 0.0 < value || value == 0.0) || isnan(value);
+            // isnan has to be implement in WebGL but may return false on some systems.
+            // so then check the bit pattern to see if is nan. 
+            // https://sakibsaikia.github.io/graphics/2022/01/04/Nan-Checks-In-HLSL.html
+            highp uint bits = floatBitsToUint(value);
+            return (value != value) || !(value < 0.0 || 0.0 < value || value == 0.0) || isnan(value) || ((bits & 0x7fffffffu) > 0x7f800000u);
         }
 
         void main(void) {


### PR DESCRIPTION
At least for me (running Chrome on Mac with Apple M2), the NaN values in a FITS file are not being detected in the shader. Optimization is basically optimizing the value of the `isNaN` function to be a constant `false` and NaN ends up being collapsed to zero. 

This PR adds a bits based check for nan values. 

I originally used `isnan`. But considering how long it has been a part of the standard, I was concerned about why it wasn't used originally. Apparenlty, if a system does not support NaN it will always return false. Perhaps this is why it was avoided. 

In any case, the NaN is still a value, and by looking at the bits it can be identified. 