### PR TITLE
Respect layer color alpha

### DIFF
--- a/engine/esm/graphics/shaders.js
+++ b/engine/esm/graphics/shaders.js
@@ -595,7 +595,7 @@ TimeSeriesPointSpriteShader.init = function (renderContext) {
             }
             else
             {
-                vColor = vec4(aVertexColor.r, aVertexColor.g, aVertexColor.b, dAlpha);
+                vColor = vec4(aVertexColor.r, aVertexColor.g, aVertexColor.b, aVertexColor.a * dAlpha);
             }
 
             float lSize = scale;

--- a/engine/esm/layers/layer_manager.js
+++ b/engine/esm/layers/layer_manager.js
@@ -1357,7 +1357,7 @@ LayerManager._colorMenu_Click = function (sender, e) {
     var layer = LayerManager._selectedLayer;
     var picker = new ColorPicker();
     if (layer.get_color() != null) {
-        picker.color = layer.get_color();
+        picker.color = layer.get_color()._clone();
     }
     picker.callBack = function () {
         layer.set_color(picker.color);


### PR DESCRIPTION
This PR makes two changes:
* Respect the alpha component of the layer color when rendering (as well as the layer opacity). This is a bit awkward, but we have the layer opacity and WWT colors have an alpha component, so we really should respect them both
* Pass a clone of the layer color when creating a color picker. This prevents a situation in the web client where the color picker view there can modify only the alpha (via the slider), but this updates the same color instance that the layer has, meaning that a `set_color` call doesn't update the layer version and so the vertex buffer is not updated.

These two changes, together with a small tweak in the web client, will resolve https://github.com/WorldWideTelescope/wwt-web-client/issues/374.