### PR TITLE
Update ray-finding method to account for Y/Z flip in 3D mode

### DIFF
--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -1618,7 +1618,13 @@ var WWTControl$ = {
       var pt = Vector2d.create(x, y);
       var pointFar = this.transformPickPointToWorldSpace(pt, this.renderContext.width, this.renderContext.height, false, far);
       var pointNear = this.transformPickPointToWorldSpace(pt, this.renderContext.width, this.renderContext.height, false, near);
-      var diff = Vector3d.create(pointFar.x - pointNear.x, pointFar.y - pointNear.y, pointFar.z - pointNear.z);
+      var diff;
+      if (this.get_solarSystemMode()) {
+        pointNear = Vector3d.create(pointNear.x, pointNear.z, pointNear.y);
+        diff = Vector3d.create(pointFar.x - pointNear.x, pointFar.z - pointNear.z, pointFar.y - pointNear.y);
+      } else {
+        diff = Vector3d.create(pointFar.x - pointNear.x, pointFar.y - pointNear.y, pointFar.z - pointNear.z);
+      }
       
       return [pointNear, diff];
     },


### PR DESCRIPTION
This PR updates the ray-finding method to account for the Y/Z flip in 3D mode. This is the same idea as #383 (just in the opposite direction)