### PR TITLE
Use same rotation matrix for coordinate transformations and render context

### DIFF
--- a/engine/esm/coordinates.js
+++ b/engine/esm/coordinates.js
@@ -442,10 +442,7 @@ Coordinates.meanObliquityOfEcliptic = function (JD) {
 Coordinates.j2000toGalactic = function (J2000RA, J2000DEC) {
     var J2000pos = [Math.cos(J2000RA / 180 * Math.PI) * Math.cos(J2000DEC / 180 * Math.PI), Math.sin(J2000RA / 180 * Math.PI) * Math.cos(J2000DEC / 180 * Math.PI), Math.sin(J2000DEC / 180 * Math.PI)];
     if (Coordinates._rotationMatrix == null) {
-        Coordinates._rotationMatrix = new Array(3);
-        Coordinates._rotationMatrix[0] = [-0.0548755604, -0.8734370902, -0.4838350155];
-        Coordinates._rotationMatrix[1] = [0.4941094279, -0.44482963, 0.7469822445];
-        Coordinates._rotationMatrix[2] = [-0.867666149, -0.1980763734, 0.4559837762];
+        Coordinates._initializeGalacticRotationMatrix();
     }
     var Galacticpos = new Array(3);
     for (var i = 0; i < 3; i++) {
@@ -467,13 +464,25 @@ Coordinates.galacticTo3dDouble = function (l, b) {
     return Coordinates.raDecTo3dAu(result[0] / 15, result[1], 1);
 };
 
+Coordinates._initializeGalacticRotationMatrix = function () {
+    Coordinates._rotationMatrix = new Array(3);
+    Coordinates._rotationMatrix[0] = [-0.0548755604, -0.8734370902, -0.4838350155];
+    Coordinates._rotationMatrix[1] = [0.4941094279, -0.44482963, 0.7469822445];
+    Coordinates._rotationMatrix[2] = [-0.867666149, -0.1980763734, 0.4559837762];
+}
+
+Coordinates.get_galacticRotationMatrix = function () {
+    if (Coordinates._rotationMatrix == null) {
+        Coordinates._initializeGalacticRotationMatrix();
+    }
+
+    return Coordinates._rotationMatrix;
+}
+
 Coordinates.galactictoJ2000 = function (GalacticL2, GalacticB2) {
     var Galacticpos = [Math.cos(GalacticL2 / 180 * Math.PI) * Math.cos(GalacticB2 / 180 * Math.PI), Math.sin(GalacticL2 / 180 * Math.PI) * Math.cos(GalacticB2 / 180 * Math.PI), Math.sin(GalacticB2 / 180 * Math.PI)];
     if (Coordinates._rotationMatrix == null) {
-        Coordinates._rotationMatrix = new Array(3);
-        Coordinates._rotationMatrix[0] = [-0.0548755604, -0.8734370902, -0.4838350155];
-        Coordinates._rotationMatrix[1] = [0.4941094279, -0.44482963, 0.7469822445];
-        Coordinates._rotationMatrix[2] = [-0.867666149, -0.1980763734, 0.4559837762];
+       Coordinates._initializeGalacticRotationMatrix();
     }
     var J2000pos = new Array(3);
     for (var i = 0; i < 3; i++) {

--- a/engine/esm/coordinates.js
+++ b/engine/esm/coordinates.js
@@ -465,6 +465,8 @@ Coordinates.galacticTo3dDouble = function (l, b) {
 };
 
 Coordinates._initializeGalacticRotationMatrix = function () {
+    // The values used here are taken from the Hipparcos-Gaia matrix
+    // https://gea.esac.esa.int/archive/documentation/GDR1/Data_processing/chap_cu3ast/sec_cu3ast_intro.html#SS7
     Coordinates._rotationMatrix = new Array(3);
     Coordinates._rotationMatrix[0] = [-0.0548755604, -0.8734370902, -0.4838350155];
     Coordinates._rotationMatrix[1] = [0.4941094279, -0.44482963, 0.7469822445];

--- a/engine/esm/render_context.js
+++ b/engine/esm/render_context.js
@@ -575,10 +575,13 @@ var RenderContext$ = {
     setupMatricesSpace3d: function (canvasWidth, canvasHeight) {
         this.lighting = false;
         if (!this._firstTimeInit) {
-            this._galacticMatrix = Matrix3d.get_identity();
-            this._galacticMatrix._multiply(Matrix3d._rotationY(-(270 - (17.7603329867975 * 15)) / 180 * Math.PI));
-            this._galacticMatrix._multiply(Matrix3d._rotationX(-(-28.9361739586894) / 180 * Math.PI));
-            this._galacticMatrix._multiply(Matrix3d._rotationZ(((31.422052860102) - 90) / 180 * Math.PI));
+            var mat = Coordinates.get_galactionRotationMatrix();
+            this._galacticMatrix = Matrix3d.create(
+              mat[1][0], mat[2][0], -mat[0][0], 0,
+              mat[1][2], mat[2][2], -mat[0][2], 0,
+              mat[1][1], mat[2][1], -mat[0][1], 0,
+              0, 0, 0, 1,
+            );
             this._firstTimeInit = true;
         }
         this.space = true;
@@ -630,6 +633,7 @@ var RenderContext$ = {
         this.set_world(WorldMatrix);
         this.set_worldBase(WorldMatrix.clone());
         var localZoomFactor = this.viewCamera.zoom;
+        // 343.774 is 6 radians in degrees
         var FovAngle = (localZoomFactor / 343.774) / Math.PI * 180;
         this.cameraPosition = Vector3d.create(0, 0, 0);
 

--- a/engine/esm/render_context.js
+++ b/engine/esm/render_context.js
@@ -575,7 +575,7 @@ var RenderContext$ = {
     setupMatricesSpace3d: function (canvasWidth, canvasHeight) {
         this.lighting = false;
         if (!this._firstTimeInit) {
-            var mat = Coordinates.get_galactionRotationMatrix();
+            var mat = Coordinates.get_galacticRotationMatrix();
             this._galacticMatrix = Matrix3d.create(
               mat[1][0], mat[2][0], -mat[0][0], 0,
               mat[1][2], mat[2][2], -mat[0][2], 0,


### PR DESCRIPTION
This PR resolves #415. The issue is that the `Coordinates` class and the render context have slightly different definitions for the galactic rotation matrix. The approach taken here is to modify the render context matrix to get its entries from the `Coordinates` rotation matrix, so that the coordinate transformations and render context are on the same page. I decided to use the `Coordinates`version as many places might call on the coordinate transformations, whereas the render context matrix is internal to its matrix setup, so this should create the least change overall.