### PR TITLE
Table layer filtering

### DIFF
--- a/engine/esm/graphics/gl_buffers.js
+++ b/engine/esm/graphics/gl_buffers.js
@@ -44,12 +44,26 @@ registerType("IndexBuffer", [IndexBuffer, IndexBuffer$, null, ss.IDisposable]);
 // wwtlib.MaskBuffer
 
 export function MaskBuffer(mask) {
-    this.buffer = tilePrepDevice.createBuffer();
-    tilePrepDevice.bindBuffer(WEBGL.ARRAY_BUFFER, this.buffer);
-    tilePrepDevice.bufferData(WEBGL.ARRAY_BUFFER, mask, WEBGL.STATIC_DRAW);
+    this.mask = mask;
 }
 
 var MaskBuffer$ = {
+    lock: function () {
+        return this.mask;
+    },
+
+    unlock: function () {
+        this.buffer = tilePrepDevice.createBuffer();
+        tilePrepDevice.bindBuffer(WEBGL.ARRAY_BUFFER, this.buffer);
+        var maskArray = new Float32Array(this.mask.length);
+        for (let i = 0; i < this.mask.length; i++) {
+            maskArray[i] = Number(this.mask[i]);
+        }
+        console.log(this.mask);
+        console.log(maskArray);
+        tilePrepDevice.bufferData(WEBGL.ARRAY_BUFFER, maskArray, WEBGL.STATIC_DRAW);
+    },
+    
     dispose: function () {
         tilePrepDevice.bindBuffer(WEBGL.ARRAY_BUFFER, null);
         tilePrepDevice.deleteBuffer(this.buffer);

--- a/engine/esm/graphics/gl_buffers.js
+++ b/engine/esm/graphics/gl_buffers.js
@@ -68,8 +68,12 @@ var MaskBuffer$ = {
     },
 
     update: function (values) {
+        var needNewBuffer = this.buffer == null || this.mask.length != values.length;
         this.mask = values;
-        if (this.buffer == null) {
+        if (needNewBuffer) {
+            if (this.buffer != null) {
+                this.dispose();
+            }
             this.unlock();
             return;
         }

--- a/engine/esm/graphics/gl_buffers.js
+++ b/engine/esm/graphics/gl_buffers.js
@@ -55,12 +55,10 @@ var MaskBuffer$ = {
     unlock: function () {
         this.buffer = tilePrepDevice.createBuffer();
         tilePrepDevice.bindBuffer(WEBGL.ARRAY_BUFFER, this.buffer);
-        var maskArray = new Float32Array(this.mask.length);
+        var maskArray = new Uint8Array(this.mask.length);
         for (let i = 0; i < this.mask.length; i++) {
             maskArray[i] = Number(this.mask[i]);
         }
-        console.log(this.mask);
-        console.log(maskArray);
         tilePrepDevice.bufferData(WEBGL.ARRAY_BUFFER, maskArray, WEBGL.STATIC_DRAW);
     },
     

--- a/engine/esm/graphics/gl_buffers.js
+++ b/engine/esm/graphics/gl_buffers.js
@@ -52,14 +52,30 @@ var MaskBuffer$ = {
         return this.mask;
     },
 
+    _createMaskArray(mask) {
+        var maskArray = new Uint8Array(mask);
+        for (let i = 0; i < this.mask.length; i++) {
+            maskArray[i] = Number(mask[i]);
+        }
+        return maskArray;
+    },
+
     unlock: function () {
         this.buffer = tilePrepDevice.createBuffer();
         tilePrepDevice.bindBuffer(WEBGL.ARRAY_BUFFER, this.buffer);
-        var maskArray = new Uint8Array(this.mask.length);
-        for (let i = 0; i < this.mask.length; i++) {
-            maskArray[i] = Number(this.mask[i]);
-        }
+        var maskArray = this._createMaskArray(this.mask);
         tilePrepDevice.bufferData(WEBGL.ARRAY_BUFFER, maskArray, WEBGL.STATIC_DRAW);
+    },
+
+    update: function (values) {
+        this.mask = values;
+        if (this.buffer == null) {
+            this.unlock();
+            return;
+        }
+
+        tilePrepDevice.bindBuffer(WEBGL.ARRAY_BUFFER, this.buffer);
+        tilePrepDevice.bufferSubData(WEBGL.ARRAY_BUFFER, 0, this._createMaskArray(this.mask));
     },
     
     dispose: function () {

--- a/engine/esm/graphics/gl_buffers.js
+++ b/engine/esm/graphics/gl_buffers.js
@@ -41,6 +41,25 @@ var IndexBuffer$ = {
 registerType("IndexBuffer", [IndexBuffer, IndexBuffer$, null, ss.IDisposable]);
 
 
+// wwtlib.MaskBuffer
+
+export function MaskBuffer(mask) {
+    this.buffer = tilePrepDevice.createBuffer();
+    tilePrepDevice.bindBuffer(WEBGL.ARRAY_BUFFER, this.buffer);
+    tilePrepDevice.bufferData(WEBGL.ARRAY_BUFFER, mask, WEBGL.STATIC_DRAW);
+}
+
+var MaskBuffer$ = {
+    dispose: function () {
+        tilePrepDevice.bindBuffer(WEBGL.ARRAY_BUFFER, null);
+        tilePrepDevice.deleteBuffer(this.buffer);
+        this.buffer = null;
+    }
+};
+
+registerType("MaskBuffer", [MaskBuffer, MaskBuffer$, null, ss.IDisposable]);
+
+
 // wwtlib.VertexBufferBase
 
 export function VertexBufferBase() { }

--- a/engine/esm/graphics/primitives3d.js
+++ b/engine/esm/graphics/primitives3d.js
@@ -753,6 +753,8 @@ var PointList$ = {
     },
 
     set_mask: function (value) {
+        console.log(value);
+        console.log(value?.length ?? null);
         this._mask = this._createMaskBuffer(value);
         if (this._mask != null) {
             this._mask.unlock();
@@ -889,7 +891,7 @@ var PointList$ = {
             var $enum2 = ss.enumerate(this._pointBuffers);
             while ($enum2.moveNext()) {
                 var pointBuffer = $enum2.current;
-                TimeSeriesPointSpriteShader.use(renderContext, pointBuffer.vertexBuffer, PointList.starTexture.texture2d, Color.fromArgb(255 * opacity, 255, 255, 255), this.depthBuffered, this.jNow, (this.timeSeries) ? this.decay : 0, cam, (this.scale * (renderContext.height / 960)), this.minSize, this.showFarSide, this.sky, this._mask);
+                TimeSeriesPointSpriteShader.use(renderContext, pointBuffer.vertexBuffer, PointList.starTexture.texture2d, Color.fromArgb(255 * opacity, 255, 255, 255), this.depthBuffered, this.jNow, (this.timeSeries) ? this.decay : 0, cam, (this.scale * (renderContext.height / 960)), this.minSize, this.showFarSide, this.sky, this._mask ? this._mask.buffer : null);
                 renderContext.gl.drawArrays(WEBGL.POINTS, 0, pointBuffer.count);
             }
             renderContext.gl.depthMask(originalDepthMask);
@@ -908,7 +910,7 @@ var PointList$ = {
         renderContext.gl.depthMask(depthMask);
         while ($enum1.moveNext()) {
             var pointBuffer = $enum1.current;
-            TimeSeriesPointSpriteShader.use(renderContext, pointBuffer.vertexBuffer, texture, Color.fromArgb(255 * opacity, 255, 255, 255), this.depthBuffered, this.jNow, this.decay, cam, (this.scale * (renderContext.height / 960)), this.minSize, this.showFarSide, this.sky, this._mask);
+            TimeSeriesPointSpriteShader.use(renderContext, pointBuffer.vertexBuffer, texture, Color.fromArgb(255 * opacity, 255, 255, 255), this.depthBuffered, this.jNow, this.decay, cam, (this.scale * (renderContext.height / 960)), this.minSize, this.showFarSide, this.sky, this._mask ? this._mask.buffer : null);
             renderContext.gl.drawArrays(WEBGL.POINTS, 0, pointBuffer.count);
         }
         renderContext.gl.depthMask(originalDepthMask);

--- a/engine/esm/graphics/primitives3d.js
+++ b/engine/esm/graphics/primitives3d.js
@@ -715,6 +715,7 @@ export function PointList(device) {
     this._dates = [];
     this._sizes = [];
     this._mask = null;
+    this._masked = false;
     this.timeSeries = false;
     this.showFarSide = false;
     this.sky = false;
@@ -750,12 +751,20 @@ var PointList$ = {
         this._dates.length = 0;
         this._sizes.length = 0;
         this._emptyPointBuffer();
+        this._emptyMaskBuffer();
     },
 
     set_mask: function (value) {
-        this._mask = this._createMaskBuffer(value);
-        if (this._mask != null) {
-            this._mask.unlock();
+        if (value == null) {
+            this._masked = false;
+            return;
+        }
+        this._masked = true;
+        if (this._mask == null) {
+          this._mask = this._createMaskBuffer(value);
+          this._mask.unlock();
+        } else {
+            this._mask.update(value);
         }
     },
 
@@ -767,6 +776,12 @@ var PointList$ = {
         }
         this._pointBuffers.length = 0;
         this._init = false;
+    },
+
+    _emptyMaskBuffer: function () {
+        if (this._mask != null) {
+            this._mask.dispose();
+        }
     },
 
     _initBuffer: function (renderContext) {
@@ -841,9 +856,6 @@ var PointList$ = {
     },
 
     _createMaskBuffer: function (values) {
-        if (values == null || values.length === 0) {
-            return null;
-        }
         return new MaskBuffer(values); 
     },
 
@@ -889,7 +901,7 @@ var PointList$ = {
             var $enum2 = ss.enumerate(this._pointBuffers);
             while ($enum2.moveNext()) {
                 var pointBuffer = $enum2.current;
-                TimeSeriesPointSpriteShader.use(renderContext, pointBuffer.vertexBuffer, PointList.starTexture.texture2d, Color.fromArgb(255 * opacity, 255, 255, 255), this.depthBuffered, this.jNow, (this.timeSeries) ? this.decay : 0, cam, (this.scale * (renderContext.height / 960)), this.minSize, this.showFarSide, this.sky, this._mask ? this._mask.buffer : null);
+                TimeSeriesPointSpriteShader.use(renderContext, pointBuffer.vertexBuffer, PointList.starTexture.texture2d, Color.fromArgb(255 * opacity, 255, 255, 255), this.depthBuffered, this.jNow, (this.timeSeries) ? this.decay : 0, cam, (this.scale * (renderContext.height / 960)), this.minSize, this.showFarSide, this.sky, this._masked ? this._mask.buffer : null);
                 renderContext.gl.drawArrays(WEBGL.POINTS, 0, pointBuffer.count);
             }
             renderContext.gl.depthMask(originalDepthMask);
@@ -908,7 +920,7 @@ var PointList$ = {
         renderContext.gl.depthMask(depthMask);
         while ($enum1.moveNext()) {
             var pointBuffer = $enum1.current;
-            TimeSeriesPointSpriteShader.use(renderContext, pointBuffer.vertexBuffer, texture, Color.fromArgb(255 * opacity, 255, 255, 255), this.depthBuffered, this.jNow, this.decay, cam, (this.scale * (renderContext.height / 960)), this.minSize, this.showFarSide, this.sky, this._mask ? this._mask.buffer : null);
+            TimeSeriesPointSpriteShader.use(renderContext, pointBuffer.vertexBuffer, texture, Color.fromArgb(255 * opacity, 255, 255, 255), this.depthBuffered, this.jNow, this.decay, cam, (this.scale * (renderContext.height / 960)), this.minSize, this.showFarSide, this.sky, this._masked ? this._mask.buffer : null);
             renderContext.gl.drawArrays(WEBGL.POINTS, 0, pointBuffer.count);
         }
         renderContext.gl.depthMask(originalDepthMask);

--- a/engine/esm/graphics/primitives3d.js
+++ b/engine/esm/graphics/primitives3d.js
@@ -753,8 +753,6 @@ var PointList$ = {
     },
 
     set_mask: function (value) {
-        console.log(value);
-        console.log(value?.length ?? null);
         this._mask = this._createMaskBuffer(value);
         if (this._mask != null) {
             this._mask.unlock();

--- a/engine/esm/graphics/primitives3d.js
+++ b/engine/esm/graphics/primitives3d.js
@@ -10,6 +10,7 @@ import { Color } from "../color.js";
 import { URLHelpers } from "../url_helpers.js";
 import { WEBGL } from "./webgl_constants.js";
 import {
+    MaskBuffer,
     PositionVertexBuffer,
     PositionColoredVertexBuffer,
     TimeSeriesLineVertexBuffer,
@@ -713,6 +714,7 @@ export function PointList(device) {
     this._colors = [];
     this._dates = [];
     this._sizes = [];
+    this._mask = null;
     this.timeSeries = false;
     this.showFarSide = false;
     this.sky = false;
@@ -748,6 +750,13 @@ var PointList$ = {
         this._dates.length = 0;
         this._sizes.length = 0;
         this._emptyPointBuffer();
+    },
+
+    set_mask: function (value) {
+        this._mask = this._createMaskBuffer(value);
+        if (this._mask != null) {
+            this._mask.unlock();
+        }
     },
 
     _emptyPointBuffer: function () {
@@ -831,6 +840,13 @@ var PointList$ = {
         }
     },
 
+    _createMaskBuffer: function (values) {
+        if (values == null || values.length === 0) {
+            return null;
+        }
+        return new MaskBuffer(values); 
+    },
+
     draw: function (renderContext, opacity, cull, depthMask=false) {
         this._initBuffer(renderContext);
         if (renderContext.gl == null) {
@@ -873,7 +889,7 @@ var PointList$ = {
             var $enum2 = ss.enumerate(this._pointBuffers);
             while ($enum2.moveNext()) {
                 var pointBuffer = $enum2.current;
-                TimeSeriesPointSpriteShader.use(renderContext, pointBuffer.vertexBuffer, PointList.starTexture.texture2d, Color.fromArgb(255 * opacity, 255, 255, 255), this.depthBuffered, this.jNow, (this.timeSeries) ? this.decay : 0, cam, (this.scale * (renderContext.height / 960)), this.minSize, this.showFarSide, this.sky);
+                TimeSeriesPointSpriteShader.use(renderContext, pointBuffer.vertexBuffer, PointList.starTexture.texture2d, Color.fromArgb(255 * opacity, 255, 255, 255), this.depthBuffered, this.jNow, (this.timeSeries) ? this.decay : 0, cam, (this.scale * (renderContext.height / 960)), this.minSize, this.showFarSide, this.sky, this._mask);
                 renderContext.gl.drawArrays(WEBGL.POINTS, 0, pointBuffer.count);
             }
             renderContext.gl.depthMask(originalDepthMask);
@@ -892,7 +908,7 @@ var PointList$ = {
         renderContext.gl.depthMask(depthMask);
         while ($enum1.moveNext()) {
             var pointBuffer = $enum1.current;
-            TimeSeriesPointSpriteShader.use(renderContext, pointBuffer.vertexBuffer, texture, Color.fromArgb(255 * opacity, 255, 255, 255), this.depthBuffered, this.jNow, this.decay, cam, (this.scale * (renderContext.height / 960)), this.minSize, this.showFarSide, this.sky);
+            TimeSeriesPointSpriteShader.use(renderContext, pointBuffer.vertexBuffer, texture, Color.fromArgb(255 * opacity, 255, 255, 255), this.depthBuffered, this.jNow, this.decay, cam, (this.scale * (renderContext.height / 960)), this.minSize, this.showFarSide, this.sky, this._mask);
             renderContext.gl.drawArrays(WEBGL.POINTS, 0, pointBuffer.count);
         }
         renderContext.gl.depthMask(originalDepthMask);

--- a/engine/esm/graphics/shaders.js
+++ b/engine/esm/graphics/shaders.js
@@ -561,7 +561,7 @@ TimeSeriesPointSpriteShader.init = function (renderContext) {
         attribute vec4 aVertexColor;
         attribute vec2 aTime;
         attribute float aPointSize;
-        attribute bool aShow;
+        attribute float aShow;
         uniform mat4 uMVMatrix;
         uniform mat4 uPMatrix;
         uniform float jNow;
@@ -579,7 +579,7 @@ TimeSeriesPointSpriteShader.init = function (renderContext) {
             float dotCam = dot( normalize(cameraPosition-aVertexPosition), normalize(aVertexPosition));
             float dist = distance(aVertexPosition, cameraPosition);
             gl_Position = uPMatrix * uMVMatrix * vec4(aVertexPosition, 1.0);
-            float dAlpha = int(aShow);
+            float dAlpha = aShow;
 
             if ( dAlpha > 0.0 && decay > 0.0 )
             {
@@ -677,6 +677,7 @@ TimeSeriesPointSpriteShader.use = function (renderContext, vertex, texture, line
         gl.disableVertexAttribArray(1);
         gl.disableVertexAttribArray(2);
         gl.disableVertexAttribArray(3);
+        gl.disableVertexAttribArray(4);
         gl.bindBuffer(WEBGL.ARRAY_BUFFER, vertex);
         gl.bindBuffer(WEBGL.ELEMENT_ARRAY_BUFFER, null);
         gl.enableVertexAttribArray(TimeSeriesPointSpriteShader.vertLoc);
@@ -691,10 +692,10 @@ TimeSeriesPointSpriteShader.use = function (renderContext, vertex, texture, line
         if (mask != null) {
           gl.bindBuffer(WEBGL.ARRAY_BUFFER, mask);
           gl.enableVertexAttribArray(TimeSeriesPointSpriteShader.showLoc);
-          gl.vertexAttribPointer(TimeSeriesPointSpriteShader.showLoc, 1, WEBGL.BOOL, false, 0, 0);
+          gl.vertexAttribPointer(TimeSeriesPointSpriteShader.showLoc, 1, WEBGL.FLOAT, false, 0, 0);
         } else {
           gl.disableVertexAttribArray(TimeSeriesPointSpriteShader.showLoc);
-          gl.vertexAttribI1ui(TimeSeriesPointSpriteShader.showLoc, 1);
+          gl.vertexAttrib1f(TimeSeriesPointSpriteShader.showLoc, 1.0);
         }
 
         gl.activeTexture(WEBGL.TEXTURE0);

--- a/engine/esm/graphics/shaders.js
+++ b/engine/esm/graphics/shaders.js
@@ -692,7 +692,7 @@ TimeSeriesPointSpriteShader.use = function (renderContext, vertex, texture, line
         if (mask != null) {
           gl.bindBuffer(WEBGL.ARRAY_BUFFER, mask);
           gl.enableVertexAttribArray(TimeSeriesPointSpriteShader.showLoc);
-          gl.vertexAttribPointer(TimeSeriesPointSpriteShader.showLoc, 1, WEBGL.FLOAT, false, 0, 0);
+          gl.vertexAttribPointer(TimeSeriesPointSpriteShader.showLoc, 1, WEBGL.UNSIGNED_BYTE, false, 0, 0);
         } else {
           gl.disableVertexAttribArray(TimeSeriesPointSpriteShader.showLoc);
           gl.vertexAttrib1f(TimeSeriesPointSpriteShader.showLoc, 1.0);

--- a/engine/esm/graphics/shaders.js
+++ b/engine/esm/graphics/shaders.js
@@ -561,6 +561,7 @@ TimeSeriesPointSpriteShader.init = function (renderContext) {
         attribute vec4 aVertexColor;
         attribute vec2 aTime;
         attribute float aPointSize;
+        attribute bool aShow;
         uniform mat4 uMVMatrix;
         uniform mat4 uPMatrix;
         uniform float jNow;
@@ -578,9 +579,9 @@ TimeSeriesPointSpriteShader.init = function (renderContext) {
             float dotCam = dot( normalize(cameraPosition-aVertexPosition), normalize(aVertexPosition));
             float dist = distance(aVertexPosition, cameraPosition);
             gl_Position = uPMatrix * uMVMatrix * vec4(aVertexPosition, 1.0);
-            float dAlpha = 1.0;
+            float dAlpha = int(aShow);
 
-            if ( decay > 0.0)
+            if ( dAlpha > 0.0 && decay > 0.0 )
             {
                     dAlpha = 1.0 - ((jNow - aTime.y) / decay);
                     if (dAlpha > 1.0 )
@@ -629,6 +630,7 @@ TimeSeriesPointSpriteShader.init = function (renderContext) {
     TimeSeriesPointSpriteShader.colorLoc = gl.getAttribLocation(TimeSeriesPointSpriteShader._prog, 'aVertexColor');
     TimeSeriesPointSpriteShader.pointSizeLoc = gl.getAttribLocation(TimeSeriesPointSpriteShader._prog, 'aPointSize');
     TimeSeriesPointSpriteShader.timeLoc = gl.getAttribLocation(TimeSeriesPointSpriteShader._prog, 'aTime');
+    TimeSeriesPointSpriteShader.showLoc = gl.getAttribLocation(TimeSeriesPointSpriteShader._prog, 'aShow');
     TimeSeriesPointSpriteShader.projMatLoc = gl.getUniformLocation(TimeSeriesPointSpriteShader._prog, 'uPMatrix');
     TimeSeriesPointSpriteShader.mvMatLoc = gl.getUniformLocation(TimeSeriesPointSpriteShader._prog, 'uMVMatrix');
     TimeSeriesPointSpriteShader.sampLoc = gl.getUniformLocation(TimeSeriesPointSpriteShader._prog, 'uSampler');
@@ -644,7 +646,7 @@ TimeSeriesPointSpriteShader.init = function (renderContext) {
     TimeSeriesPointSpriteShader.initialized = true;
 };
 
-TimeSeriesPointSpriteShader.use = function (renderContext, vertex, texture, lineColor, zBuffer, jNow, decay, camera, scale, minSize, showFarSide, sky) {
+TimeSeriesPointSpriteShader.use = function (renderContext, vertex, texture, lineColor, zBuffer, jNow, decay, camera, scale, minSize, showFarSide, sky, mask) {
     if (texture == null) {
         texture = Texture.getEmpty();
     }
@@ -685,6 +687,16 @@ TimeSeriesPointSpriteShader.use = function (renderContext, vertex, texture, line
         gl.vertexAttribPointer(TimeSeriesPointSpriteShader.colorLoc, 4, WEBGL.FLOAT, false, 40, 12);
         gl.vertexAttribPointer(TimeSeriesPointSpriteShader.pointSizeLoc, 1, WEBGL.FLOAT, false, 40, 36);
         gl.vertexAttribPointer(TimeSeriesPointSpriteShader.timeLoc, 2, WEBGL.FLOAT, false, 40, 28);
+
+        if (mask != null) {
+          gl.bindBuffer(WEBGL.ARRAY_BUFFER, mask);
+          gl.enableVertexAttribArray(TimeSeriesPointSpriteShader.showLoc);
+          gl.vertexAttribPointer(TimeSeriesPointSpriteShader.showLoc, 1, WEBGL.BOOL, false, 0, 0);
+        } else {
+          gl.disableVertexAttribArray(TimeSeriesPointSpriteShader.showLoc);
+          gl.vertexAttribI1ui(TimeSeriesPointSpriteShader.showLoc, 1);
+        }
+
         gl.activeTexture(WEBGL.TEXTURE0);
         gl.bindTexture(WEBGL.TEXTURE_2D, texture);
         gl.lineWidth(1);

--- a/engine/esm/layers/spreadsheet_layer.js
+++ b/engine/esm/layers/spreadsheet_layer.js
@@ -1937,6 +1937,9 @@ var SpreadSheetLayer$ = {
     },
 
     _createMask: function () {
+        if (this._filter == null) {
+            return null;
+        }
         var count = this._table$1.rows.length;
         var mask = new Array(count);
         for (let i = 0; i < count; i++) {
@@ -1948,7 +1951,7 @@ var SpreadSheetLayer$ = {
     set_filter: function (filter, dynamic) {
         this._filter = filter;
         this._filterDynamic = dynamic;
-        if (!this._filterDynamic) {
+        if (this._filter == null || !this._filterDynamic) {
             // TODO: Do we need to check whether the point list is non-null?
             // and if so, how would we deal with that?
             this.pointList.set_mask(this._createMask());

--- a/engine/esm/layers/spreadsheet_layer.js
+++ b/engine/esm/layers/spreadsheet_layer.js
@@ -1958,6 +1958,12 @@ var SpreadSheetLayer$ = {
         }
     },
 
+    remove_filter: function () {
+        this._filter = null;
+        this._filterDynamic = false;
+        this.pointList.set_mask(null);
+    },
+
     draw: function (renderContext, opacity, flat) {
         var device = renderContext;
         if (this.version !== this.lastVersion) {

--- a/engine/esm/layers/spreadsheet_layer.js
+++ b/engine/esm/layers/spreadsheet_layer.js
@@ -237,6 +237,10 @@ export function SpreadSheetLayer() {
     this.pointScaleType = 1;
     this.positions = [];
     this.bufferIsFlat = false;
+
+    this._filter = null;
+    this._filterDynamic = false;
+
     this.baseDate = new Date(2010, 0, 1, 12, 0, 0);
     this.dirty = true;
     this.lastVersion = 0;
@@ -1932,6 +1936,25 @@ var SpreadSheetLayer$ = {
         return value;
     },
 
+    _createMask: function () {
+        var count = this._table$1.rows.length;
+        var mask = new Array(count);
+        for (let i = 0; i < count; i++) {
+            mask[i] = this._filter(this._table$1.rows[i], this._table$1.header, this);
+        }
+        return mask;
+    },
+
+    set_filter: function (filter, dynamic) {
+        this._filter = filter;
+        this._filterDynamic = dynamic;
+        if (!this._filterDynamic) {
+            // TODO: Do we need to check whether the point list is non-null?
+            // and if so, how would we deal with that?
+            this.pointList.set_mask(this._createMask());
+        }
+    },
+
     draw: function (renderContext, opacity, flat) {
         var device = renderContext;
         if (this.version !== this.lastVersion) {
@@ -1941,7 +1964,8 @@ var SpreadSheetLayer$ = {
         if (this.bufferIsFlat !== flat) {
             this.cleanUp();
             this.bufferIsFlat = flat;
-        }
+        } 
+
         if (this.dirty) {
             this.prepVertexBuffer(device, opacity);
         }
@@ -1972,6 +1996,11 @@ var SpreadSheetLayer$ = {
             this.pointList.timeSeries = this.timeSeries;
             this.pointList.jNow = jNow;
             this.pointList.scale = (this._markerScale$1 === 1) ? adjustedScale : -adjustedScale;
+
+            if (this._filter != null && this._filterDynamic) {
+                this.pointList.set_mask(this._createMask());
+            }
+
             switch (this._plotType$1) {
                 case 0:
                     this.pointList.draw(renderContext, opacity * this.get_opacity(), false);

--- a/engine/esm/layers/spreadsheet_layer.js
+++ b/engine/esm/layers/spreadsheet_layer.js
@@ -1951,9 +1951,9 @@ var SpreadSheetLayer$ = {
     set_filter: function (filter, dynamic) {
         this._filter = filter;
         this._filterDynamic = dynamic;
-        if (this._filter == null || !this._filterDynamic) {
-            // TODO: Do we need to check whether the point list is non-null?
-            // and if so, how would we deal with that?
+        // Don't set the mask if the data is dirty
+        // since then we'll do it on the next draw call anywas
+        if (!this.dirty && this.pointList != null && (this._filter == null || !this._filterDynamic)) {
             this.pointList.set_mask(this._createMask());
         }
     },
@@ -1977,6 +1977,7 @@ var SpreadSheetLayer$ = {
 
         if (this.dirty) {
             this.prepVertexBuffer(device, opacity);
+            this.pointList.set_mask(this._createMask());
         }
         var jNow = SpaceTimeController.get_jNow() - SpaceTimeController.utcToJulian(this.baseDate);
         var adjustedScale = this.scaleFactor * 3;

--- a/engine/esm/layers/spreadsheet_layer.js
+++ b/engine/esm/layers/spreadsheet_layer.js
@@ -1942,8 +1942,8 @@ var SpreadSheetLayer$ = {
         }
         var count = this._table$1.rows.length;
         var mask = new Array(count);
-        for (let i = 0; i < count; i++) {
-            mask[i] = this._filter(this._table$1.rows[i], this._table$1.header, this);
+        for (let index = 0; index < count; index++) {
+            mask[index] = this._filter(this._table$1.rows[index], this._table$1.header, index, this);
         }
         return mask;
     },

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -1864,6 +1864,16 @@ export namespace SpaceTimeController {
  * {@link SpaceTimeController} namespace. */
 export type SpaceTimeControllerObject = typeof SpaceTimeController;
 
+
+/**
+ * A type defining the function signature for a filter function to be used in {@link SpreadSheetLayer.set_filter}.
+ *
+ * @param row An array of string values representing the current item. The order matches the order of columns in the table data.
+ * @param header The header row (column names) for the layer's data
+ * @param index The index of the row in the table layer data.
+ * @param layer A reference to the layer.
+ * @returns Whether the point should be displayed.
+ */
 export type SpreadSheetLayerFilter = (row: string[], header: string[], index: number, layer: SpreadSheetLayer) => boolean;
 
 /** A tabular data layer. */

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -1864,6 +1864,7 @@ export namespace SpaceTimeController {
  * {@link SpaceTimeController} namespace. */
 export type SpaceTimeControllerObject = typeof SpaceTimeController;
 
+export type SpreadSheetLayerFilter = (row: string[], header: string[], index: number, layer: SpreadSheetLayer) => boolean;
 
 /** A tabular data layer. */
 export class SpreadSheetLayer extends Layer implements SpreadSheetLayerSettingsInterface {
@@ -1986,6 +1987,22 @@ export class SpreadSheetLayer extends Layer implements SpreadSheetLayerSettingsI
   guessHeaderAssignmentsFromVoTable(votable: VoTable): void;
 
   updateData(data: string, purgeOld: boolean, purgeAll: boolean, hasHeader: boolean): boolean;
+
+  /**
+   * Set a filter to allow masking a subset of the layer's points.
+   * At a low level, setting a filter writes to a separate WebGL buffer that stores the layer's mask.
+   * This means that setting a filter does not involve re-creating the primary buffer.
+   *
+   * @param filter The filter function that determines which points are rendered. Only points for
+   * which the filter returns true are rendered.
+   * @param dynamic Whether the filter should be evaluated once when set (false) or on each frame (true)
+   */
+  set_filter(filter: SpreadSheetLayerFilter, dynamic: boolean): void;
+
+  /**
+   * Unset the filter for the layer. This is the same as calling `set_filter(null, false)`.
+   */
+  remove_filter(): void;
 }
 
 /** The full SpreadSheetLayerSetting type, which augments engine-types'


### PR DESCRIPTION
This PR is a first attempt at implementing table layer filtering as described in #401. The way that this is done here is as follows. I primarily was trying to minimize storage space and `WebGLBuffer` writes.
* If the user doesn't ever create a filter, no extra space is allocated
* When the user assigns a filter, we create a separate WebGL buffer for the mask (which points are shown or not). The mask booleans are passed in as unsigned bytes. That's the smallest thing that we can pass in as attributes. I guess in the future we could think about some kind of bitpacking, but that's beyond the scope of what I want to do here. We then use this value in the shader - if it's zero, we use a clear color. This approach (using a clear color if out of range) is similar to what's done with the start/end date column calculation.
* When the filter is updated, we update only the mask buffer - the primary buffer for the table data is never touched by any of this filtering scheme. This API here allows the caller to specify whether the filter is static or dynamic. If the filter is static, the mask buffer is updated once - I'm imagining the use case for this is that the filtering is done by a user selecting a UI element or some discrete action. If the filter is dynamic, the mask buffer is updated on each frame. This is a lot more costly, but if the user's filter depends on something like e.g. the viewport position that can change constantly, there's really no other option.

To try out an example of this, add the following inside the `waitForReady` block of the research app:
```javascript
const N = 20;
const items: string[] = [];
for (let i = 0; i < N; i++) {
  const ra = 45 + 2 * Math.random();
  const dec = 20 + 3 * Math.random();
  items.push(`${ra}\t${dec}`);
}

const data = items.join("\r\n");

this.createTableLayer({
  referenceFrame: "Sky",
  name: "Data",
  dataCsv: data,
}).then(layer => {
  layer.set_lngColumn(0);
  layer.set_latColumn(1);
  layer.set_raUnits(RAUnits.degrees);
  layer.set_cartesianScale(AltUnits.astronomicalUnits);
  layer.set_markerScale(MarkerScales.screen);
  layer.set_scaleFactor(100);
  layer.set_showFarSide(true);
  layer.set_color(Color.fromArgb(255, 255, 0, 0));

  function filter(_row: string[], _header: string[], index: number, _layer: unknown) {
    return index % 2 == 0;
  }

  function filterDynamic(_row: string[], _header: string[], index: number, _layer: unknown) {
    return index % 2 == Math.round(Date.now() / 1000) % 2;
  }

  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
  // @ts-ignore
  window.layer = layer; window.filter = filter; window.filterDynamic = filterDynamic;

  this.gotoRADecZoom({ raRad: 45 * D2R, decRad: 20 * D2R, zoomDeg: 50, instant: true });
});
```

Then in the JavaScript console you can run e.g.:
```javascript
layer.set_filter(filter, false);  // The static filter
layer.set_filter(filterDynamic, true); // A dynamic filter that remakes the mask buffer on each frame
layer.remove_filter();  // you could also do `layer.set_filter(null, false)`
```