### PR TITLE
Fix calculation of scaleX from CD matrix for WCS images

### DIFF
--- a/engine/esm/layers/wcs_image.js
+++ b/engine/esm/layers/wcs_image.js
@@ -225,7 +225,7 @@ var WcsImage$ = {
     },
 
     calculateScaleFromCD: function () {
-        this.scaleX = (Math.sqrt(this.cd1_1 * this.cd1_1 + this.cd2_1 * this.cd2_1) * (this.cd1_1 * this.cd2_2 - this.cd1_2 * this.cd2_1) < 0) ? -1 : 1;
+        this.scaleX = Math.sqrt(this.cd1_1 * this.cd1_1 + this.cd2_1 * this.cd2_1) * ((this.cd1_1 * this.cd2_2 - this.cd1_2 * this.cd2_1) < 0 ? -1 : 1);
         this.scaleY = Math.sqrt(this.cd1_2 * this.cd1_2 + this.cd2_2 * this.cd2_2);
     },
 


### PR DESCRIPTION
This PR fixes #419. See that issue for the discussion of the problem.