### PR TITLE
Bump Node setup task in CI; bump browserstack-local version

### DIFF
--- a/ci/azure-job-setup.yml
+++ b/ci/azure-job-setup.yml
@@ -65,10 +65,10 @@ steps:
   displayName: Restore release commit
 
 - ${{ if parameters.setupBuild }}:
-  - task: NodeTool@0
+  - task: UseNode@1
     displayName: Set up node.js
     inputs:
-      versionSpec: '16'
+      version: '16'
 
   - bash: yarn install
     displayName: Install Yarn dependencies

--- a/ci/azure-prep.yml
+++ b/ci/azure-prep.yml
@@ -22,10 +22,10 @@ jobs:
       echo "##vso[task.prependpath]$d"
     displayName: Install latest Cranko (Windows)
 
-  - task: NodeTool@0
+  - task: UseNode@1
     displayName: Set up node.js
     inputs:
-      versionSpec: '16'
+      version: '16'
 
   - bash: cranko release-workflow apply-versions
     displayName: Apply versions with Cranko

--- a/tests/package.json
+++ b/tests/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@types/jsdom": "^21.1.0",
     "axios": "^1.16",
-    "browserstack-local": "^1.4.8",
+    "browserstack-local": "^1.5.13",
     "jsdom": "^21.1.0"
   },
   "description": "Tests for the WorldWide Telescope engine and apps.",


### PR DESCRIPTION
This PR bumps `NodeTool@0` to `UseNode@1` in our CI scripts as the former is deprecated - despite the different name, this is the new version of that task (see the Microsoft docs [here](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/use-node-v1?view=azure-pipelines)). We aren't doing anything too fancy so the update is simple, the only real change for our purposes is that the version input is now `version` rather than `versionSpec`.