### PR TITLE
Allow drawing annotations in different coordinates

### DIFF
--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -2007,7 +2007,7 @@ export const engineStore = defineStore('wwt-engine', {
 
     // Annotations
 
-    addAnnotationBatch(options: CreateAnnotationBatchOptions): AnnotationBatch {
+    createAnnotationBatch(options: CreateAnnotationBatchOptions): AnnotationBatch {
       if (this.$wwt.inst === null)
         throw new Error('cannot createAnnotationBatch without linking to WWTInstance');
       const batch = new AnnotationBatch();

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -14,6 +14,7 @@ import {
 
 import {
   Annotation,
+  AnnotationBatch,
   ColorMapContainer,
   EngineSetting,
   Folder,
@@ -24,6 +25,8 @@ import {
   InViewReturnMessage,
   Layer,
   LayerMap,
+  Matrix3d,
+  RenderContext,
   SpreadSheetLayer,
   SpreadSheetLayerSettingsInterfaceRO,
   TileCache,
@@ -204,6 +207,17 @@ export class ImageSetLayerState {
   getGuid(): string {
     return this.guidText;
   }
+}
+
+export type AnnotationTransform =
+  "equatorial" |
+  "horizon"    |
+  Matrix3d     |
+  ((rc: RenderContext) => Matrix3d);
+
+export interface CreateAnnotationBatchOptions {
+  name: string;
+  transform?: AnnotationTransform;
 }
 
 /** This interface expresses the properties exposed by the WWT Engine’s Pinia
@@ -1996,25 +2010,42 @@ export const engineStore = defineStore('wwt-engine', {
 
     // Annotations
 
+    addAnnotationBatch(options: CreateAnnotationBatchOptions): AnnotationBatch {
+      if (this.$wwt.inst === null)
+        throw new Error('cannot createAnnotationBatch without linking to WWTInstance');
+      const batch = new AnnotationBatch();
+      if (options.transform) {
+        batch.viewTransform = options.transform;
+      }
+      this.$wwt.inst.si.addAnnotationBatch(batch, options.name);
+      return batch;
+    },
+
+    removeAnnotationBatch(batch: string | AnnotationBatch): void {
+      if (this.$wwt.inst === null)
+        throw new Error('cannot removeAnnotationBatch without linking to WWTInstance');
+      this.$wwt.inst.si.removeAnnotationBatch(batch);
+    },
+
     /** Add an [Annotation](../../engine/classes/Annotation.html) to the view. */
-    addAnnotation(ann: Annotation): void {
+    addAnnotation(ann: Annotation, batch?: string | AnnotationBatch): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot addAnnotation without linking to WWTInstance');
-      this.$wwt.inst.si.addAnnotation(ann);
+      this.$wwt.inst.si.addAnnotation(ann, batch);
     },
 
     /** Remove the specified [Annotation](../../engine/classes/Annotation.html) from the view. */
-    removeAnnotation(ann: Annotation): void {
+    removeAnnotation(ann: Annotation, batch?: string | AnnotationBatch): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot removeAnnotation without linking to WWTInstance');
-      this.$wwt.inst.si.removeAnnotation(ann);
+      this.$wwt.inst.si.removeAnnotation(ann, batch);
     },
 
     /** Clear all [Annotations](../../engine/classes/Annotation.html) from the view. */
-    clearAnnotations(): void {
+    clearAnnotations(batch?: string | AnnotationBatch): void {
       if (this.$wwt.inst === null)
         throw new Error('cannot clearAnnotations without linking to WWTInstance');
-      this.$wwt.inst.si.clearAnnotations();
+      this.$wwt.inst.si.clearAnnotations(batch);
     },
 
     // Capturing the current display

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -15,7 +15,7 @@ import {
 import {
   Annotation,
   AnnotationBatch,
-  BatchViewTransform,
+  BatchTransform,
   ColorMapContainer,
   EngineSetting,
   Folder,
@@ -210,7 +210,11 @@ export class ImageSetLayerState {
 
 export interface CreateAnnotationBatchOptions {
   name: string;
-  transform?: BatchViewTransform;
+  transforms?: {
+    world?: BatchTransform,
+    projection?: BatchTransform,
+    view?: BatchTransform,
+  };
 }
 
 /** This interface expresses the properties exposed by the WWT Engine’s Pinia
@@ -2007,8 +2011,17 @@ export const engineStore = defineStore('wwt-engine', {
       if (this.$wwt.inst === null)
         throw new Error('cannot createAnnotationBatch without linking to WWTInstance');
       const batch = new AnnotationBatch();
-      if (options.transform) {
-        batch.set_viewTransform(options.transform);
+      const transforms = options.transforms;
+      if (transforms) {
+        if (transforms.world) {
+          batch.set_worldTransform(transforms.world);
+        }
+        if (transforms.view) {
+          batch.set_viewTransform(transforms.view);
+        }
+        if (transforms.projection) {
+          batch.set_projectionTransform(transforms.projection);
+        }
       }
       this.$wwt.inst.si.addAnnotationBatch(batch, options.name);
       return batch;

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -211,7 +211,7 @@ export class ImageSetLayerState {
 
 export type AnnotationTransform =
   "equatorial" |
-  "horizon"    |
+  "horizontal" |
   Matrix3d     |
   ((rc: RenderContext) => Matrix3d);
 

--- a/engine-pinia/src/store.ts
+++ b/engine-pinia/src/store.ts
@@ -15,6 +15,7 @@ import {
 import {
   Annotation,
   AnnotationBatch,
+  BatchViewTransform,
   ColorMapContainer,
   EngineSetting,
   Folder,
@@ -25,8 +26,6 @@ import {
   InViewReturnMessage,
   Layer,
   LayerMap,
-  Matrix3d,
-  RenderContext,
   SpreadSheetLayer,
   SpreadSheetLayerSettingsInterfaceRO,
   TileCache,
@@ -209,15 +208,9 @@ export class ImageSetLayerState {
   }
 }
 
-export type AnnotationTransform =
-  "equatorial" |
-  "horizontal" |
-  Matrix3d     |
-  ((rc: RenderContext) => Matrix3d);
-
 export interface CreateAnnotationBatchOptions {
   name: string;
-  transform?: AnnotationTransform;
+  transform?: BatchViewTransform;
 }
 
 /** This interface expresses the properties exposed by the WWT Engine’s Pinia
@@ -2015,7 +2008,7 @@ export const engineStore = defineStore('wwt-engine', {
         throw new Error('cannot createAnnotationBatch without linking to WWTInstance');
       const batch = new AnnotationBatch();
       if (options.transform) {
-        batch.viewTransform = options.transform;
+        batch.set_viewTransform(options.transform);
       }
       this.$wwt.inst.si.addAnnotationBatch(batch, options.name);
       return batch;

--- a/engine-pinia/src/wwtaware.ts
+++ b/engine-pinia/src/wwtaware.ts
@@ -148,7 +148,7 @@ export const WWTAwareComponent = defineComponent({
       "removeFrameCallback",
       "createColormap",
       "deleteColormap",
-      "addAnnotationBatch",
+      "createAnnotationBatch",
       "removeAnnotationBatch",
       // Formerly mutations
       "addAnnotation",

--- a/engine-pinia/src/wwtaware.ts
+++ b/engine-pinia/src/wwtaware.ts
@@ -148,6 +148,8 @@ export const WWTAwareComponent = defineComponent({
       "removeFrameCallback",
       "createColormap",
       "deleteColormap",
+      "addAnnotationBatch",
+      "removeAnnotationBatch",
       // Formerly mutations
       "addAnnotation",
       "applyFitsLayerSettings",

--- a/engine/esm/annotation.js
+++ b/engine/esm/annotation.js
@@ -42,6 +42,28 @@ AnnotationBatch.horizontalWorldTransform = function (_renderContext) {
     return mat;
 };
 
+AnnotationBatch.overlayWorldTransform = function (position) {
+  var overlayWorldInitial = Matrix3d.rotationYawPitchRoll(-(position.get_RA() - 12) * Coordinates.RCRA, -position.get_dec() * Coordinates.RC, 0);
+  return function (renderContext) {
+    var world = renderContext.get_world().clone();
+    world.invert();
+    return Matrix3d.multiplyMatrix(overlayWorldInitial, world); 
+  }
+}
+
+AnnotationBatch.overlayViewTransform = function (rotation) {
+  var overlayViewInitial = Matrix3d.lookAtLH(
+    Vector3d.create(0, 0, 0),
+    Vector3d.create(0, 0, -1),
+    Vector3d.create(Math.sin(rotation, Math.cos(rotation), 0)),
+  );
+  return function (renderContext) {
+    var view = renderContext.get_view().clone();
+    view.invert();
+    return Matrix3d.multiplyMatrix(overlayViewInitial, view);
+  }
+}
+
 var AnnotationBatch$ = {
     add: function (annotation) {
         this.items.push(annotation);

--- a/engine/esm/annotation.js
+++ b/engine/esm/annotation.js
@@ -31,6 +31,13 @@ export function AnnotationBatch() {
     this._dirty = true;
 }
 
+// Without this matrix, converting from RA/Dec gives
+// (RA, Dec) -> (270 - Az, Alt)
+// This is a previously known problem - for example, the alt/az grid text
+// explicitly offsets by 6 hours = 90 degrees to account for this
+// This matrix provides the correct transformation.
+// It's done in homogeneous coordinates, but we're just flipping x + z
+// and reversing the sign of both
 AnnotationBatch._horizontalWorldAdjustment = Matrix3d.create(
     0, 0, -1, 0,
     0, 1, 0, 0,
@@ -57,7 +64,7 @@ AnnotationBatch.overlayWorldTransform = function (position) {
     world.invert();
     return Matrix3d.multiplyMatrix(overlayWorldInitial, world); 
   }
-}
+};
 
 AnnotationBatch.overlayViewTransform = function (rotation) {
   var overlayViewInitial = Matrix3d.lookAtLH(
@@ -70,7 +77,7 @@ AnnotationBatch.overlayViewTransform = function (rotation) {
     view.invert();
     return Matrix3d.multiplyMatrix(overlayViewInitial, view);
   }
-}
+};
 
 var AnnotationBatch$ = {
     add: function (annotation) {

--- a/engine/esm/annotation.js
+++ b/engine/esm/annotation.js
@@ -31,6 +31,13 @@ export function AnnotationBatch() {
     this._dirty = true;
 }
 
+AnnotationBatch._horizontalWorldAdjustment = Matrix3d.create(
+    0, 0, -1, 0,
+    0, 1, 0, 0,
+    -1, 0, 0, 0,
+    0, 0, 0, 1,
+);
+
 AnnotationBatch.horizontalWorldTransform = function (_renderContext) {
     var zenithAltAz = new Coordinates(0, 0);
     var zenith = Coordinates.horizonToEquitorial(zenithAltAz, SpaceTimeController.get_location(), SpaceTimeController.get_now());
@@ -39,6 +46,7 @@ AnnotationBatch.horizontalWorldTransform = function (_renderContext) {
     var mat = Matrix3d._rotationY(-raPart);
     mat._multiply(Matrix3d._rotationX(decPart));
     mat.invert();
+    mat = Matrix3d.multiplyMatrix(AnnotationBatch._horizontalWorldAdjustment, mat);
     return mat;
 };
 
@@ -162,10 +170,6 @@ Annotation.defaultCoordinateTransform = function (x, y) {
 }
 
 Annotation.galacticCoordinateTransform = Coordinates.galacticTo3dDouble;
-
-Annotation.horizontalCoordinateTransform = function (alt, az) {
-    return Annotation.defaultCoordinateTransform(270 - alt, az);
-}
 
 Annotation.separation = function (Alpha1, Delta1, Alpha2, Delta2) {
     Delta1 = Delta1 / 180 * Math.PI;

--- a/engine/esm/annotation.js
+++ b/engine/esm/annotation.js
@@ -94,7 +94,7 @@ export function Annotation() {
     this.annotationDirty = true;
     this._opacity = 1;
     this._showHoverLabel = false;
-    this._coordinateTransform = Annotation.defaultCoordinateTransform;
+    this.coordinateTransform = Annotation.defaultCoordinateTransform;
 }
 
 Annotation.defaultCoordinateTransform = function (x, y) {
@@ -190,6 +190,15 @@ var Annotation$ = {
         return value;
     },
 
+    get_coordinateTransform: function() {
+        return this.coordinateTransform;
+    },
+
+    set_coordinateTransform: function(transform) {
+        this.coordinateTransform = transform;
+        this.markDirty(true);
+    },
+
     markDirty: function (dirty) {
         this.annotationDirty = dirty;
     },
@@ -209,7 +218,7 @@ export function Circle() {
     this._fillColor$1 = Colors.get_white();
     this._x$1 = 0;
     this._y$1 = 0;
-    this._coordinateTransform = Coordinates.raDecTo3d;
+    this.coordinateTransform = Coordinates.raDecTo3d;
     Annotation.call(this);
 }
 
@@ -274,11 +283,17 @@ var Circle$ = {
         return value;
     },
 
+    set_coordinateTransform: function (transform) {
+        this.coordinateTransform = transform;
+        this.center = this.coordinateTransform(this._x$1, this._y$1);
+        this.markDirty(true);
+    },
+
     setCenter: function (x, y) {
         this.markDirty(true);
-        this._x$1 = x / 15;
+        this._x$1 = x;
         this._y$1 = y;
-        this.center = this._coordinateTransform(this._x$1, this._y$1);
+        this.center = this.coordinateTransform(this._x$1, this._y$1);
     },
 
     draw: function (renderContext, batch) {
@@ -395,7 +410,7 @@ export function Poly() {
 var Poly$ = {
     addPoint: function (x, y) {
         this.markDirty(true);
-        this._points$1.push(this._coordinateTransform(x, y));
+        this._points$1.push([x, y]);
     },
 
     get_fill: function () {
@@ -438,20 +453,29 @@ var Poly$ = {
         return value;
     },
 
+    set_coordinateTransform: function (transform) {
+        this.coordinateTransform = transform;
+        this.markDirty(true);
+    },
+
     draw: function (renderContext, batch) {
         if (renderContext.gl != null) {
             if (this.annotationDirty) {
                 batch.markDirty(true);
                 //todo can we save this work for later?
-                var vertexList = this._points$1;
+                var vertexList = new Array(this._points$1);
+                for (let i = 0; i < this._points$1.length; i++) {
+                    var point = this._points$1[i];
+                    vertexList[i] = this.coordinateTransform(point[0], point[1]);
+                }
 
-                if (this._strokeWidth$1 > 0 && this._points$1.length > 1) {
+                if (this._strokeWidth$1 > 0 && vertexList.length > 1) {
                     var lineColorWithOpacity = this._lineColor$1._clone();
                     lineColorWithOpacity.a = Math.round(lineColorWithOpacity.a * this.get_opacity());
-                    for (var i = 0; i < (this._points$1.length - 1); i++) {
+                    for (var i = 0; i < (vertexList.length - 1); i++) {
                         batch.lineList.addLine(vertexList[i], vertexList[i + 1], lineColorWithOpacity, new Dates(0, 1));
                     }
-                    batch.lineList.addLine(vertexList[this._points$1.length - 1], vertexList[0], lineColorWithOpacity, new Dates(0, 1));
+                    batch.lineList.addLine(vertexList[vertexList.length - 1], vertexList[0], lineColorWithOpacity, new Dates(0, 1));
                 }
                 if (this._fill$1) {
                     var fillColorWithOpacity = this._fillColor$1._clone();
@@ -518,7 +542,7 @@ export function PolyLine() {
 var PolyLine$ = {
     addPoint: function (x, y) {
         this.markDirty(true);
-        this._points$1.push(this._coordinateTransform(x, y));
+        this._points$1.push([x, y]);
     },
 
     get_lineWidth: function () {
@@ -546,11 +570,15 @@ var PolyLine$ = {
             if (this.annotationDirty) {
                 batch.markDirty(true);
                 //todo can we save this work for later?
-                var vertexList = this._points$1;
+                var vertexList = new Array(this._points$1);
+                for (let i = 0; i < this._points$1.length; i++) {
+                    var point = this._points$1[i];
+                    vertexList[i] = this.coordinateTransform(point[0], point[1]);
+                }
                 if (this._strokeWidth$1 > 0) {
                     var lineColorWithOpacity = this._lineColor$1._clone();
                     lineColorWithOpacity.a = Math.round(lineColorWithOpacity.a * this.get_opacity());
-                    for (var i = 0; i < (this._points$1.length - 1); i++) {
+                    for (var i = 0; i < (vertexList.length - 1); i++) {
                         batch.lineList.addLine(vertexList[i], vertexList[i + 1], lineColorWithOpacity, new Dates(0, 1));
                     }
                 }

--- a/engine/esm/annotation.js
+++ b/engine/esm/annotation.js
@@ -79,6 +79,14 @@ var AnnotationBatch$ = {
         this.markDirty(false);
     },
 
+    get_viewTransform: function () {
+        return this.viewTransform;
+    },
+
+    set_viewTransform: function (transform) {
+        this.viewTransform = transform;
+    },
+
     markDirty: function (dirty) {
         this._dirty = dirty;
     },

--- a/engine/esm/annotation.js
+++ b/engine/esm/annotation.js
@@ -19,13 +19,13 @@ import { Coordinates } from "./coordinates.js";
 // wwtlib.AnnotationBatch
 
 export function AnnotationBatch() {
-  this.items = [];
-  this.pointList = null;
-  this.lineList = null;
-  this.triangleFanPointList = null;
-  this.triangleList = null;
-  this.viewTransform = null;
-  this._dirty = true;
+    this.items = [];
+    this.pointList = null;
+    this.lineList = null;
+    this.triangleFanPointList = null;
+    this.triangleList = null;
+    this.viewTransform = null;
+    this._dirty = true;
 }
 
 var AnnotationBatch$ = {
@@ -39,7 +39,7 @@ var AnnotationBatch$ = {
         this.markDirty(true); 
     },
 
-    prepBatch: function (renderContext) {
+    prepareBatch: function (renderContext) {
         if (this.pointList == null || this._dirty) {
             this.pointList = new PointList(renderContext);
             this.lineList = new LineList();
@@ -67,16 +67,16 @@ var AnnotationBatch$ = {
     },
 
     drawBatch: function (renderContext) {
-        this.markDirty(false);
         for (var i = 0; i < this.items.length; i++) {
             this.items[i].draw(renderContext, this);
         }
         if (this.viewTransform != null) {
             var matrix = this.viewTransform instanceof Matrix3d ? this.viewTransform : this.viewTransform(renderContext);
-            renderContext.executeWithWorldTransform(matrix, this._drawCommands);
+            renderContext.executeWithWorldTransform(matrix, this._drawCommands.bind(this));
         } else {
             this._drawCommands(renderContext);
         }
+        this.markDirty(false);
     },
 
     markDirty: function (dirty) {

--- a/engine/esm/annotation.js
+++ b/engine/esm/annotation.js
@@ -30,6 +30,17 @@ export function AnnotationBatch() {
     this._dirty = true;
 }
 
+AnnotationBatch.horizontalWorldTransform = function (_renderContext) {
+    var zenithAltAz = new Coordinates(0, 0);
+    var zenith = Coordinates.horizonToEquitorial(zenithAltAz, SpaceTimeController.get_location(), SpaceTimeController.get_now());
+    var raPart = -((zenith.get_RA() + 6) / 24 * (Math.PI * 2));
+    var decPart = -(zenith.get_dec() / 360 * (Math.PI * 2));
+    var mat = Matrix3d._rotationY(-raPart);
+    mat._multiply(Matrix3d._rotationX(decPart));
+    mat.invert();
+    return mat;
+};
+
 var AnnotationBatch$ = {
     add: function (annotation) {
         this.items.push(annotation);

--- a/engine/esm/annotation.js
+++ b/engine/esm/annotation.js
@@ -163,6 +163,10 @@ Annotation.defaultCoordinateTransform = function (x, y) {
 
 Annotation.galacticCoordinateTransform = Coordinates.galacticTo3dDouble;
 
+Annotation.horizontalCoordinateTransform = function (alt, az) {
+    return Annotation.defaultCoordinateTransform(270 - alt, az);
+}
+
 Annotation.separation = function (Alpha1, Delta1, Alpha2, Delta2) {
     Delta1 = Delta1 / 180 * Math.PI;
     Delta2 = Delta2 / 180 * Math.PI;
@@ -181,7 +185,7 @@ Annotation.separation = function (Alpha1, Delta1, Alpha2, Delta2) {
 
 Annotation.separationCartesian = function (u, v) {
   var dot = Vector3d.dot(u, v);
-  var cross = Vector3d.cross(u, v).getLength();
+  var cross = Vector3d.cross(u, v).length();
   return Math.atan2(cross, dot);
 }
 
@@ -448,15 +452,8 @@ var Circle$ = {
     },
 
     hitTest: function (renderContext, RA, dec, x, y) {
-        if (ss.emptyString(this.get_id())) {
-            return false;
-        }
-        var rad = this._radius$1;
-        if (!this._skyRelative$1) {
-            rad *= renderContext.get_fovScale() / 3600;
-        }
         var test = Coordinates.raDecTo3d(RA, dec);
-        return Annotation.separationCartesian(this.center, test) < rad;
+        return Annotation.separationCartesian(this.center, test) < (this._radius$1 * Math.PI / 180);
     }
 };
 

--- a/engine/esm/annotation.js
+++ b/engine/esm/annotation.js
@@ -14,6 +14,7 @@ import { Dates, LineList, TriangleList, TriangleFanList, PointList } from "./gra
 import { Tessellator } from "./graphics/tessellator.js";
 import { Color, Colors } from "./color.js";
 import { Coordinates } from "./coordinates.js";
+import { SpaceTimeController } from "./space_time_controller.js";
 
 
 // wwtlib.AnnotationBatch
@@ -84,9 +85,9 @@ var AnnotationBatch$ = {
             this.items[i].draw(renderContext, this);
         }
         var transforms = {
-            world: this.worldTransform instanceof Matrix3d ? this.worldTransform : this.worldTransform(renderContext),
-            view: this.viewTransform instanceof Matrix3d ? this.viewTransform : this.viewTransform(renderContext),
-            projection: this.projectionTransform instanceof Matrix3d ? this.projectionTransform : this.projectionTransform(renderContext),
+            world: (!this.worldTransform || this.worldTransform instanceof Matrix3d) ? this.worldTransform : this.worldTransform(renderContext),
+            view: (!this.viewTransform || this.viewTransform instanceof Matrix3d) ? this.viewTransform : this.viewTransform(renderContext),
+            projection: (!this.projectionTransform || this.projectionTransform instanceof Matrix3d) ? this.projectionTransform : this.projectionTransform(renderContext),
         };
         renderContext.executeWithTransforms(transforms, this._drawCommands.bind(this));
         this.markDirty(false);

--- a/engine/esm/annotation.js
+++ b/engine/esm/annotation.js
@@ -94,7 +94,14 @@ export function Annotation() {
     this.annotationDirty = true;
     this._opacity = 1;
     this._showHoverLabel = false;
+    this._coordinateTransform = Annotation.defaultCoordinateTransform;
 }
+
+Annotation.defaultCoordinateTransform = function (x, y) {
+    return Coordinates.raDecTo3d(x / 15, y);
+}
+
+Annotation.galacticCoordinateTransform = Coordinates.galacticTo3dDouble;
 
 Annotation.separation = function (Alpha1, Delta1, Alpha2, Delta2) {
     Delta1 = Delta1 / 180 * Math.PI;
@@ -202,6 +209,7 @@ export function Circle() {
     this._fillColor$1 = Colors.get_white();
     this._x$1 = 0;
     this._y$1 = 0;
+    this._coordinateTransform = Coordinates.raDecTo3d;
     Annotation.call(this);
 }
 
@@ -270,7 +278,7 @@ var Circle$ = {
         this.markDirty(true);
         this._x$1 = x / 15;
         this._y$1 = y;
-        this.center = Coordinates.raDecTo3d(this._ra$1, this._dec$1);
+        this.center = this._coordinateTransform(this._x$1, this._y$1);
     },
 
     draw: function (renderContext, batch) {
@@ -387,7 +395,7 @@ export function Poly() {
 var Poly$ = {
     addPoint: function (x, y) {
         this.markDirty(true);
-        this._points$1.push(Coordinates.raDecTo3d(x / 15, y));
+        this._points$1.push(this._coordinateTransform(x, y));
     },
 
     get_fill: function () {
@@ -510,7 +518,7 @@ export function PolyLine() {
 var PolyLine$ = {
     addPoint: function (x, y) {
         this.markDirty(true);
-        this._points$1.push(Coordinates.raDecTo3d(x / 15, y));
+        this._points$1.push(this._coordinateTransform(x, y));
     },
 
     get_lineWidth: function () {

--- a/engine/esm/annotation.js
+++ b/engine/esm/annotation.js
@@ -179,6 +179,12 @@ Annotation.separation = function (Alpha1, Delta1, Alpha2, Delta2) {
     return vvalue;
 };
 
+Annotation.separationCartesian = function (u, v) {
+  var dot = Vector3d.dot(u, v);
+  var cross = Vector3d.cross(u, v).getLength();
+  return Math.atan2(cross, dot);
+}
+
 Annotation.colorToUint = function (col) {
     return (col.a) << 24 | (col.r << 16) | (col.g) << 8 | col.b;
 };
@@ -449,7 +455,8 @@ var Circle$ = {
         if (!this._skyRelative$1) {
             rad *= renderContext.get_fovScale() / 3600;
         }
-        return Annotation.separation(RA, dec, this._x$1, this._y$1) < rad;
+        var test = Coordinates.raDecTo3d(RA, dec);
+        return Annotation.separationCartesian(this.center, test) < rad;
     }
 };
 

--- a/engine/esm/annotation.js
+++ b/engine/esm/annotation.js
@@ -9,11 +9,82 @@
 
 import { registerType } from "./typesystem.js";
 import { ss } from "./ss.js";
-import { Vector3d } from "./double3d.js";
+import { Matrix3d, Vector3d } from "./double3d.js";
 import { Dates, LineList, TriangleList, TriangleFanList, PointList } from "./graphics/primitives3d.js";
 import { Tessellator } from "./graphics/tessellator.js";
 import { Color, Colors } from "./color.js";
 import { Coordinates } from "./coordinates.js";
+
+
+// wwtlib.AnnotationBatch
+
+export function AnnotationBatch() {
+  this.items = [];
+  this.pointList = null;
+  this.lineList = null;
+  this.triangleFanPointList = null;
+  this.triangleList = null;
+  this.viewTransform = null;
+  this._dirty = true;
+}
+
+var AnnotationBatch$ = {
+    add: function (annotation) {
+        this.items.push(annotation);
+        this.markDirty(true); 
+    },
+
+    remove: function (annotation) {
+        ss.remove(this.items, annotation);
+        this.markDirty(true); 
+    },
+
+    prepBatch: function (renderContext) {
+        if (this.pointList == null || this._dirty) {
+            this.pointList = new PointList(renderContext);
+            this.lineList = new LineList();
+            this.triangleFanPointList = new TriangleFanList();
+            this.triangleList = new TriangleList();
+            this.lineList.set_depthBuffered(false);
+            this.triangleList.depthBuffered = false;
+        }
+        this.markDirty(false);
+    },
+
+    _drawCommands: function (renderContext) {
+        if (this.pointList != null) {
+            this.pointList.draw(renderContext, 1, false);
+        }
+        if (this.lineList != null) {
+            this.lineList.drawLines(renderContext, 1);
+        }
+        if (this.triangleFanPointList != null) {
+            this.triangleFanPointList.draw(renderContext, 1);
+        }
+        if (this.triangleList != null) {
+            this.triangleList.draw(renderContext, 1, 0);
+        }
+    },
+
+    drawBatch: function (renderContext) {
+        this.markDirty(false);
+        for (var i = 0; i < this.items.length; i++) {
+            this.items[i].draw(renderContext, this);
+        }
+        if (this.viewTransform != null) {
+            var matrix = this.viewTransform instanceof Matrix3d ? this.viewTransform : this.viewTransform(renderContext);
+            renderContext.executeWithWorldTransform(matrix, this._drawCommands);
+        } else {
+            this._drawCommands(renderContext);
+        }
+    },
+
+    markDirty: function (dirty) {
+        this._dirty = dirty;
+    },
+};
+
+registerType("AnnotationBatch", [AnnotationBatch, AnnotationBatch$, null]);
 
 
 // wwtlib.Annotation
@@ -24,42 +95,6 @@ export function Annotation() {
     this._opacity = 1;
     this._showHoverLabel = false;
 }
-
-Annotation.pointList = null;
-Annotation.lineList = null;
-Annotation.triangleFanPointList = null;
-Annotation.triangleList = null;
-Annotation.batchDirty = true;
-
-Annotation.prepBatch = function (renderContext) {
-    if (Annotation.pointList == null || Annotation.batchDirty) {
-        Annotation.pointList = new PointList(renderContext);
-        Annotation.lineList = new LineList();
-        Annotation.triangleFanPointList = new TriangleFanList();
-        Annotation.triangleList = new TriangleList();
-        Annotation.lineList.set_depthBuffered(false);
-        Annotation.triangleList.depthBuffered = false;
-    }
-};
-
-Annotation.drawBatch = function (renderContext) {
-    Annotation.batchDirty = false;
-    if (renderContext.gl == null) {
-        return;
-    }
-    if (Annotation.pointList != null) {
-        Annotation.pointList.draw(renderContext, 1, false);
-    }
-    if (Annotation.lineList != null) {
-        Annotation.lineList.drawLines(renderContext, 1);
-    }
-    if (Annotation.triangleFanPointList != null) {
-        Annotation.triangleFanPointList.draw(renderContext, 1);
-    }
-    if (Annotation.triangleList != null) {
-        Annotation.triangleList.draw(renderContext, 1, 0);
-    }
-};
 
 Annotation.separation = function (Alpha1, Delta1, Alpha2, Delta2) {
     Delta1 = Delta1 / 180 * Math.PI;
@@ -86,14 +121,14 @@ Annotation.colorToUintAlpha = function (col, opacity) {
 };
 
 var Annotation$ = {
-    draw: function (renderContext) { },
+    draw: function (renderContext, batch) { },
 
     get_opacity: function () {
         return this._opacity;
     },
 
     set_opacity: function (value) {
-        Annotation.batchDirty = true;
+        this.markDirty(true);
         this._opacity = value;
         return value;
     },
@@ -143,9 +178,14 @@ var Annotation$ = {
     },
 
     set_center: function (value) {
+        this.markDirty(true);
         this.center = value;
         return value;
-    }
+    },
+
+    markDirty: function (dirty) {
+        this.annotationDirty = dirty;
+    },
 };
 
 registerType("Annotation", [Annotation, Annotation$, null]);
@@ -160,8 +200,8 @@ export function Circle() {
     this._radius$1 = 10;
     this._lineColor$1 = Colors.get_white();
     this._fillColor$1 = Colors.get_white();
-    this._ra$1 = 0;
-    this._dec$1 = 0;
+    this._x$1 = 0;
+    this._y$1 = 0;
     Annotation.call(this);
 }
 
@@ -171,7 +211,7 @@ var Circle$ = {
     },
 
     set_fill: function (value) {
-        Annotation.batchDirty = true;
+        this.markDirty(true);
         this._fill$1 = value;
         return value;
     },
@@ -181,7 +221,7 @@ var Circle$ = {
     },
 
     set_skyRelative: function (value) {
-        Annotation.batchDirty = true;
+        this.markDirty(true);
         this._skyRelative$1 = value;
         return value;
     },
@@ -191,7 +231,7 @@ var Circle$ = {
     },
 
     set_lineWidth: function (value) {
-        Annotation.batchDirty = true;
+        this.markDirty(true);
         this._strokeWidth$1 = value;
         return value;
     },
@@ -201,7 +241,7 @@ var Circle$ = {
     },
 
     set_radius: function (value) {
-        Annotation.batchDirty = true;
+        this.markDirty(true);
         this._radius$1 = value;
         return value;
     },
@@ -211,7 +251,7 @@ var Circle$ = {
     },
 
     set_lineColor: function (value) {
-        Annotation.batchDirty = true;
+        this.markDirty(true);
         this._lineColor$1 = Color.load(value);
         return value;
     },
@@ -221,19 +261,19 @@ var Circle$ = {
     },
 
     set_fillColor: function (value) {
-        Annotation.batchDirty = true;
+        this.markDirty(true);
         this._fillColor$1 = Color.fromName(value);
         return value;
     },
 
-    setCenter: function (ra, dec) {
-        Annotation.batchDirty = true;
-        this._ra$1 = ra / 15;
-        this._dec$1 = dec;
+    setCenter: function (x, y) {
+        this.markDirty(true);
+        this._x$1 = x / 15;
+        this._y$1 = y;
         this.center = Coordinates.raDecTo3d(this._ra$1, this._dec$1);
     },
 
-    draw: function (renderContext) {
+    draw: function (renderContext, batch) {
         var onScreen = true;
 
         var rad = this._radius$1;
@@ -251,14 +291,15 @@ var Circle$ = {
         }
 
         if (renderContext.gl != null) {
-            if (Annotation.batchDirty || this.annotationDirty) {
+            if (this.annotationDirty) {
+                batch.markDirty(true);
                 var up = Vector3d.create(0, 1, 0);
                 var xNormal = Vector3d.cross(this.center, up);
                 var yNormal = Vector3d.cross(this.center, xNormal);
 
                 // Here we guard, lamely, against div-by-0; circles at decs of
                 // +-90 will surely not render well.
-                var cosdec = Math.cos(this._dec$1 * Math.PI / 180)
+                var cosdec = Math.cos(this._y$1 * Math.PI / 180)
                 cosdec = Math.max(cosdec, 1e-5);
                 var r = this._radius$1 * Math.PI / (180 * cosdec);
 
@@ -283,7 +324,7 @@ var Circle$ = {
                     lineColorWithOpacity.a = Math.round(lineColorWithOpacity.a * this.get_opacity());
 
                     for (var i = 0; i < vertexList.length - 1; i++) {
-                        Annotation.lineList.addLine(vertexList[i], vertexList[i + 1], lineColorWithOpacity, new Dates(0, 1));
+                        batch.lineList.addLine(vertexList[i], vertexList[i + 1], lineColorWithOpacity, new Dates(0, 1));
                     }
                 }
 
@@ -292,7 +333,7 @@ var Circle$ = {
                     fillColorWithOpacity.a = Math.round(fillColorWithOpacity.a * this.get_opacity());
                     var pos = Vector3d.create(this.center.x, this.center.y, this.center.z);
                     vertexList.splice(0, 0, pos);
-                    Annotation.triangleFanPointList.addShape(vertexList, fillColorWithOpacity, new Dates(0, 1));
+                    batch.triangleFanPointList.addShape(vertexList, fillColorWithOpacity, new Dates(0, 1));
                 }
 
                 this.annotationDirty = false;
@@ -325,7 +366,7 @@ var Circle$ = {
         if (!this._skyRelative$1) {
             rad *= renderContext.get_fovScale() / 3600;
         }
-        return Annotation.separation(RA, dec, this._ra$1, this._dec$1) < rad;
+        return Annotation.separation(RA, dec, this._x$1, this._y$1) < rad;
     }
 };
 
@@ -345,7 +386,7 @@ export function Poly() {
 
 var Poly$ = {
     addPoint: function (x, y) {
-        Annotation.batchDirty = true;
+        this.markDirty(true);
         this._points$1.push(Coordinates.raDecTo3d(x / 15, y));
     },
 
@@ -354,7 +395,7 @@ var Poly$ = {
     },
 
     set_fill: function (value) {
-        Annotation.batchDirty = true;
+        this.markDirty(true);
         this._fill$1 = value;
         return value;
     },
@@ -364,7 +405,7 @@ var Poly$ = {
     },
 
     set_lineWidth: function (value) {
-        Annotation.batchDirty = true;
+        this.markDirty(true);
         this._strokeWidth$1 = value;
         return value;
     },
@@ -374,7 +415,7 @@ var Poly$ = {
     },
 
     set_lineColor: function (value) {
-        Annotation.batchDirty = true;
+        this.markDirty(true);
         this._lineColor$1 = Color.fromName(value);
         return value;
     },
@@ -384,14 +425,15 @@ var Poly$ = {
     },
 
     set_fillColor: function (value) {
-        Annotation.batchDirty = true;
+        this.markDirty(true);
         this._fillColor$1 = Color.fromName(value);
         return value;
     },
 
-    draw: function (renderContext) {
+    draw: function (renderContext, batch) {
         if (renderContext.gl != null) {
-            if (Annotation.batchDirty || this.annotationDirty) {
+            if (this.annotationDirty) {
+                batch.markDirty(true);
                 //todo can we save this work for later?
                 var vertexList = this._points$1;
 
@@ -399,16 +441,16 @@ var Poly$ = {
                     var lineColorWithOpacity = this._lineColor$1._clone();
                     lineColorWithOpacity.a = Math.round(lineColorWithOpacity.a * this.get_opacity());
                     for (var i = 0; i < (this._points$1.length - 1); i++) {
-                        Annotation.lineList.addLine(vertexList[i], vertexList[i + 1], lineColorWithOpacity, new Dates(0, 1));
+                        batch.lineList.addLine(vertexList[i], vertexList[i + 1], lineColorWithOpacity, new Dates(0, 1));
                     }
-                    Annotation.lineList.addLine(vertexList[this._points$1.length - 1], vertexList[0], lineColorWithOpacity, new Dates(0, 1));
+                    batch.lineList.addLine(vertexList[this._points$1.length - 1], vertexList[0], lineColorWithOpacity, new Dates(0, 1));
                 }
                 if (this._fill$1) {
                     var fillColorWithOpacity = this._fillColor$1._clone();
                     fillColorWithOpacity.a = Math.round(fillColorWithOpacity.a * this.get_opacity());
                     var indexes = Tessellator.tesselateSimplePoly(vertexList);
                     for (var i = 0; i < indexes.length; i += 3) {
-                        Annotation.triangleList.addSubdividedTriangles(vertexList[indexes[i]], vertexList[indexes[i + 1]], vertexList[indexes[i + 2]], fillColorWithOpacity, new Dates(0, 1), 2);
+                        batch.triangleList.addSubdividedTriangles(vertexList[indexes[i]], vertexList[indexes[i + 1]], vertexList[indexes[i + 2]], fillColorWithOpacity, new Dates(0, 1), 2);
                     }
                 }
                 this.annotationDirty = false;
@@ -467,7 +509,7 @@ export function PolyLine() {
 
 var PolyLine$ = {
     addPoint: function (x, y) {
-        Annotation.batchDirty = true;
+        this.markDirty(true);
         this._points$1.push(Coordinates.raDecTo3d(x / 15, y));
     },
 
@@ -476,7 +518,7 @@ var PolyLine$ = {
     },
 
     set_lineWidth: function (value) {
-        Annotation.batchDirty = true;
+        this.markDirty(true);
         this._strokeWidth$1 = value;
         return value;
     },
@@ -486,21 +528,22 @@ var PolyLine$ = {
     },
 
     set_lineColor: function (value) {
-        Annotation.batchDirty = true;
+        this.markDirty(true);
         this._lineColor$1 = Color.fromName(value);
         return value;
     },
 
-    draw: function (renderContext) {
+    draw: function (renderContext, batch) {
         if (renderContext.gl != null) {
-            if (Annotation.batchDirty || this.annotationDirty) {
+            if (this.annotationDirty) {
+                batch.markDirty(true);
                 //todo can we save this work for later?
                 var vertexList = this._points$1;
                 if (this._strokeWidth$1 > 0) {
                     var lineColorWithOpacity = this._lineColor$1._clone();
                     lineColorWithOpacity.a = Math.round(lineColorWithOpacity.a * this.get_opacity());
                     for (var i = 0; i < (this._points$1.length - 1); i++) {
-                        Annotation.lineList.addLine(vertexList[i], vertexList[i + 1], lineColorWithOpacity, new Dates(0, 1));
+                        batch.lineList.addLine(vertexList[i], vertexList[i + 1], lineColorWithOpacity, new Dates(0, 1));
                     }
                 }
                 this.annotationDirty = false;

--- a/engine/esm/annotation.js
+++ b/engine/esm/annotation.js
@@ -25,6 +25,8 @@ export function AnnotationBatch() {
     this.triangleFanPointList = null;
     this.triangleList = null;
     this.viewTransform = null;
+    this.worldTransform = null;
+    this.projectionTransform = null;
     this._dirty = true;
 }
 
@@ -70,12 +72,12 @@ var AnnotationBatch$ = {
         for (var i = 0; i < this.items.length; i++) {
             this.items[i].draw(renderContext, this);
         }
-        if (this.viewTransform != null) {
-            var matrix = this.viewTransform instanceof Matrix3d ? this.viewTransform : this.viewTransform(renderContext);
-            renderContext.executeWithWorldTransform(matrix, this._drawCommands.bind(this));
-        } else {
-            this._drawCommands(renderContext);
-        }
+        var transforms = {
+            world: this.worldTransform instanceof Matrix3d ? this.worldTransform : this.worldTransform(renderContext),
+            view: this.viewTransform instanceof Matrix3d ? this.viewTransform : this.viewTransform(renderContext),
+            projection: this.projectionTransform instanceof Matrix3d ? this.projectionTransform : this.projectionTransform(renderContext),
+        };
+        renderContext.executeWithTransforms(transforms, this._drawCommands.bind(this));
         this.markDirty(false);
     },
 
@@ -85,6 +87,22 @@ var AnnotationBatch$ = {
 
     set_viewTransform: function (transform) {
         this.viewTransform = transform;
+    },
+
+    get_worldTransform: function () {
+        return this.worldTransform;
+    },
+
+    set_worldTransform: function (transform) {
+        this.worldTransform = transform;
+    },
+
+    get_projectionTransform: function () {
+        return this.projectionTransform;
+    },
+
+    set_projectionTransform: function (transform) {
+        this.projectionTransform = transform;
     },
 
     markDirty: function (dirty) {

--- a/engine/esm/annotation.js
+++ b/engine/esm/annotation.js
@@ -58,7 +58,7 @@ AnnotationBatch.horizontalWorldTransform = function (_renderContext) {
 };
 
 AnnotationBatch.overlayWorldTransform = function (position) {
-  var overlayWorldInitial = Matrix3d.rotationYawPitchRoll(-(position.get_RA() - 12) * Coordinates.RCRA, -position.get_dec() * Coordinates.RC, 0);
+  var overlayWorldInitial = Matrix3d.rotationYawPitchRoll(-(position.get_RA() - 6) * Coordinates.RCRA, -position.get_dec() * Coordinates.RC, 0);
   return function (renderContext) {
     var world = renderContext.get_world().clone();
     world.invert();
@@ -70,7 +70,7 @@ AnnotationBatch.overlayViewTransform = function (rotation) {
   var overlayViewInitial = Matrix3d.lookAtLH(
     Vector3d.create(0, 0, 0),
     Vector3d.create(0, 0, -1),
-    Vector3d.create(Math.sin(rotation, Math.cos(rotation), 0)),
+    Vector3d.create(Math.sin(rotation), Math.cos(rotation), 0),
   );
   return function (renderContext) {
     var view = renderContext.get_view().clone();
@@ -90,7 +90,20 @@ var AnnotationBatch$ = {
         this.markDirty(true); 
     },
 
+    _anyChildDirty: function () {
+        for (var i = 0; i < this.items.length; i++) {
+            if (this.items[i].get_dirty()) {
+                return true;
+            }
+        }
+        return false;
+    }, 
+
     prepareBatch: function (renderContext) {
+        var dirty = this.get_dirty() || this._anyChildDirty();
+        if (dirty) {
+          this.markDirty(true);
+        }
         if (this.pointList == null || this._dirty) {
             this.pointList = new PointList(renderContext);
             this.lineList = new LineList();
@@ -99,7 +112,6 @@ var AnnotationBatch$ = {
             this.lineList.set_depthBuffered(false);
             this.triangleList.depthBuffered = false;
         }
-        this.markDirty(false);
     },
 
     _drawCommands: function (renderContext) {
@@ -155,7 +167,11 @@ var AnnotationBatch$ = {
     },
 
     markDirty: function (dirty) {
-        this._dirty = dirty;
+        this._dirty = dirty; 
+    },
+
+    get_dirty: function() {
+        return this._dirty;
     },
 };
 
@@ -283,6 +299,14 @@ var Annotation$ = {
     markDirty: function (dirty) {
         this.annotationDirty = dirty;
     },
+
+    get_dirty: function () {
+        return this.annotationDirty;
+    },
+
+    _needsDraw: function(batch) {
+        return this.annotationDirty || batch.get_dirty();
+    },
 };
 
 registerType("Annotation", [Annotation, Annotation$, null]);
@@ -395,8 +419,7 @@ var Circle$ = {
         }
 
         if (renderContext.gl != null) {
-            if (this.annotationDirty) {
-                batch.markDirty(true);
+            if (this._needsDraw(batch)) {
                 var up = Vector3d.create(0, 1, 0);
                 var xNormal = Vector3d.cross(this.center, up);
                 var yNormal = Vector3d.cross(this.center, xNormal);
@@ -535,8 +558,7 @@ var Poly$ = {
 
     draw: function (renderContext, batch) {
         if (renderContext.gl != null) {
-            if (this.annotationDirty) {
-                batch.markDirty(true);
+            if (this._needsDraw(batch)) {
                 //todo can we save this work for later?
                 var vertexList = new Array(this._points$1);
                 for (let i = 0; i < this._points$1.length; i++) {
@@ -642,8 +664,7 @@ var PolyLine$ = {
 
     draw: function (renderContext, batch) {
         if (renderContext.gl != null) {
-            if (this.annotationDirty) {
-                batch.markDirty(true);
+            if (this._needsDraw(batch)) {
                 //todo can we save this work for later?
                 var vertexList = new Array(this._points$1);
                 for (let i = 0; i < this._points$1.length; i++) {

--- a/engine/esm/grids.js
+++ b/engine/esm/grids.js
@@ -657,7 +657,6 @@ Grids.drawAltAzGridText = function (renderContext, opacity, drawColor) {
 };
 
 Grids._makeAltAzGridText = function () {
-    var drawColor = Colors.get_white();
     var index = 0;
     if (Grids._altAzTextBatch == null) {
         Grids._altAzTextBatch = new Text3dBatch(30);
@@ -753,7 +752,6 @@ Grids.drawEclipticGridText = function (renderContext, opacity, drawColor) {
 };
 
 Grids._makeEclipticGridText = function () {
-    var drawColor = Colors.get_white();
     var obliquity = Coordinates.meanObliquityOfEcliptic(SpaceTimeController.get_jNow());
     var mat = Matrix3d._rotationX((-obliquity / 360 * (Math.PI * 2)));
     if (Grids._eclipticTextBatch == null) {

--- a/engine/esm/grids.js
+++ b/engine/esm/grids.js
@@ -662,7 +662,6 @@ Grids.drawAltAzGridText = function (renderContext, opacity, drawColor) {
 };
 
 Grids._makeAltAzGridText = function () {
-    var drawColor = Colors.get_white();
     var index = 0;
     if (Grids._altAzTextBatch == null) {
         Grids._altAzTextBatch = new Text3dBatch(30);
@@ -758,7 +757,6 @@ Grids.drawEclipticGridText = function (renderContext, opacity, drawColor) {
 };
 
 Grids._makeEclipticGridText = function () {
-    var drawColor = Colors.get_white();
     var obliquity = Coordinates.meanObliquityOfEcliptic(SpaceTimeController.get_jNow());
     var mat = Matrix3d._rotationX((-obliquity / 360 * (Math.PI * 2)));
     if (Grids._eclipticTextBatch == null) {

--- a/engine/esm/index.js
+++ b/engine/esm/index.js
@@ -177,7 +177,7 @@ export {
     ISettings,
     IUndoStep,
 } from "./interfaces.js";
-export { Annotation, Circle, Poly, PolyLine } from "./annotation.js";
+export { AnnotationBatch, Annotation, Circle, Poly, PolyLine } from "./annotation.js";
 export { SolarSystemObjects, InterpolationType, CameraParameters } from "./camera_parameters.js";
 export { ConstellationFilter } from "./constellation_filter.js";
 export { FitsProperties, ScaleTypes } from "./fits_properties.js";

--- a/engine/esm/render_context.js
+++ b/engine/esm/render_context.js
@@ -964,14 +964,17 @@ var RenderContext$ = {
         var oldProjection = this.get_projection().clone();
       
         if (transforms.world) {
-          this.set_worldBase(Matrix3d.multiplyMatrix(transforms.world, this.get_world()));
+          var worldMatrix = transforms.world instanceof Matrix3d ? transforms.world : transforms.world(this);
+          this.set_worldBase(Matrix3d.multiplyMatrix(worldMatrix, this.get_world()));
           this.set_world(this.get_worldBase().clone());
         }
         if (transforms.view) {
-          this.set_view(Matrix3d.multiplyMatrix(transforms.view, this.get_view()));
+          var viewMatrix = transforms.view instanceof Matrix3d ? transforms.view : transforms.view(this);
+          this.set_view(Matrix3d.multiplyMatrix(viewMatrix, this.get_view()));
         }
         if (transforms.projection) {
-          this.set_projection(Matrix3d.multiplyMatrix(transforms.projection, this.get_projection()));
+          var projectionMatrix = transforms.projection instanceof Matrix3d ? transforms.projection : transforms.projection(this);
+          this.set_projection(Matrix3d.multiplyMatrix(projectionMatrix, this.get_projection()));
         }
         this.makeFrustum();
       

--- a/engine/esm/script_interface.js
+++ b/engine/esm/script_interface.js
@@ -14,7 +14,7 @@ import { registerType } from "./typesystem.js";
 import { Util } from "./util.js";
 import { globalRenderContext, useGlVersion2 } from "./render_globals.js";
 import { globalWWTControl, layerManagerGetAllMaps, loadWtmlFile } from "./data_globals.js";
-import { Annotation, Circle, Poly, PolyLine } from "./annotation.js";
+import { Annotation, AnnotationBatch, Circle, Poly, PolyLine } from "./annotation.js";
 import { FitsImage } from "./layers/fits_image.js";
 import { FitsImageJs } from "./layers/fits_image_js.js";
 import { Imageset } from "./imageset.js";
@@ -671,25 +671,37 @@ var ScriptInterface$ = {
         return c;
     },
 
-    addAnnotation: function (annotation) {
+    addAnnotationBatch: function (batch, name) {
+        if (batch!= null && ss.canCast(batch, AnnotationBatch) && globalWWTControl != null) {
+            globalWWTControl._addAnnotationBatch(batch, name);
+        }
+    },
+
+    removeAnnotationBatch: function (batchOrName) {
+        if ((globalWWTControl != null) && (typeof batchOrName === "string" || ss.canCast(batchOrName, AnnotationBatch))) {
+            globalWWTControl._removeAnnotationBatch(batchOrName); 
+        }
+    },
+
+    addAnnotation: function (annotation, batch) {
         if (annotation != null && ss.canCast(annotation, Annotation)) {
             if (globalWWTControl != null) {
-                globalWWTControl._addAnnotation(annotation);
+                globalWWTControl._addAnnotation(annotation, batch);
             }
         }
     },
 
-    removeAnnotation: function (annotation) {
+    removeAnnotation: function (annotation, batch) {
         if (annotation != null) {
             if (globalWWTControl != null) {
-                globalWWTControl._removeAnnotation(annotation);
+                globalWWTControl._removeAnnotation(annotation, batch);
             }
         }
     },
 
-    clearAnnotations: function () {
+    clearAnnotations: function (batch) {
         if (globalWWTControl != null) {
-            globalWWTControl._clearAnnotations();
+            globalWWTControl._clearAnnotations(batch);
         }
     },
 

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -440,6 +440,13 @@ var WWTControl$ = {
         }
     },
 
+    _setupGalacticAnnotation: function (annotation) {
+        if (!("galactic" in this._annotations)) {
+            this._annotations["galactic"] = new AnnotationBatch();
+        }
+        annotation._coordinateTransform = Annotation.galacticCoordinateTransform;
+    },
+
     _addAnnotationBatch: function (batch, name) {
         this._annotations[name] = batch;
     },
@@ -463,6 +470,10 @@ var WWTControl$ = {
 
         if (batchOrName === "horizon") {
             this._setupHorizonAnnotations();
+        }
+
+        if (batchOrName == "galactic") {
+            this._setupGalacticAnnotation(annotation);
         }
 
         var batch = typeof batchOrName === "string" ? this._annotations[batchOrName] : batchOrName;

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -423,30 +423,6 @@ WWTControl.showLayers = function (show) {
 
 var WWTControl$ = {
 
-    _setupHorizontalAnnotations: function () {
-        if (!("horizontal" in this._annotations)) {
-            var horizontalAnnotations = new AnnotationBatch();
-            horizontalAnnotations.viewTransform = function (_renderContext) {
-                var zenithAltAz = new Coordinates(0, 0);
-                var zenith = Coordinates.horizonToEquitorial(zenithAltAz, SpaceTimeController.get_location(), SpaceTimeController.get_now());
-                var raPart = -((zenith.get_RA() + 6) / 24 * (Math.PI * 2));
-                var decPart = -(zenith.get_dec() / 360 * (Math.PI * 2));
-                var mat = Matrix3d._rotationY(-raPart);
-                mat._multiply(Matrix3d._rotationX(decPart));
-                mat.invert();
-                return mat;
-            }
-            this._annotations["horizontal"] = horizontalAnnotations;
-        }
-    },
-
-    _setupGalacticAnnotation: function (annotation) {
-        if (!("galactic" in this._annotations)) {
-            this._annotations["galactic"] = new AnnotationBatch();
-        }
-        annotation.coordinateTransform = Annotation.galacticCoordinateTransform;
-    },
-
     _addAnnotationBatch: function (batch, name) {
         this._annotations[name] = batch;
     },
@@ -466,14 +442,6 @@ var WWTControl$ = {
     _addAnnotation: function (annotation, batchOrName) {
         if (batchOrName == null) {
             batchOrName = "equatorial";
-        }
-
-        if (batchOrName === "horizontal") {
-            this._setupHorizontalAnnotations();
-        }
-
-        if (batchOrName == "galactic") {
-            this._setupGalacticAnnotation(annotation);
         }
 
         var batch = typeof batchOrName === "string" ? this._annotations[batchOrName] : batchOrName;
@@ -509,7 +477,6 @@ var WWTControl$ = {
 
     _annotationclicked: function (ra, dec, x, y) {
         if (this._annotations != null && this._annotations.length > 0) {
-            var index = 0;
             for (var batchKey of this._annotations) {
                 var batch = this._annotations[batchKey];
                 var $enum1 = ss.enumerate(batch.items);

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -444,7 +444,7 @@ var WWTControl$ = {
         if (!("galactic" in this._annotations)) {
             this._annotations["galactic"] = new AnnotationBatch();
         }
-        annotation._coordinateTransform = Annotation.galacticCoordinateTransform;
+        annotation.coordinateTransform = Annotation.galacticCoordinateTransform;
     },
 
     _addAnnotationBatch: function (batch, name) {

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -40,7 +40,7 @@ import {
 import { SimpleLineList } from "./graphics/primitives3d.js";
 import { Sprite2d } from "./graphics/sprite2d.js";
 
-import { Annotation } from "./annotation.js";
+import { AnnotationBatch } from "./annotation.js";
 import { CameraParameters, SolarSystemObjects } from "./camera_parameters.js";
 import { Constellations } from "./constellations.js";
 import { Coordinates } from "./coordinates.js";
@@ -81,7 +81,7 @@ export function WWTControl() {
     this.freestandingMode = false;
 
     this.uiController = null;
-    this._annotations = [];
+    this._annotations = {};
     this._hoverText = '';
     this._hoverTextPoint = new Vector2d();
     this._lastMouseMove = new Date(1900, 1, 0, 0, 0, 0, 0);
@@ -422,32 +422,71 @@ WWTControl.showLayers = function (show) {
 };
 
 var WWTControl$ = {
-    _addAnnotation: function (annotation) {
-        this._annotations.push(annotation);
-        Annotation.batchDirty = true;
+
+    _addAnnotationBatch: function (batch, name) {
+        this._annotations[name] = batch;
     },
 
-    _removeAnnotation: function (annotation) {
-        ss.remove(this._annotations, annotation);
-        Annotation.batchDirty = true;
+    _removeAnnotationBatch: function (batchOrName) {
+        if (typeof batchOrName === "string") {
+            delete this._annotations[name];
+        } else {
+            for (var name in this._annotations) {
+                if (this._annotations[name] === batchOrName) {
+                    delete this._annotations[name];
+                }
+            }
+        }
     },
 
-    _clearAnnotations: function () {
-        this._annotations.length = 0;
-        Annotation.batchDirty = true;
+    _addAnnotation: function (annotation, batchOrName) {
+        if (batchOrName == null) {
+            batchOrName = "equatorial";
+        }
+
+        var batch = typeof batchOrName === "string" ? this._annotations[batchOrName] : batchOrName;
+        batch.add(annotation);
+    },
+
+    _removeAnnotation: function (annotation, batchOrName) {
+        if (batchOrName == null) {
+            batchOrName = "equatorial";
+        }
+
+        var batch = typeof batchOrName === "string" ? this._annotations[batchOrName] : batchOrName;
+        batch.remove(annotation);
+    },
+
+    _clearAnnotations: function (batchOrName) {
+        if (batchOrName != null) {
+            if (typeof batchOrName === "string") {
+                delete this._annotations[batchOrName];
+            } else {
+                for (var name in this._annotations) {
+                    if (this._annotations[name] === batchOrName) {
+                        delete this._annotations[name];
+                    }
+                }
+            }
+        } else {
+            this._annotations = {};
+        }
     },
 
     _annotationclicked: function (ra, dec, x, y) {
         if (this._annotations != null && this._annotations.length > 0) {
             var index = 0;
-            var $enum1 = ss.enumerate(this._annotations);
-            while ($enum1.moveNext()) {
-                var note = $enum1.current;
-                if (note.hitTest(this.renderContext, ra, dec, x, y)) {
-                    globalScriptInterface._fireAnnotationclicked(ra, dec, note.get_id());
-                    return true;
+            for (var batchKey of this._annotations) {
+                var batch = this._annotations[batchKey];
+                var $enum1 = ss.enumerate(batch.items);
+                while ($enum1.moveNext()) {
+                    var note = $enum1.current;
+                    if (note.hitTest(this.renderContext, ra, dec, x, y)) {
+                        globalScriptInterface._fireAnnotationclicked(ra, dec, note.get_id());
+                        return true;
+                    }
+                    index++;
                 }
-                index++;
             }
         }
         return false;
@@ -456,15 +495,18 @@ var WWTControl$ = {
     _annotationHover: function (ra, dec, x, y) {
         if (this._annotations != null && this._annotations.length > 0) {
             var index = 0;
-            var $enum1 = ss.enumerate(this._annotations);
-            while ($enum1.moveNext()) {
-                var note = $enum1.current;
-                if (note.hitTest(this.renderContext, ra, dec, x, y)) {
-                    this._hoverText = note.get_label();
-                    this._hoverTextPoint = Vector2d.create(x, y);
-                    return true;
+            for (var batchKey of this._annotations) {
+                var batch = this._annotations[batchKey];
+                var $enum1 = ss.enumerate(batch.items);
+                while ($enum1.moveNext()) {
+                    var note = $enum1.current;
+                    if (note.hitTest(this.renderContext, ra, dec, x, y)) {
+                        this._hoverText = note.get_label();
+                        this._hoverTextPoint = Vector2d.create(x, y);
+                        return true;
+                    }
+                    index++;
                 }
-                index++;
             }
         }
         return false;
@@ -643,6 +685,20 @@ var WWTControl$ = {
           var state = this._fadeStates[setting];
           var target = Number(Settings.get_active()[`get_${setting}`]());
           state.set_targetState(target);
+        }
+
+        if (!("horizon" in this._annotations)) {
+          var horizonAnnotations = new AnnotationBatch();
+          horizonAnnotations.viewTransform = function (_renderContext) {
+              var zenithAltAz = new Coordinates(0, 0);
+              var zenith = Coordinates.horizonToEquitorial(zenithAltAz, SpaceTimeController.get_location(), SpaceTimeController.get_now());
+              var raPart = -((zenith.get_RA() + 6) / 24 * (Math.PI * 2));
+              var decPart = -(zenith.get_dec() / 360 * (Math.PI * 2));
+              var mat = Matrix3d._rotationY(-raPart);
+              mat._multiply(Matrix3d._rotationX(decPart));
+              mat.invert();
+              return mat;
+          }
         }
 
         Tile.lastDeepestLevel = Tile.deepestLevel;
@@ -836,15 +892,11 @@ var WWTControl$ = {
         if (this.uiController != null) {
             this.uiController.render(this.renderContext);
         } else {
-            var index = 0;
-            Annotation.prepBatch(this.renderContext);
-            var $enum2 = ss.enumerate(this._annotations);
-            while ($enum2.moveNext()) {
-                var item = $enum2.current;
-                item.draw(this.renderContext);
-                index++;
+            for (var batchKey in this._annotations) {
+               var batch = this._annotations[batchKey];
+                batch.prepareBatch(this.renderContext);
+                batch.drawBatch(this.renderContext);
             }
-            Annotation.drawBatch(this.renderContext);
             if ((ss.now() - this._lastMouseMove) > 400) {
                 var ptDown = this.getCoordinatesForScreenPoint(this._hoverTextPoint.x, this._hoverTextPoint.y);
                 if (ptDown) {

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -40,7 +40,7 @@ import {
 import { SimpleLineList } from "./graphics/primitives3d.js";
 import { Sprite2d } from "./graphics/sprite2d.js";
 
-import { AnnotationBatch } from "./annotation.js";
+import { AnnotationBatch, Annotation } from "./annotation.js";
 import { CameraParameters, SolarSystemObjects } from "./camera_parameters.js";
 import { Constellations } from "./constellations.js";
 import { Coordinates } from "./coordinates.js";
@@ -81,7 +81,7 @@ export function WWTControl() {
     this.freestandingMode = false;
 
     this.uiController = null;
-    this._annotations = {};
+    this._clearAnnotations();
     this._hoverText = '';
     this._hoverTextPoint = new Vector2d();
     this._lastMouseMove = new Date(1900, 1, 0, 0, 0, 0, 0);
@@ -501,7 +501,9 @@ var WWTControl$ = {
                 }
             }
         } else {
-            this._annotations = {};
+            this._annotations = {
+                equatorial: new AnnotationBatch(),
+            };
         }
     },
 

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -486,7 +486,6 @@ var WWTControl$ = {
                         globalScriptInterface._fireAnnotationclicked(ra, dec, note.get_id());
                         return true;
                     }
-                    index++;
                 }
             }
         }
@@ -495,7 +494,6 @@ var WWTControl$ = {
 
     _annotationHover: function (ra, dec, x, y) {
         if (this._annotations != null && this._annotations.length > 0) {
-            var index = 0;
             for (var batchKey of this._annotations) {
                 var batch = this._annotations[batchKey];
                 var $enum1 = ss.enumerate(batch.items);
@@ -506,7 +504,6 @@ var WWTControl$ = {
                         this._hoverTextPoint = Vector2d.create(x, y);
                         return true;
                     }
-                    index++;
                 }
             }
         }

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -423,10 +423,10 @@ WWTControl.showLayers = function (show) {
 
 var WWTControl$ = {
 
-    _setupHorizonAnnotations: function () {
-        if (!("horizon" in this._annotations)) {
-            var horizonAnnotations = new AnnotationBatch();
-            horizonAnnotations.viewTransform = function (_renderContext) {
+    _setupHorizontalAnnotations: function () {
+        if (!("horizontal" in this._annotations)) {
+            var horizontalAnnotations = new AnnotationBatch();
+            horizontalAnnotations.viewTransform = function (_renderContext) {
                 var zenithAltAz = new Coordinates(0, 0);
                 var zenith = Coordinates.horizonToEquitorial(zenithAltAz, SpaceTimeController.get_location(), SpaceTimeController.get_now());
                 var raPart = -((zenith.get_RA() + 6) / 24 * (Math.PI * 2));
@@ -436,7 +436,7 @@ var WWTControl$ = {
                 mat.invert();
                 return mat;
             }
-            this._annotations["horizon"] = horizonAnnotations;
+            this._annotations["horizontal"] = horizontalAnnotations;
         }
     },
 
@@ -468,8 +468,8 @@ var WWTControl$ = {
             batchOrName = "equatorial";
         }
 
-        if (batchOrName === "horizon") {
-            this._setupHorizonAnnotations();
+        if (batchOrName === "horizontal") {
+            this._setupHorizontalAnnotations();
         }
 
         if (batchOrName == "galactic") {

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -40,7 +40,7 @@ import {
 import { SimpleLineList } from "./graphics/primitives3d.js";
 import { Sprite2d } from "./graphics/sprite2d.js";
 
-import { AnnotationBatch, Annotation } from "./annotation.js";
+import { AnnotationBatch } from "./annotation.js";
 import { CameraParameters, SolarSystemObjects } from "./camera_parameters.js";
 import { Constellations } from "./constellations.js";
 import { Coordinates } from "./coordinates.js";
@@ -421,6 +421,8 @@ WWTControl.showLayers = function (show) {
     WWTControl.showDataLayers = show;
 };
 
+WWTControl._defaultAnnotationBatchName = "6518e545-97a3-407a-9f4f-d33a08554f13";
+
 var WWTControl$ = {
 
     _addAnnotationBatch: function (batch, name) {
@@ -441,7 +443,7 @@ var WWTControl$ = {
 
     _addAnnotation: function (annotation, batchOrName) {
         if (batchOrName == null) {
-            batchOrName = "equatorial";
+            batchOrName = WWTControl._defaultAnnotationBatchName;
         }
 
         var batch = typeof batchOrName === "string" ? this._annotations[batchOrName] : batchOrName;
@@ -450,7 +452,7 @@ var WWTControl$ = {
 
     _removeAnnotation: function (annotation, batchOrName) {
         if (batchOrName == null) {
-            batchOrName = "equatorial";
+            batchOrName = WWTControl._defaultAnnotationBatchName;
         }
 
         var batch = typeof batchOrName === "string" ? this._annotations[batchOrName] : batchOrName;
@@ -470,7 +472,7 @@ var WWTControl$ = {
             }
         } else {
             this._annotations = {
-                equatorial: new AnnotationBatch(),
+                [WWTControl._defaultAnnotationBatchName]: new AnnotationBatch(),
             };
         }
     },

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -477,18 +477,30 @@ var WWTControl$ = {
         }
     },
 
-    _annotationclicked: function (ra, dec, x, y) {
-        if (this._annotations != null && this._annotations.length > 0) {
-            for (var batchKey of this._annotations) {
+    _annotationInBatchClicked: function (renderContext, batch, x, y) {
+        var $enum1 = ss.enumerate(batch.items);
+        var coordinatesDown = this.getCoordinatesForScreenPoint(x, y);
+        var ra = coordinatesDown.x;
+        var dec = coordinatesDown.y;
+        while ($enum1.moveNext()) {
+            var note = $enum1.current;
+            if (note.hitTest(renderContext, ra, dec, x, y)) {
+                globalScriptInterface._fireAnnotationclicked(ra, dec, note.get_id());
+                return true;
+            }
+        }
+    },
+
+    _annotationclicked: function (x, y) {
+        var control = this;
+        if (this._annotations != null) {
+            for (var batchKey in this._annotations) {
                 var batch = this._annotations[batchKey];
-                var $enum1 = ss.enumerate(batch.items);
-                while ($enum1.moveNext()) {
-                    var note = $enum1.current;
-                    if (note.hitTest(this.renderContext, ra, dec, x, y)) {
-                        globalScriptInterface._fireAnnotationclicked(ra, dec, note.get_id());
-                        return true;
-                    }
-                }
+                this.renderContext.executeWithTransforms({
+                    world: batch.get_worldTransform(),
+                    view: batch.get_viewTransform(),
+                    projection: batch.get_projectionTransform(),
+                }, function (renderContext) { this._annotationInBatchClicked(renderContext, batch, x, y); }.bind(control));
             }
         }
         return false;
@@ -1545,11 +1557,13 @@ var WWTControl$ = {
             }
         }
         if (this._mouseDown && !this._moved) {
-            var raDecDown = this.getCoordinatesForScreenPoint(Mouse.offsetX(this.canvas, e), Mouse.offsetY(this.canvas, e));
+            var x = Mouse.offsetX(this.canvas, e);
+            var y = Mouse.offsetY(this.canvas, e);
+            var raDecDown = this.getCoordinatesForScreenPoint(x, y);
             if (raDecDown) {
-              if (!this._annotationclicked(raDecDown.x, raDecDown.y, Mouse.offsetX(this.canvas, e), Mouse.offsetY(this.canvas, e))) {
-                  globalScriptInterface._fireClick(raDecDown.x, raDecDown.y);
-              }
+                if (!this._annotationclicked(x, y)) {
+                    globalScriptInterface._fireClick(raDecDown.x, raDecDown.y);
+                }
             }
         }
         this._mouseDown = false;

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -82,6 +82,7 @@ export function WWTControl() {
 
     this.uiController = null;
     this._annotations = {};
+    this._setupHorizonAnnotations();
     this._hoverText = '';
     this._hoverTextPoint = new Vector2d();
     this._lastMouseMove = new Date(1900, 1, 0, 0, 0, 0, 0);
@@ -423,6 +424,23 @@ WWTControl.showLayers = function (show) {
 
 var WWTControl$ = {
 
+    _setupHorizonAnnotations: function () {
+        if (!("horizon" in this._annotations)) {
+            var horizonAnnotations = new AnnotationBatch();
+            horizonAnnotations.viewTransform = function (_renderContext) {
+                var zenithAltAz = new Coordinates(0, 0);
+                var zenith = Coordinates.horizonToEquitorial(zenithAltAz, SpaceTimeController.get_location(), SpaceTimeController.get_now());
+                var raPart = -((zenith.get_RA() + 6) / 24 * (Math.PI * 2));
+                var decPart = -(zenith.get_dec() / 360 * (Math.PI * 2));
+                var mat = Matrix3d._rotationY(-raPart);
+                mat._multiply(Matrix3d._rotationX(decPart));
+                mat.invert();
+                return mat;
+            }
+            this._annotations["horizon"] = horizonAnnotations;
+        }
+    },
+
     _addAnnotationBatch: function (batch, name) {
         this._annotations[name] = batch;
     },
@@ -687,19 +705,7 @@ var WWTControl$ = {
           state.set_targetState(target);
         }
 
-        if (!("horizon" in this._annotations)) {
-          var horizonAnnotations = new AnnotationBatch();
-          horizonAnnotations.viewTransform = function (_renderContext) {
-              var zenithAltAz = new Coordinates(0, 0);
-              var zenith = Coordinates.horizonToEquitorial(zenithAltAz, SpaceTimeController.get_location(), SpaceTimeController.get_now());
-              var raPart = -((zenith.get_RA() + 6) / 24 * (Math.PI * 2));
-              var decPart = -(zenith.get_dec() / 360 * (Math.PI * 2));
-              var mat = Matrix3d._rotationY(-raPart);
-              mat._multiply(Matrix3d._rotationX(decPart));
-              mat.invert();
-              return mat;
-          }
-        }
+        this._setupHorizonAnnotations();
 
         Tile.lastDeepestLevel = Tile.deepestLevel;
         RenderTriangle.width = this.renderContext.width = this.canvas.width;

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -82,7 +82,6 @@ export function WWTControl() {
 
     this.uiController = null;
     this._annotations = {};
-    this._setupHorizonAnnotations();
     this._hoverText = '';
     this._hoverTextPoint = new Vector2d();
     this._lastMouseMove = new Date(1900, 1, 0, 0, 0, 0, 0);
@@ -462,6 +461,10 @@ var WWTControl$ = {
             batchOrName = "equatorial";
         }
 
+        if (batchOrName === "horizon") {
+            this._setupHorizonAnnotations();
+        }
+
         var batch = typeof batchOrName === "string" ? this._annotations[batchOrName] : batchOrName;
         batch.add(annotation);
     },
@@ -704,8 +707,6 @@ var WWTControl$ = {
           var target = Number(Settings.get_active()[`get_${setting}`]());
           state.set_targetState(target);
         }
-
-        this._setupHorizonAnnotations();
 
         Tile.lastDeepestLevel = Tile.deepestLevel;
         RenderTriangle.width = this.renderContext.width = this.canvas.width;

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -512,17 +512,22 @@ export class Annotation implements AnnotationSettingsInterface {
   set_showHoverLabel(v: boolean): boolean;
   get_tag(): string;
   set_tag(v: string): string;
+  get_coordinateTransform(): AnnotationCoordinateTransform;
+  set_coordinateTransform(transform: AnnotationCoordinateTransform): void;
 
   hitTest(renderContext: RenderContext, ra: number, dec: number, x: number, y: number): boolean;
 }
 
 export class AnnotationBatch {
-    items: Annotation[];
-    viewTransform: Matrix3d | ((rc: RenderContext) => Matrix3d);
+    readonly items: Annotation[];
+    get_viewTransform(): BatchViewTransform;
+    set_viewTransform(transform: BatchViewTransform): void;
 
     add(annotation: Annotation): void;
     remove(annotation: Annotation): void;
 }
+
+type AnnotationCoordinateTransform = (x: number, y: number) => Vector3d;
 
 /** Possible settings that can be applied to generic annotations.
  *
@@ -551,6 +556,8 @@ export interface ArrivedEventCallback {
   /** Called when the WWT view has arrived at a commanded position. */
   (si: ScriptInterface, args: ArrivedEventArgs): void;
 }
+
+export type BatchViewTransform = Matrix3d | ((rc: RenderContext) => Matrix3d);
 
 export class CameraParameters {
   lat: number;
@@ -1298,9 +1305,6 @@ export class LayerMap {
 // NOTE: isLayerSetting in engine-helpers needs to be kept in sync.
 export type LayerSetting = BaseLayerSetting |
 ["color", Color];
-
-export class Matrix3d {
-}
 
 export class Place implements Thumbnail {
   annotation: string;

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -518,6 +518,9 @@ export class Annotation implements AnnotationSettingsInterface {
 export class AnnotationBatch {
     items: Annotation[];
     viewTransform: Matrix3d | ((rc: RenderContext) => Matrix3d);
+
+    add(annotation: Annotation): void;
+    remove(annotation: Annotation): void;
 }
 
 /** Possible settings that can be applied to generic annotations.

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -220,6 +220,7 @@ export class Matrix3d {
   static invertMatrix(matrix: Matrix3d): Matrix3d;
   static translation(vector: Vector3d): Matrix3d;
   static addMatrices(matrix1: Matrix3d, matrix2: Matrix3d): Matrix3d;
+  static lookAtLH(cameraPosition: Vector3d, cameraTarget: Vector3d, cameraUpVector: Vector3d): Matrix3d;
 
   clone(): Matrix3d;
   setIdentity(): void;
@@ -1548,6 +1549,10 @@ export class RenderContext {
     viewLong: number
   ): number;
   onTarget(place: Place): boolean;
+
+  get_view(): Matrix3d;
+  get_world(): Matrix3d;
+  get_projection(): Matrix3d;
 }
 
 export class ScriptInterface {

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -527,7 +527,7 @@ export class AnnotationBatch {
     remove(annotation: Annotation): void;
 }
 
-type AnnotationCoordinateTransform = (x: number, y: number) => Vector3d;
+export type AnnotationCoordinateTransform = (x: number, y: number) => Vector3d;
 
 /** Possible settings that can be applied to generic annotations.
  *

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -519,6 +519,9 @@ export class Annotation implements AnnotationSettingsInterface {
 export class AnnotationBatch {
     items: Annotation[];
     viewTransform: Matrix3d | ((rc: RenderContext) => Matrix3d);
+
+    add(annotation: Annotation): void;
+    remove(annotation: Annotation): void;
 }
 
 /** Possible settings that can be applied to generic annotations.

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -520,8 +520,12 @@ export class Annotation implements AnnotationSettingsInterface {
 
 export class AnnotationBatch {
     readonly items: Annotation[];
-    get_viewTransform(): BatchViewTransform;
-    set_viewTransform(transform: BatchViewTransform): void;
+    get_viewTransform(): BatchTransform;
+    set_viewTransform(transform: BatchTransform): void;
+    get_worldTransform(): BatchTransform;
+    set_worldTransform(transform: BatchTransform): void;
+    get_projectionTransform(): BatchTransform;
+    set_projectionTransform(transform: BatchTransform): void;
 
     add(annotation: Annotation): void;
     remove(annotation: Annotation): void;
@@ -557,7 +561,7 @@ export interface ArrivedEventCallback {
   (si: ScriptInterface, args: ArrivedEventArgs): void;
 }
 
-export type BatchViewTransform = Matrix3d | ((rc: RenderContext) => Matrix3d);
+export type BatchTransform = Matrix3d | ((rc: RenderContext) => Matrix3d);
 
 export class CameraParameters {
   lat: number;

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -511,17 +511,22 @@ export class Annotation implements AnnotationSettingsInterface {
   set_showHoverLabel(v: boolean): boolean;
   get_tag(): string;
   set_tag(v: string): string;
+  get_coordinateTransform(): AnnotationCoordinateTransform;
+  set_coordinateTransform(transform: AnnotationCoordinateTransform): void;
 
   hitTest(renderContext: RenderContext, ra: number, dec: number, x: number, y: number): boolean;
 }
 
 export class AnnotationBatch {
-    items: Annotation[];
-    viewTransform: Matrix3d | ((rc: RenderContext) => Matrix3d);
+    readonly items: Annotation[];
+    get_viewTransform(): BatchViewTransform;
+    set_viewTransform(transform: BatchViewTransform): void;
 
     add(annotation: Annotation): void;
     remove(annotation: Annotation): void;
 }
+
+type AnnotationCoordinateTransform = (x: number, y: number) => Vector3d;
 
 /** Possible settings that can be applied to generic annotations.
  *
@@ -550,6 +555,8 @@ export interface ArrivedEventCallback {
   /** Called when the WWT view has arrived at a commanded position. */
   (si: ScriptInterface, args: ArrivedEventArgs): void;
 }
+
+export type BatchViewTransform = Matrix3d | ((rc: RenderContext) => Matrix3d);
 
 export class CameraParameters {
   lat: number;
@@ -1297,9 +1304,6 @@ export class LayerMap {
 // NOTE: isLayerSetting in engine-helpers needs to be kept in sync.
 export type LayerSetting = BaseLayerSetting |
 ["color", Color];
-
-export class Matrix3d {
-}
 
 export class Place implements Thumbnail {
   annotation: string;

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -503,6 +503,7 @@ export interface Action {
 export class Annotation implements AnnotationSettingsInterface {
   static readonly defaultCoordinateTransform: AnnotationCoordinateTransform;
   static readonly galacticCoordinateTransform: AnnotationCoordinateTransform;
+  static readonly horizontalCoordinateTransform: AnnotationCoordinateTransform;
 
   //get_center
   get_id(): string;
@@ -524,6 +525,8 @@ export class Annotation implements AnnotationSettingsInterface {
 
 export class AnnotationBatch {
     static readonly horizontalWorldTransform: BatchTransform;
+    static readonly overlayWorldTransform: BatchTransform;
+    static readonly overlayViewTransform: BatchTransform;
 
     readonly items: Annotation[];
     get_viewTransform(): BatchTransform;

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -516,6 +516,11 @@ export class Annotation implements AnnotationSettingsInterface {
   hitTest(renderContext: RenderContext, ra: number, dec: number, x: number, y: number): boolean;
 }
 
+export class AnnotationBatch {
+    items: Annotation[];
+    viewTransform: Matrix3d | ((rc: RenderContext) => Matrix3d);
+}
+
 /** Possible settings that can be applied to generic annotations.
  *
  * Specific annotation instances (e.g. Circles) can have additional settings.
@@ -583,7 +588,7 @@ export class Circle extends Annotation implements CircleAnnotationSettingsInterf
   set_skyRelative(v: boolean): boolean;
 
   /** Set the position of this circle's center. */
-  setCenter(raDeg: number, decDeg: number): void;
+  setCenter(xDeg: number, yDeg: number): void;
 }
 
 /** Possible settings that can be applied to Circle annotations. */
@@ -1291,6 +1296,9 @@ export class LayerMap {
 export type LayerSetting = BaseLayerSetting |
 ["color", Color];
 
+export class Matrix3d {
+}
+
 export class Place implements Thumbnail {
   annotation: string;
   angularSize: number;
@@ -1370,7 +1378,7 @@ export class Poly extends Annotation implements PolyAnnotationSettingsInterface 
   set_lineWidth(v: number): number;
 
   /** Add a point to this annotation's definition. */
-  addPoint(raDeg: number, decDeg: number): void;
+  addPoint(xDeg: number, yDeg: number): void;
 }
 
 /** Possible settings that can be applied to Poly annotations. */
@@ -1393,7 +1401,7 @@ export class PolyLine extends Annotation implements PolyLineAnnotationSettingsIn
   set_lineWidth(v: number): number;
 
   /** Add a point to this annotation's definition. */
-  addPoint(raDeg: number, decDeg: number): void;
+  addPoint(xDeg: number, yDeg: number): void;
 }
 
 /** Possible settings that can be applied to PolyLine annotations. */
@@ -1669,14 +1677,23 @@ export class ScriptInterface {
    */
   createPolyLine(unused: boolean): PolyLine;
 
+  /** Add an annotation batch to the renderer */
+  addAnnotationBatch(batch: AnnotationBatch, name: string): void;
+
+  /** Remove an annotation batch from the renderer */
+  removeAnnotationBatch(batch: string | AnnotationBatch): void;
+
   /** Add an annotation to the renderer. */
-  addAnnotation(ann: Annotation): void;
+  addAnnotation(ann: Annotation, batch?: string | AnnotationBatch): void;
 
   /** Remove an annotation from the renderer. */
-  removeAnnotation(ann: Annotation): void;
+  removeAnnotation(ann: Annotation, batch?: string | AnnotationBatch): void;
 
-  /** Remove all annotations from the renderer. */
-  clearAnnotations(): void;
+  /** Remove annotations from the renderer. 
+    * If a batch is specified, only the annotations from that batch are removed.
+    * Otherwise, all annotations are removed.
+    */
+  clearAnnotations(batch?: string | AnnotationBatch): void;
 }
 
 /** A generic {@link ScriptInterface} callback. */

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -500,6 +500,9 @@ export interface Action {
 
 /** A visual annotation in the WWT view. */
 export class Annotation implements AnnotationSettingsInterface {
+  static readonly defaultCoordinateTransform: AnnotationCoordinateTransform;
+  static readonly galacticCoordinateTransform: AnnotationCoordinateTransform;
+
   //get_center
   get_id(): string;
   set_id(v: string): string;
@@ -519,6 +522,8 @@ export class Annotation implements AnnotationSettingsInterface {
 }
 
 export class AnnotationBatch {
+    static readonly horizontalWorldTransform: BatchTransform;
+
     readonly items: Annotation[];
     get_viewTransform(): BatchTransform;
     set_viewTransform(transform: BatchTransform): void;

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -526,7 +526,7 @@ export class AnnotationBatch {
     remove(annotation: Annotation): void;
 }
 
-type AnnotationCoordinateTransform = (x: number, y: number) => Vector3d;
+export type AnnotationCoordinateTransform = (x: number, y: number) => Vector3d;
 
 /** Possible settings that can be applied to generic annotations.
  *

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -515,6 +515,11 @@ export class Annotation implements AnnotationSettingsInterface {
   hitTest(renderContext: RenderContext, ra: number, dec: number, x: number, y: number): boolean;
 }
 
+export class AnnotationBatch {
+    items: Annotation[];
+    viewTransform: Matrix3d | ((rc: RenderContext) => Matrix3d);
+}
+
 /** Possible settings that can be applied to generic annotations.
  *
  * Specific annotation instances (e.g. Circles) can have additional settings.
@@ -582,7 +587,7 @@ export class Circle extends Annotation implements CircleAnnotationSettingsInterf
   set_skyRelative(v: boolean): boolean;
 
   /** Set the position of this circle's center. */
-  setCenter(raDeg: number, decDeg: number): void;
+  setCenter(xDeg: number, yDeg: number): void;
 }
 
 /** Possible settings that can be applied to Circle annotations. */
@@ -1290,6 +1295,9 @@ export class LayerMap {
 export type LayerSetting = BaseLayerSetting |
 ["color", Color];
 
+export class Matrix3d {
+}
+
 export class Place implements Thumbnail {
   annotation: string;
   angularSize: number;
@@ -1369,7 +1377,7 @@ export class Poly extends Annotation implements PolyAnnotationSettingsInterface 
   set_lineWidth(v: number): number;
 
   /** Add a point to this annotation's definition. */
-  addPoint(raDeg: number, decDeg: number): void;
+  addPoint(xDeg: number, yDeg: number): void;
 }
 
 /** Possible settings that can be applied to Poly annotations. */
@@ -1392,7 +1400,7 @@ export class PolyLine extends Annotation implements PolyLineAnnotationSettingsIn
   set_lineWidth(v: number): number;
 
   /** Add a point to this annotation's definition. */
-  addPoint(raDeg: number, decDeg: number): void;
+  addPoint(xDeg: number, yDeg: number): void;
 }
 
 /** Possible settings that can be applied to PolyLine annotations. */
@@ -1668,14 +1676,23 @@ export class ScriptInterface {
    */
   createPolyLine(unused: boolean): PolyLine;
 
+  /** Add an annotation batch to the renderer */
+  addAnnotationBatch(batch: AnnotationBatch, name: string): void;
+
+  /** Remove an annotation batch from the renderer */
+  removeAnnotationBatch(batch: string | AnnotationBatch): void;
+
   /** Add an annotation to the renderer. */
-  addAnnotation(ann: Annotation): void;
+  addAnnotation(ann: Annotation, batch?: string | AnnotationBatch): void;
 
   /** Remove an annotation from the renderer. */
-  removeAnnotation(ann: Annotation): void;
+  removeAnnotation(ann: Annotation, batch?: string | AnnotationBatch): void;
 
-  /** Remove all annotations from the renderer. */
-  clearAnnotations(): void;
+  /** Remove annotations from the renderer. 
+    * If a batch is specified, only the annotations from that batch are removed.
+    * Otherwise, all annotations are removed.
+    */
+  clearAnnotations(batch?: string | AnnotationBatch): void;
 }
 
 /** A generic {@link ScriptInterface} callback. */

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -503,7 +503,6 @@ export interface Action {
 export class Annotation implements AnnotationSettingsInterface {
   static readonly defaultCoordinateTransform: AnnotationCoordinateTransform;
   static readonly galacticCoordinateTransform: AnnotationCoordinateTransform;
-  static readonly horizontalCoordinateTransform: AnnotationCoordinateTransform;
 
   //get_center
   get_id(): string;

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -524,8 +524,8 @@ export class Annotation implements AnnotationSettingsInterface {
 
 export class AnnotationBatch {
     static readonly horizontalWorldTransform: BatchTransform;
-    static readonly overlayWorldTransform: BatchTransform;
-    static readonly overlayViewTransform: BatchTransform;
+    static overlayWorldTransform(position: Coordinates): BatchTransform;
+    static overlayViewTransform(rotation: number): BatchTransform;
 
     readonly items: Annotation[];
     get_viewTransform(): BatchTransform;


### PR DESCRIPTION
While the WWT annotation system is very useful, it currently has the restriction that all annotation coordinates must be specified in RA/Dec. This has been a significant pain point for CosmicDS, as we often want to draw things in alt/az coordinates. These coordinates have a time-varying relationship with RA/Dec, which means that we can't just transform once and be done - we've needed to either update the annotation on each frame (requires re-buffering and leads to jittery annotations) or just directly add our own graphics primitives. The latter option works, but requires a rather decent knowledge of how WWT rendering works, and necessitates the objects being drawn at the end of the frame (in a frame callback), or directly modifying the render frame. IMO this points to something missing from the API.

Hence this PR. In order to facilitate a somewhat general approach to using different coordinate systems, I've made a few changes to the annotations setup:
* Currently all annotations in the engine are prepped and buffered together. In order to facilitate the changes in this PR, I added an `AnnotationBatch` class. This behaves similarly to the `Text3dBatch` that the engine uses for text. This also has the advantage that users can now decide which annotations they want to batch together to get re-buffered.
* In order to handle time-varying coordinate frames relative to equatorial (like Alt/Az) without re-buffering, this PR uses the same technique that the engine uses for the alt/az grid, which is to temporarily adjust the render context matrices to be drawing in the relevant frame. This is handled via `worldTransform`, `viewTransform`, and `projectionTransform` at the annotation batch level, which is either a `Matrix3d` or function that maps `RenderContext -> Matrix3d` defining how to adjust the world matrix to do the annotation drawing.
* At the annotation level, we allow defining a static `coordinateTransform` to allow specifying coordinates in other systems like galactic. It's not a problem to define these individually on each annotation as they don't need to be recalculated on each frame render and can thus be computed when prepping the batch.
* As a convenience, we provide two static members of the `AnnotationBatch` class:
  - An `AnnotationBatch.horizontalWorldTransform` function that, when assigned as the world transformation for a batch, will draw the annotations with their coordinates representing altitude and azimuth.
  - An `Annotation.galacticCoordinateTransform` that allows specifying annotation points in galactic coordinates

To preserve backwards compatibility, calling `addAnnotation` without a batch name/value will automatically put the annotation into a default equatorial batch. Similarly, omitting the batch argument in `removeAnnotation` and `clearAnnotations` will lead to the current expected behavior.

I've marked this as a draft as there are still a few things that I'm still working out:
* Currently I have the `coordinateTransform` field for an annotation set as the function that maps the 2D sky coordinates (in the relevant frame) to 3D, as that's what the WWT graphics primitives ultimately want. Alternatively, we could have the coordinate transform map the relevant 2D coordinates to RA/Dec (so trivial in the equatorial frame), and then map the RA/Dec coordinates to 3D internally. The current approach is a bit cleaner behind the scenes and avoids a hardcoded internal preference for RA/Dec, but defining the transformation in sky space might be simpler for users?
* I haven't adjusted annotation hover/click detection yet. This is currently only defined for circles anyway - maybe a more generic implementation there can be partially repurposed for polytope annotations? 