### PR TITLE
Add render context method for executing code with transformed world matrix

### DIFF
--- a/engine/esm/grids.js
+++ b/engine/esm/grids.js
@@ -582,7 +582,6 @@ Grids.drawAltAzGrid = function (renderContext, opacity, drawColor) {
     var zenith = Coordinates.horizonToEquitorial(zenithAltAz, SpaceTimeController.get_location(), SpaceTimeController.get_now());
     var raPart = -((zenith.get_RA() + 6) / 24 * (Math.PI * 2));
     var decPart = -(zenith.get_dec() / 360 * (Math.PI * 2));
-    var raText = Coordinates.formatDMS(zenith.get_RA());
     var mat = Matrix3d._rotationY(-raPart);
     mat._multiply(Matrix3d._rotationX(decPart));
     mat.invert();
@@ -631,16 +630,11 @@ Grids.drawAltAzGrid = function (renderContext, opacity, drawColor) {
             }
         }
     }
-    var matOldWorld = renderContext.get_world().clone();
-    var matOldWorldBase = renderContext.get_worldBase().clone();
-    renderContext.set_worldBase(Matrix3d.multiplyMatrix(mat, renderContext.get_world()));
-    renderContext.set_world(renderContext.get_worldBase().clone());
-    renderContext.makeFrustum();
+
     Grids._altAzLineList.viewTransform = Matrix3d.invertMatrix(mat);
-    Grids._altAzLineList.drawLines(renderContext, opacity, drawColor);
-    renderContext.set_worldBase(matOldWorldBase);
-    renderContext.set_world(matOldWorld);
-    renderContext.makeFrustum();
+    renderContext.executeWithWorldTransform(mat, function (renderContext) {
+        Grids._altAzLineList.drawLines(renderContext, opacity, drawColor);
+    });
     return true;
 };
 
@@ -649,21 +643,16 @@ Grids.drawAltAzGridText = function (renderContext, opacity, drawColor) {
     var zenith = Coordinates.horizonToEquitorial(zenithAltAz, SpaceTimeController.get_location(), SpaceTimeController.get_now());
     var raPart = -((zenith.get_RA() - 6) / 24 * (Math.PI * 2));
     var decPart = -(zenith.get_dec() / 360 * (Math.PI * 2));
-    var raText = Coordinates.formatDMS(zenith.get_RA());
     var mat = Matrix3d._rotationY(-raPart - Math.PI);
     mat._multiply(Matrix3d._rotationX(decPart));
     mat.invert();
     Grids._makeAltAzGridText();
-    var matOldWorld = renderContext.get_world().clone();
-    var matOldWorldBase = renderContext.get_worldBase().clone();
-    renderContext.set_worldBase(Matrix3d.multiplyMatrix(mat, renderContext.get_world()));
-    renderContext.set_world(renderContext.get_worldBase().clone());
-    renderContext.makeFrustum();
+
     Grids._altAzTextBatch.viewTransform = Matrix3d.invertMatrix(mat);
+    renderContext.executeWithWorldTransform(mat, function (renderContext) {
+        Grids._altAzTextBatch.draw(renderContext, opacity, drawColor);
+    });
     Grids._altAzTextBatch.draw(renderContext, opacity, drawColor);
-    renderContext.set_worldBase(matOldWorldBase);
-    renderContext.set_world(matOldWorld);
-    renderContext.makeFrustum();
     return true;
 };
 

--- a/engine/esm/render_context.js
+++ b/engine/esm/render_context.js
@@ -957,6 +957,20 @@ var RenderContext$ = {
         this._setMatrixes();
     },
 
+    executeWithWorldTransform: function (matrix, callable) {
+        var matOldWorld = this.get_world().clone();
+        var matOldWorldBase = this.get_worldBase().clone();
+        this.set_worldBase(Matrix3d.multiplyMatrix(matrix, this.get_world()));
+        this.set_world(this.get_worldBase().clone());
+        this.makeFrustum();
+         
+        callable(this);
+
+        this.set_worldBase(matOldWorldBase);
+        this.set_world(matOldWorld);
+        this.makeFrustum();
+    },
+
     _initGL: function () {
         if (this.gl == null) {
             return;


### PR DESCRIPTION
This PR factors out a piece of functionality from #438 that I also want to incorporate into #436, which is a helper method on the render context to allow executing code with a transformed world matrix. This helper method is then used for drawing the alt/az grid and its labels, as this functionality is essentially taken from the existing way that the alt/az grid drawing handles the time-varying relationship between horizontal and equatorial coordinates.