### PR TITLE
Expose Matrix3d to Typescript

### DIFF
--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -206,6 +206,73 @@ export interface LayerSettingsInterface extends LayerSettingsInterfaceRO {
   set_version(v: number): number;
 }
 
+export class Matrix3d {
+  static create(
+    m11: number, m12: number, m13: number, m14: number,
+    m21: number, m22: number, m23: number, m24: number,
+    m31: number, m32: number, m33: number, m34: number,
+    offsetX: number, offsetY: number, offsetZ: number, m44: number,
+  ): Matrix3d;
+  static get_identity(): Matrix3d;
+  static multiplyMatrix(matrix1: Matrix3d, matrix2: Matrix3d): Matrix3d;
+  static equals(matrix1: Matrix3d, matrix2: Matrix3d): boolean;
+  static rotationYawPitchRoll(heading: number, pitch: number, roll: number): Matrix3d;
+  static invertMatrix(matrix: Matrix3d): Matrix3d;
+  static translation(vector: Vector3d): Matrix3d;
+
+  clone(): Matrix3d;
+  setIdentity(): void;
+  set(matrix: Matrix3d): void;
+  scale(value: Vector3d): void;
+  translate(value: Vector3d): void;
+  transform(vector: Vector3d): Vector3d;
+  transformArray(points: Vector3d[]): void;
+  get_determinant(): number;
+  invert(): void;
+  transpose(): void;
+  multiplyVector(vector: Vector3d): void;
+
+  get_m11(): number;
+  get_m12(): number;
+  get_m13(): number;
+  get_m14(): number;
+  get_m21(): number;
+  get_m22(): number;
+  get_m23(): number;
+  get_m24(): number;
+  get_m31(): number;
+  get_m32(): number;
+  get_m33(): number;
+  get_m34(): number;
+  get_m41(): number;
+  get_m42(): number;
+  get_m43(): number;
+  get_m44(): number;
+  get_offsetX(): number;
+  get_offsetY(): number;
+  get_offsetZ(): number;
+
+  set_m11(value: number): number;
+  set_m12(value: number): number;
+  set_m13(value: number): number;
+  set_m14(value: number): number;
+  set_m21(value: number): number;
+  set_m22(value: number): number;
+  set_m23(value: number): number;
+  set_m24(value: number): number;
+  set_m31(value: number): number;
+  set_m32(value: number): number;
+  set_m33(value: number): number;
+  set_m34(value: number): number;
+  set_m41(value: number): number;
+  set_m42(value: number): number;
+  set_m43(value: number): number;
+  set_m44(value: number): number;
+  set_offsetX(value: number): number;
+  set_offsetY(value: number): number;
+  set_offsetZ(value: number): number;
+}
+
 export interface PolyAnnotationSettingsInterfaceRO extends AnnotationSettingsInterfaceRO {
   get_fill(): boolean;
   get_fillColor(): string;


### PR DESCRIPTION
Similar to #440, this is an update that will be useful for both #436  and #438, which will both allow users to define custom transforms for the relevant batches of display items. Thus I refactored it out into a separate PR.

The only change here is to expose the `Matrix3d` class and some of its static and instance methods to TypeScript, so that TypeScript-based clients (including our own Vue/Pinia layers) can effectively set up matrices.