### PR TITLE
Add static methods for matrix addition

### DIFF
--- a/engine/esm/double3d.js
+++ b/engine/esm/double3d.js
@@ -919,6 +919,30 @@ Matrix3d.getMapMatrix = function (center, fieldWidth, fieldHeight, rotation) {
     return Matrix3d.fromMatrix2d(mat);
 };
 
+Matrix3d.addMatrices = function (matrix1, matrix2) {
+    return Matrix3d.create(
+        matrix1._m11 + matrix2._m11,
+        matrix1._m12 + matrix2._m12,
+        matrix1._m13 + matrix2._m13,
+        matrix1._m14 + matrix2._m14,
+
+        matrix1._m21 + matrix2._m21,
+        matrix1._m22 + matrix2._m22,
+        matrix1._m23 + matrix2._m23,
+        matrix1._m24 + matrix2._m24,
+
+        matrix1._m31 + matrix2._m31,
+        matrix1._m32 + matrix2._m32,
+        matrix1._m33 + matrix2._m33,
+        matrix1._m34 + matrix2._m34,
+
+        matrix1._offsetX + matrix2._offsetX,
+        matrix1._offsetY + matrix2._offsetY,
+        matrix1._offsetZ + matrix2._offsetZ,
+        matrix1._m44 + matrix2._m44,
+    );
+};
+
 var Matrix3d$ = {
     clone: function () {
         var tmp = new Matrix3d();
@@ -1741,6 +1765,22 @@ Matrix2d.rotateAt = function (angle, pnt) {
     var matR = Matrix2d.rotation(angle);
     var matT1 = Matrix2d.translation(pnt.x, pnt.y);
     return Matrix2d.multiply(Matrix2d.multiply(matT0, matR), matT1);
+};
+
+Matrix2d.addMatrices = function (matrix1, matrix2) {
+    return Matrix2d.create(
+        matrix1._m11 + matrix2._m11,
+        matrix1._m12 + matrix2._m12,
+        matrix1._m13 + matrix2._m13,
+
+        matrix1._m21 + matrix2._m21,
+        matrix1._m22 + matrix2._m22,
+        matrix1._m23 + matrix2._m23,
+
+        matrix1._m31 + matrix2._m31,
+        matrix1._m32 + matrix2._m32,
+        matrix1._m33 + matrix2._m33,
+    );
 };
 
 var Matrix2d$ = {

--- a/engine/src/index.d.ts
+++ b/engine/src/index.d.ts
@@ -219,6 +219,7 @@ export class Matrix3d {
   static rotationYawPitchRoll(heading: number, pitch: number, roll: number): Matrix3d;
   static invertMatrix(matrix: Matrix3d): Matrix3d;
   static translation(vector: Vector3d): Matrix3d;
+  static addMatrices(matrix1: Matrix3d, matrix2: Matrix3d): Matrix3d;
 
   clone(): Matrix3d;
   setIdentity(): void;


### PR DESCRIPTION
I had a use case earlier where I wanted to do some WWT matrix math that involved adding matrices, and realized that the engine didn't already have this sort of functionality built in (I'm not too surprised as multiplication is going to be the primary operation). These methods are straightforward but somewhat tedious to write out, so hopefully someone else will also benefit from having this built in.

This adds addition functions for both `Matrix2d` and `Matrix3d`, and exposes the `Matrix3d` version to TypeScript.