### PR TITLE
Allow executing code with transformed projection and view matrices as well

### DIFF
--- a/engine/esm/grids.js
+++ b/engine/esm/grids.js
@@ -632,9 +632,12 @@ Grids.drawAltAzGrid = function (renderContext, opacity, drawColor) {
     }
 
     Grids._altAzLineList.viewTransform = Matrix3d.invertMatrix(mat);
-    renderContext.executeWithWorldTransform(mat, function (renderContext) {
+    renderContext.executeWithTransforms(
+      { world: mat },
+      function (renderContext) {
         Grids._altAzLineList.drawLines(renderContext, opacity, drawColor);
-    });
+      }
+    );
     return true;
 };
 
@@ -649,10 +652,12 @@ Grids.drawAltAzGridText = function (renderContext, opacity, drawColor) {
     Grids._makeAltAzGridText();
 
     Grids._altAzTextBatch.viewTransform = Matrix3d.invertMatrix(mat);
-    renderContext.executeWithWorldTransform(mat, function (renderContext) {
+    renderContext.executeWithTransforms(
+      { world: mat },
+      function (renderContext) {
         Grids._altAzTextBatch.draw(renderContext, opacity, drawColor);
-    });
-    Grids._altAzTextBatch.draw(renderContext, opacity, drawColor);
+      }
+    );
     return true;
 };
 

--- a/engine/esm/render_context.js
+++ b/engine/esm/render_context.js
@@ -957,17 +957,30 @@ var RenderContext$ = {
         this._setMatrixes();
     },
 
-    executeWithWorldTransform: function (matrix, callable) {
-        var matOldWorld = this.get_world().clone();
-        var matOldWorldBase = this.get_worldBase().clone();
-        this.set_worldBase(Matrix3d.multiplyMatrix(matrix, this.get_world()));
-        this.set_world(this.get_worldBase().clone());
+    executeWithTransforms: function (transforms, callable) {
+        var oldWorld = this.get_world().clone();
+        var oldWorldBase = this.get_worldBase().clone();
+        var oldView = this.get_view().clone();
+        var oldProjection = this.get_projection().clone();
+      
+        if (transforms.world) {
+          this.set_worldBase(Matrix3d.multiplyMatrix(transforms.world, this.get_world()));
+          this.set_world(this.get_worldBase().clone());
+        }
+        if (transforms.view) {
+          this.set_view(Matrix3d.multiplyMatrix(transforms.view, this.get_view()));
+        }
+        if (transforms.projection) {
+          this.set_projection(Matrix3d.multiplyMatrix(transforms.projection, this.get_projection()));
+        }
         this.makeFrustum();
-         
+      
         callable(this);
-
-        this.set_worldBase(matOldWorldBase);
-        this.set_world(matOldWorld);
+      
+        this.set_worldBase(oldWorldBase);
+        this.set_world(oldWorld);
+        this.set_view(oldView);
+        this.set_projection(oldProjection);
         this.makeFrustum();
     },
 


### PR DESCRIPTION
This PR builds on #440 by allowing the relevant code to be executed with transformed projection and view matrices as well. Instead of a single matrix, the new method expects an object with transforms keyed by `world`, `view`, and `projection`, if relevant. As before, we update the alt/az grid drawing to use this scheme.

Since we haven't tagged a release yet with #440 included, I'm not worried about the API change here.