### PR TITLE
Bump internal dependencies

### DIFF
--- a/engine-pinia/package.json
+++ b/engine-pinia/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://worldwidetelescope.org/home/",
   "internalDepVersions": {
     "@wwtelescope/astro": "thiscommit:2022-11-29:pfBFAzl",
-    "@wwtelescope/engine": "thiscommit:2026-05-24:Dk7FcU7",
+    "@wwtelescope/engine": "thiscommit:2026-08-25:xYZjXv7",
     "@wwtelescope/engine-helpers": "thiscommit:2026-05-24:rHytw25",
     "@wwtelescope/engine-types": "thiscommit:2022-11-29:OIQ6vzL"
   },

--- a/research-app/package.json
+++ b/research-app/package.json
@@ -48,9 +48,9 @@
   "homepage": "https://worldwidetelescope.org/home/",
   "internalDepVersions": {
     "@wwtelescope/astro": "7cb232125428a91bd8fd10be24fec904e3589cce",
-    "@wwtelescope/engine": "thiscommit:2026-04-05:ulYu3lE",
+    "@wwtelescope/engine": "thiscommit:2026-08-25:GxLIUjF",
     "@wwtelescope/engine-helpers": "263bedcc26dd2d13d03ba68daece76aa5e16f145",
-    "@wwtelescope/engine-pinia": "thiscommit:2026-04-05:imSNAoM",
+    "@wwtelescope/engine-pinia": "thiscommit:2026-08-25:aZsj1Qh",
     "@wwtelescope/engine-types": "263bedcc26dd2d13d03ba68daece76aa5e16f145",
     "@wwtelescope/research-app-messages": "thiscommit:2025-07-16:AvbWk1X",
     "@wwtelescope/ui-components": "thiscommit:2025-07-11:6supceo"


### PR DESCRIPTION
This PR bumps a couple of our internal dependency tags in preparation for new releases.