### PR TITLE
Fix issues with too-close non-instant promises

### DIFF
--- a/engine/esm/view_mover.js
+++ b/engine/esm/view_mover.js
@@ -117,11 +117,17 @@ ViewMoverSlew.create = function (from, to, duration) {
     temp.init(from, to);
     if (duration) {
       const originalTargetTime = temp._toTargetTime;
-      const upFraction = temp._upTargetTime / originalTargetTime;
-      const downFraction = temp._downTargetTime / originalTargetTime;
-      temp._upTargetTime = duration * upFraction;
-      temp._downTargetTime = duration * downFraction;
-      temp._toTargetTime = duration; 
+      if (originalTargetTime != 0) {
+        const upFraction = temp._upTargetTime / originalTargetTime;
+        const downFraction = temp._downTargetTime / originalTargetTime;
+        temp._upTargetTime = duration * upFraction;
+        temp._downTargetTime = duration * downFraction;
+        temp._toTargetTime = duration;
+      } else {
+        temp._upTargetTime = 0.5 * duration;
+        temp._downTargetTime = 0.5 * duration;
+      }
+      temp._toTargetTime = duration;
     }
     return temp;
 };

--- a/engine/esm/view_mover.js
+++ b/engine/esm/view_mover.js
@@ -115,14 +115,13 @@ export function ViewMoverSlew() {
 ViewMoverSlew.create = function (from, to, duration) {
     var temp = new ViewMoverSlew();
     temp.init(from, to);
-    if (duration) {
+    if (duration != null) {
       const originalTargetTime = temp._toTargetTime;
       if (originalTargetTime != 0) {
         const upFraction = temp._upTargetTime / originalTargetTime;
         const downFraction = temp._downTargetTime / originalTargetTime;
         temp._upTargetTime = duration * upFraction;
         temp._downTargetTime = duration * downFraction;
-        temp._toTargetTime = duration;
       } else {
         temp._upTargetTime = 0.5 * duration;
         temp._downTargetTime = 0.5 * duration;

--- a/engine/esm/wwt_control.js
+++ b/engine/esm/wwt_control.js
@@ -1994,7 +1994,10 @@ var WWTControl$ = {
                 }
             }
         }
-        if (instant || this._tooCloseForSlewMove(cameraParams)) {
+        if (this._tooCloseForSlewMove(cameraParams)) {
+          cameraParams = this.renderContext.viewCamera.copy();
+        }
+        if (instant) {
             this.set__mover(null);
             this.renderContext.targetCamera = cameraParams.copy();
             this.renderContext.viewCamera = this.renderContext.targetCamera.copy();


### PR DESCRIPTION
This PR resolves #448 with the following changes:
* If the target is determined to be too close for a slew move, but an instant motion wasn't requested, we still create the view mover, but set the target to be the same as the current camera parameters. This directly solves the problem in #448. Alternatively we could directly change the goto promise to be requested as instant if the slew move is considered too close. However, the controller method that determines whether a move is too close for a slew isn't exposed to TypeScript, and I don't think that we necessarily want to. Hence I decided against this route - I think just creating the no-op mover keeps things simpler. The experience for the caller should be the same either way.
*  Second, if a slew mover is made with a specific duration for a move that would naturally have a duration of zero (i.e. no move), we run into a divide-by-zero error in the mover creation function. This PR adds special logic for that case that sets the "up" and "down" times (not really meaningful in this case anyways) to each be half of the requested duration, and the total time to be the requested duration